### PR TITLE
Google.Drive: NewFile update

### DIFF
--- a/src/appmixer/google/drive/NewFile/NewFile.js
+++ b/src/appmixer/google/drive/NewFile/NewFile.js
@@ -47,9 +47,9 @@ const detectNewFiles = async function(context) {
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
 
-        const { newFiles, newStartPageToken } = await getNewFiles(lock, drive, folder.id, startPageToken);
-
         await context.stateSet('hasSkippedMessage', false);
+
+        const { newFiles, newStartPageToken } = await getNewFiles(lock, drive, folder.id, startPageToken);
 
         const processedFilesSet = commons.processedItemsBuffer(processedFiles);
 

--- a/src/appmixer/google/drive/NewFile/NewFile.js
+++ b/src/appmixer/google/drive/NewFile/NewFile.js
@@ -57,11 +57,11 @@ const detectNewFiles = async function(context) {
             if (!processedFilesSet.has(file.id)) {
                 processedFilesSet.add(newStartPageToken, file.id);
                 await context.sendJson(file, 'file');
+                await context.stateSet('processedFiles', processedFilesSet.export());
             }
         }
 
         await context.stateSet('startPageToken', newStartPageToken);
-        await context.stateSet('processedFiles', processedFilesSet.export());
 
     } finally {
         if (lock) {

--- a/src/appmixer/google/drive/NewFile/NewFile.js
+++ b/src/appmixer/google/drive/NewFile/NewFile.js
@@ -6,7 +6,8 @@ const getNewFiles = async (lock, drive, folder, pageToken, newFiles = []) => {
 
     const { data: { changes, newStartPageToken, nextPageToken } } = await drive.changes.list({
         pageToken,
-        fields: '*'
+        fields: '*',
+        includeRemoved: false
     });
 
     changes.forEach(change => {

--- a/src/appmixer/google/drive/NewFile/NewFile.js
+++ b/src/appmixer/google/drive/NewFile/NewFile.js
@@ -1,13 +1,14 @@
-'use strict';
 const Promise = require('bluebird');
 const moment = require('moment');
 const { google } = require('googleapis');
 const commons = require('../drive-commons');
-const { URL, URLSearchParams } = require('url');
 
 const getNewFiles = async (lock, drive, folder, pageToken, newFiles = []) => {
 
-    const { data: { changes, newStartPageToken, nextPageToken } } = await drive.changes.list({ pageToken, fields: '*', includeRemoved: false, includeDeleted: false });
+    const { data: { changes, newStartPageToken, nextPageToken } } = await drive.changes.list({
+        pageToken,
+        fields: '*'
+    });
 
     changes.forEach(change => {
         if (change.changeType === 'file' && !change.removed && !change.file?.trashed && new Date(change.file?.createdTime) >= new Date(change.file?.modifiedTime)) {
@@ -27,6 +28,53 @@ const getNewFiles = async (lock, drive, folder, pageToken, newFiles = []) => {
     }
 
     return { newFiles, newStartPageToken };
+};
+
+const detectNewFiles = async function(context) {
+
+    const { folder = {} } = context.properties;
+
+    let lock = null;
+    try {
+        lock = await context.lock(context.componentId, { maxRetryCount: 0 });
+    } catch (err) {
+        context.log({ stage: 'lock error' });
+        await context.stateSet('hasSkippedMessage', true);
+        return context.response();
+    }
+
+    try {
+
+        const { startPageToken, lastChangeFileIDs = {}, processedFiles = [] } = await context.loadState();
+
+        const auth = commons.getOauth2Client(context.auth);
+        const drive = google.drive({ version: 'v3', auth });
+
+        const { newFiles, newStartPageToken } = await getNewFiles(lock, drive, folder.id, startPageToken);
+
+        await context.stateSet('hasSkippedMessage', false);
+
+        const processedFilesSet = x(processedFiles);
+
+        for (let file of newFiles) {
+            lastChangeFileIDs[file.name] = lastChangeFileIDs[file.name] || [];
+            lastChangeFileIDs[file.name].push(newStartPageToken);
+            if (!processedFilesSet.has(file.id)) {
+                processedFilesSet.add(newStartPageToken, file.id)
+                lastChangeFileIDs[file.name].push('triggered!!!!');
+                await context.sendJson(file, 'file');
+            }
+        }
+
+        await context.stateSet('startPageToken', newStartPageToken);
+        await context.stateSet('lastChangeFileIDs', lastChangeFileIDs);
+        await context.stateSet('processedFiles', processedFilesSet.export());
+
+    } finally {
+        if (lock) {
+            await lock.unlock();
+        }
+    }
 };
 
 module.exports = {
@@ -52,77 +100,22 @@ module.exports = {
             return context.response();
         }
 
-        // there's a bug in the drive changes API. Looks like they have a replica there and when the
-        // webhook arrives the change may not get to all the replicas yet, therefore the getChanges
-        // api sometimes does not correctly return that change (it's not there yet), component can handle
-        // this situation (line 86), but seems that delaying the webhook a bit helps.
-        await new Promise(resolve => {
-            setTimeout(() => {
-                resolve();
-            }, 1000);
-        });
+        context.log({ w: context.messages.webhook });
 
-        const { folder = {} } = context.properties;
-
-        let lock = null;
-        try {
-            try {
-                lock = await context.lock(context.componentId, { retryDelay: 4000 });
-            } catch (e) {
-                return;
-            }
-            const { startPageToken, lastChangeFileIDs } = await context.loadState();
-            const lastFiles = Array.isArray(lastChangeFileIDs) ? new Set(lastChangeFileIDs) : new Set();
-
-            const changesResourceURL = new URL(context.messages.webhook.content['headers']['x-goog-resource-uri']);
-            const params = new URLSearchParams(changesResourceURL.searchParams);
-
-            const auth = commons.getOauth2Client(context.auth);
-            const drive = google.drive({ version: 'v3', auth });
-
-            if (params.get('pageToken') < startPageToken) {
-                // if the Google Drive changes API worked properly, this section wouldn't be needed,
-                // but a pageToken with the same ID may be sent many times (case when multiple files
-                // are created at the same time) through the webhook and return different results
-                // when getting the list of changes starting from the same pageToken. That seems to
-                // be a bug, that should not happen.
-                const { newFiles } = await getNewFiles(lock, drive, folder.id, params.get('pageToken'));
-
-                await Promise.map(newFiles, file => {
-                    if (!lastFiles.has(file.id)) {
-                        lastFiles.add(file.id);
-                        return context.sendJson(file, 'file');
-                    }
-                }, { concurrency: 5 });
-
-                await context.stateSet('lastChangeFileIDs', Array.from(lastFiles));
-
-                // we have already processed that change
-                return context.response();
-            }
-
-            const { newFiles, newStartPageToken } = await getNewFiles(lock, drive, folder.id, startPageToken);
-
-            const newFileIDs = [];
-            await Promise.map(newFiles, file => {
-                newFileIDs.push(file.id);
-                return context.sendJson(file, 'file');
-            }, { concurrency: 5 });
-
-            await context.stateSet('startPageToken', newStartPageToken);
-            await context.stateSet('lastChangeFileIDs', newFileIDs);
-        } finally {
-            if (lock) {
-                await lock.unlock();
-            }
-        }
+        await detectNewFiles(context);
 
         return context.response();
     },
 
     async tick(context) {
 
-        const { expiration } = await context.loadState();
+        const { expiration, hasSkippedMessage } = await context.loadState();
+
+        if (hasSkippedMessage) {
+            context.log({ stage: 'XXXXXXXXXXXXXXXXXXXXX', });
+            await detectNewFiles(context);
+        }
+
         if (expiration) {
             const renewDate = moment(expiration).subtract(5, 'hours');
             if (moment().isSameOrAfter(renewDate)) {

--- a/src/appmixer/google/drive/NewFile/NewFile.js
+++ b/src/appmixer/google/drive/NewFile/NewFile.js
@@ -38,7 +38,7 @@ const detectNewFiles = async function(context) {
         lock = await context.lock(context.componentId, { maxRetryCount: 0 });
     } catch (err) {
         await context.stateSet('hasSkippedMessage', true);
-        return context.response();
+        return;
     }
 
     try {
@@ -148,7 +148,7 @@ module.exports = {
                 includeRemoved: false,
                 pageToken,
                 requestBody: {
-                    address: context.getWebhookUrl(),
+                    address: context.getWebhookUrl() + '?enqueueOnly=true',
                     id: context.componentId,
                     payload: true,
                     token: context.componentId,

--- a/src/appmixer/google/drive/NewFile/NewFile.js
+++ b/src/appmixer/google/drive/NewFile/NewFile.js
@@ -1,7 +1,6 @@
 const moment = require('moment');
 const { google } = require('googleapis');
 const commons = require('../drive-commons');
-const DEBUG = false;
 
 const getNewFiles = async (lock, drive, folder, pageToken, newFiles = []) => {
 
@@ -33,6 +32,7 @@ const getNewFiles = async (lock, drive, folder, pageToken, newFiles = []) => {
 
 const detectNewFiles = async function(context) {
 
+    const DEBUG = context.config.DEBUG !== 'false' || false;
     const { folder = {} } = context.properties;
 
     let lock = null;
@@ -68,8 +68,13 @@ const detectNewFiles = async function(context) {
         }
 
         if (DEBUG) {
-            await context.log(debugInfo);
-            await context.stateSet('debugInfo', debugInfo);
+            await context.log({ 'DEBUG': debugInfo });
+            if (Object.keys(debugInfo).length > 10000) {
+                await context.log({ 'DEBUG': 'Clearing debug log, maximum count of records reached.' });
+                await context.stateSet('debugInfo', {});
+            } else {
+                await context.stateSet('debugInfo', debugInfo);
+            }
         }
 
         await context.stateSet('startPageToken', newStartPageToken);

--- a/src/appmixer/google/drive/NewFile/component.json
+++ b/src/appmixer/google/drive/NewFile/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.google.drive.NewFile",
     "author": "Jimoh Damilola <jimoh@client.io>",
     "description": "This trigger fires every time there's new file. It does not download the file! If you need the content of the file use the ExportFile component.",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "private": false,
     "webhook": true,
     "tick": true,

--- a/src/appmixer/google/drive/bundle.json
+++ b/src/appmixer/google/drive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.drive",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -40,7 +40,7 @@
         "1.4.1": [
             "Fixed 'ListFiles' component outPort options."
         ],
-        "1.4.3": [
+        "1.4.4": [
             "Fixed 'NewFile' trigger."
         ]
     }

--- a/src/appmixer/google/drive/bundle.json
+++ b/src/appmixer/google/drive/bundle.json
@@ -41,7 +41,7 @@
             "Fixed 'ListFiles' component outPort options."
         ],
         "1.4.4": [
-            "Fixed 'NewFile' trigger."
+            "NewFile: fixes, improvements. Added DEBUG info messages. Set the DEBUG configuration key in the Backoffice to true to see the messages."
         ]
     }
 }

--- a/src/appmixer/google/drive/drive-commons.js
+++ b/src/appmixer/google/drive/drive-commons.js
@@ -23,7 +23,7 @@ let defaultExportFormats = {
     }
 };
 
-const x = function(data = []) {
+const processedItemsBuffer = function(data = []) {
 
     const MAX_GROUP_COUNT = 3;
     return {
@@ -43,13 +43,12 @@ const x = function(data = []) {
         export() {
             return data.slice(-MAX_GROUP_COUNT);
         }
-
     };
 };
 
 module.exports = {
 
-    x,
+    processedItemsBuffer,
     defaultExportFormats,
 
     getOauth2Client(auth) {

--- a/src/appmixer/google/drive/drive-commons.js
+++ b/src/appmixer/google/drive/drive-commons.js
@@ -23,8 +23,33 @@ let defaultExportFormats = {
     }
 };
 
+const x = function(data = []) {
+
+    const MAX_GROUP_COUNT = 3;
+    return {
+        has(id) {
+            return data.find(group => group.ids[id]);
+        },
+        add(group, id) {
+            const groupData = data.find(groupData => groupData.group === group);
+            if (!groupData) {
+                const ids = {};
+                ids[id] = true;
+                data.push({ group, ids });
+            } else {
+                groupData.ids[id] = true;
+            }
+        },
+        export() {
+            return data.slice(-MAX_GROUP_COUNT);
+        }
+
+    };
+};
+
 module.exports = {
 
+    x,
     defaultExportFormats,
 
     getOauth2Client(auth) {

--- a/src/appmixer/google/drive/module.json
+++ b/src/appmixer/google/drive/module.json
@@ -2,6 +2,7 @@
     "name": "appmixer.google.drive",
     "label": "Google Drive",
     "category": "applications",
+    "version": "1.1.0",
     "description": "Google Drive is a file storage and synchronization service. It allows users to store files on their servers, synchronize files across devices, and share files.",
     "icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMC8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvVFIvMjAwMS9SRUMtU1ZHLTIwMDEwOTA0L0RURC9zdmcxMC5kdGQnPjxzdmcgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMzIgMzIiIGhlaWdodD0iMzJweCIgaWQ9IkxheWVyXzEiIHZlcnNpb249IjEuMCIgdmlld0JveD0iMCAwIDMyIDMyIiB3aWR0aD0iMzJweCIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+PGc+PHBvbHlsaW5lIGZpbGw9IiM1MzdBQkQiIHBvaW50cz0iMzEuODY4LDIxIDkuODY4LDIxIDQuODY4LDMwIDI2LjU1NiwzMCAgIi8+PHBvbHlsaW5lIGZpbGw9IiMyRUI2NzIiIHBvaW50cz0iMTAuOTYyLDIgLTAuMDM4LDIwIDQuOTYyLDMwIDE1LjY4MywxMC4zNDUgICIvPjxwb2x5bGluZSBmaWxsPSIjRkVEMTRCIiBwb2ludHM9IjIwLjk2MiwyIDEwLjk2MiwyIDIxLjcxMiwyMSAzMS45NjIsMjEgMjAuOTYyLDIgICIvPjwvZz48Zy8+PGcvPjxnLz48Zy8+PGcvPjxnLz48L3N2Zz4="
 }


### PR DESCRIPTION
port of the https://github.com/clientIO/appmixer-components/pull/1696

- `processedFiles` preventing duplicities - checking if the file hasn't been processed already in last 3 pagetokens

tested on QA (https://my.qa.appmixer.com/designer/95920319-1836-4adb-a79d-a2785375603c/88f79df7-c4c2-4609-b33f-1ee2f6dec424)

- upload 4 files in parallel on start 
- upload 200 files manually in the Gdrive ui
- once the NewFile is triggered, it uploads the file into Appmixer files


results: 208 dummy files has been uploaded 
- small_dummy_996 - 999 - uploaded using the uploadFile on flow start -
- newFile has been triggered 4x (small_dummy_996 - 999 ) + 200x for after the manual upload within gdrive => total 208 small_dummy files: 
![image](https://github.com/clientIO/appmixer-connectors/assets/927250/06a20f6d-53c2-4cf0-a082-46736bd3a1a0)

