### PR TITLE
Utils converters csv2workbook bom fix

### DIFF
--- a/src/appmixer/utils/converters/CSV2XLSX/component.json
+++ b/src/appmixer/utils/converters/CSV2XLSX/component.json
@@ -3,7 +3,7 @@
     "author": "David Durman <david@client.io>",
     "description": "Convert a CSV file to XLSX Excel 2007+ XML Format.",
     "private": false,
-    "version": "1.1.0",
+    "version": "1.1.1",
     "inPorts": [
         {
             "name": "in",

--- a/src/appmixer/utils/converters/bundle.json
+++ b/src/appmixer/utils/converters/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.converters",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "changelog": {
         "1.1.0": [
             "FileId inputs changed from 'text' to 'filepicker'. Requires Appmixer 4.4.4 or higher."
@@ -10,6 +10,9 @@
         ],
         "1.2.1": [
             "Fixed Archive component timeout error."
+        ],
+        "1.2.2": [
+            "Fixed encoding issue with UTF-8 files without BOM."
         ]
     }
 }

--- a/src/appmixer/utils/converters/xlsx-helpers.js
+++ b/src/appmixer/utils/converters/xlsx-helpers.js
@@ -34,6 +34,16 @@ module.exports.CSV2Workbook = async function(readStream) {
             reject(err);
         }).on('end', () => {
             try {
+                // Is there BOM at the beginning of the file?
+                const isBom = buffers[0].readUInt8(0) === 0xEF
+                    && buffers[0].readUInt8(1) === 0xBB
+                    && buffers[0].readUInt8(2) === 0xBF;
+
+                if (!isBom) {
+                    // If there is no BOM, we need to add it. See #1717.
+                    const bom = Buffer.from([0xEF, 0xBB, 0xBF]);
+                    buffers[0] = Buffer.concat([bom, buffers[0]]);
+                }
                 const buffer = Buffer.concat(buffers);
                 const workbook = xlsx.read(buffer, { type: 'buffer' });
                 resolve(workbook);


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/1717

## Repro
- https://oss.sheetjs.com/
- upload [csv-line.csv](https://github.com/clientIO/appmixer-connectors/files/14495521/csv-line.csv). No COM in the file. Wrong result.
- expected result: `Ja’Darius`
<img width="535" alt="image" src="https://github.com/clientIO/appmixer-connectors/assets/12988096/b3b328be-d0da-4658-97cf-fab464dfa58b">


## OK
Works fine for CSV files with BOM. Example: [csv-line-bom.csv](https://github.com/clientIO/appmixer-connectors/files/14495540/csv-line-bom.csv)

