### PR TITLE
Shopify: support for mandatory webhooks

### DIFF
--- a/src/appmixer/shopify/CustomerDataRequest.js
+++ b/src/appmixer/shopify/CustomerDataRequest.js
@@ -1,0 +1,26 @@
+module.exports = context => {
+
+    class CustomerDataRequest extends context.db.Model {
+
+        static get collection() {
+            return 'customerDataRequests_temp_1';
+        }
+
+        static get idProperty() {
+            return 'id';
+        }
+
+        static get properties() {
+
+            return [
+                'id',
+                'request',
+                'created'
+            ];
+        }
+    }
+
+    CustomerDataRequest.createSettersAndGetters();
+
+    return CustomerDataRequest;
+};

--- a/src/appmixer/shopify/CustomerDataRequest.js
+++ b/src/appmixer/shopify/CustomerDataRequest.js
@@ -3,7 +3,7 @@ module.exports = context => {
     class CustomerDataRequest extends context.db.Model {
 
         static get collection() {
-            return 'customerDataRequests_temp_1';
+            return 'customerDataRequests';
         }
 
         static get idProperty() {

--- a/src/appmixer/shopify/CustomerRedactRequest.js
+++ b/src/appmixer/shopify/CustomerRedactRequest.js
@@ -1,0 +1,26 @@
+module.exports = context => {
+
+    class CustomerRedactRequest extends context.db.Model {
+
+        static get collection() {
+            return 'customerRedactsRequests_temp_1';
+        }
+
+        static get idProperty() {
+            return 'id';
+        }
+
+        static get properties() {
+
+            return [
+                'id',
+                'request',
+                'created'
+            ];
+        }
+    }
+
+    CustomerRedactRequest.createSettersAndGetters();
+
+    return CustomerRedactRequest;
+};

--- a/src/appmixer/shopify/CustomerRedactRequest.js
+++ b/src/appmixer/shopify/CustomerRedactRequest.js
@@ -3,7 +3,7 @@ module.exports = context => {
     class CustomerRedactRequest extends context.db.Model {
 
         static get collection() {
-            return 'customerRedactsRequests_temp_1';
+            return 'customerRedactsRequests';
         }
 
         static get idProperty() {

--- a/src/appmixer/shopify/ShopRedactRequest.js
+++ b/src/appmixer/shopify/ShopRedactRequest.js
@@ -1,0 +1,27 @@
+module.exports = context => {
+
+    class ShopRedactRequest extends context.db.Model {
+
+        static get collection() {
+            return 'shopRedactRequests_temp_1';
+        }
+
+        static get idProperty() {
+            return 'id';
+        }
+
+        static get properties() {
+
+            return [
+                'id',
+                'request',
+                'created'
+            ];
+        }
+    }
+
+    ShopRedactRequest.createSettersAndGetters();
+
+    return ShopRedactRequest;
+};
+

--- a/src/appmixer/shopify/ShopRedactRequest.js
+++ b/src/appmixer/shopify/ShopRedactRequest.js
@@ -3,7 +3,7 @@ module.exports = context => {
     class ShopRedactRequest extends context.db.Model {
 
         static get collection() {
-            return 'shopRedactRequests_temp_1';
+            return 'shopRedactRequests';
         }
 
         static get idProperty() {

--- a/src/appmixer/shopify/package.json
+++ b/src/appmixer/shopify/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "author": "Jimoh Damilola <jimoh@client.io>",
     "dependencies": {
+        "crypto": "1.0.1",
         "shopify-api-node": "3.12.1",
         "shopify-token": "4.0.0"
     }

--- a/src/appmixer/shopify/package.json
+++ b/src/appmixer/shopify/package.json
@@ -4,7 +4,7 @@
     "author": "Jimoh Damilola <jimoh@client.io>",
     "dependencies": {
         "crypto": "1.0.1",
-        "shopify-api-node": "3.12.1",
+        "shopify-api-node": "3.13.1",
         "shopify-token": "4.0.0"
     }
 }

--- a/src/appmixer/shopify/plugin.js
+++ b/src/appmixer/shopify/plugin.js
@@ -1,0 +1,37 @@
+const path = require('path');
+
+module.exports = function(context) {
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/customers/data_request',
+        options: {
+            handler: (request, h) => {
+                return {}
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/customers/redact',
+        options: {
+            handler: (request, h) => {
+                return {}
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/shop/redact',
+        options: {
+            handler: (request, h) => {
+                return {}
+            },
+            auth: false
+        }
+    });
+};

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -1,0 +1,104 @@
+module.exports = function(context) {
+
+    const CustomerDataRequest = require('./CustomerDataRequest')(context);
+    const CustomerRedactRequest = require('./CustomerRedactRequest')(context);
+    const ShopRedactRequest = require('./ShopRedactRequest')(context);
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/customers/data_request',
+        options: {
+            handler: (req) => {
+
+                const { payload } = req;
+
+                return new CustomerDataRequest().populate({
+                    request: payload,
+                    created: new Date(),
+                }).save();
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/customers/redact',
+        options: {
+            handler: (req) => {
+
+                const { payload } = req;
+
+                return new CustomerRedactRequest().populate({
+                    request: payload,
+                    created: new Date(),
+                }).save();
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/shop/redact',
+        options: {
+            handler: (req) => {
+
+                const { payload } = req;
+
+                return new ShopRedactRequest().populate({
+                    request: payload,
+                    created: new Date(),
+                }).save();
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'GET',
+        path: '/customers/data_request',
+        options: {
+            handler: (request, h) => {
+                return CustomerDataRequest.find() || [];
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'GET',
+        path: '/customers/redact',
+        options: {
+            handler: () => {
+                return CustomerRedactRequest.find() || [];
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'GET',
+        path: '/shop/redact',
+        options: {
+            handler: () => {
+                return ShopRedactRequest.find() || [];
+            },
+            auth: false
+        }
+    });
+
+    context.http.router.register({
+        method: 'GET',
+        path: '/',
+        options: {
+            handler: (request, h) => {
+                return {
+                    version: '1.0',
+                    published: new Date().toISOString()
+                };
+            },
+            auth: false
+        }
+    });
+};

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -20,10 +20,10 @@ module.exports = function(context) {
 
                 const { shop } = req.query;
                 const clientId = encodeURIComponent(context.config.clientId);
-                const redirect_uri = encodeURIComponent(context.config.appStoreInstallRedirectUri);
+                const redirectUrl = encodeURIComponent(context.config.appStoreInstallRedirectUri);
                 const scopes = encodeURIComponent(auth.definition.scope.join(','));
 
-                const authUrl = `https://${shop}/admin/oauth/authorize?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scopes}`;
+                const authUrl = `https://${shop}/admin/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUrl}&scope=${scopes}`;
 
                 return h.redirect(authUrl);
             },

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -39,8 +39,7 @@ module.exports = function(context) {
                     created: new Date()
                 }).save();
             },
-            auth: false,
-
+            auth: false
         }
     });
 

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -118,20 +118,6 @@ module.exports = function(context) {
         }
     });
 
-    context.http.router.register({
-        method: 'GET',
-        path: '/',
-        options: {
-            handler: () => {
-                return {
-                    version: '1.0',
-                    published: new Date().toISOString()
-                };
-            },
-            auth: false
-        }
-    });
-
     const getSignature = function(data, secret) {
         return crypto
             .createHmac('sha256', secret)

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -1,9 +1,35 @@
 const crypto = require('crypto');
+const auth = require('./auth');
+
 module.exports = function(context) {
 
     const CustomerDataRequest = require('./CustomerDataRequest')(context);
     const CustomerRedactRequest = require('./CustomerRedactRequest')(context);
     const ShopRedactRequest = require('./ShopRedactRequest')(context);
+
+    /**
+     * Shopify install link, Shopify calls this link to install the app:
+     * https://api.qa.appmixer.com/plugins/appmixer/shopify/install?shop=appmixer.myshopify.com
+     * Set the base url (https://api.qa.appmixer.com/plugins/appmixer/shopify) in the Shopify app settings.
+     */
+    context.http.router.register({
+        method: 'GET',
+        path: '/install',
+        options: {
+            handler: (req, h) => {
+
+                const { shop } = req.query;
+                const clientId = encodeURIComponent(context.config.clientId);
+                const redirect_uri = encodeURIComponent(context.config.appStoreInstallRedirectUri);
+                const scopes = encodeURIComponent(auth.definition.scope.join(','));
+
+                const authUrl = `https://${shop}/admin/oauth/authorize?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scopes}`;
+
+                return h.redirect(authUrl);
+            },
+            auth: false
+        }
+    });
 
     context.http.router.register({
         method: 'POST',

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -68,8 +68,7 @@ module.exports = function(context) {
         options: {
             handler: () => {
                 return CustomerDataRequest.find() || [];
-            },
-            auth: false
+            }
         }
     });
 
@@ -79,8 +78,7 @@ module.exports = function(context) {
         options: {
             handler: () => {
                 return CustomerRedactRequest.find() || [];
-            },
-            auth: false
+            }
         }
     });
 
@@ -90,8 +88,7 @@ module.exports = function(context) {
         options: {
             handler: () => {
                 return ShopRedactRequest.find() || [];
-            },
-            auth: false
+            }
         }
     });
 
@@ -117,6 +114,12 @@ module.exports = function(context) {
 
     };
 
+    /**
+     * verify HMAC token from Shopify
+     * https://shopify.dev/docs/apps/webhooks/configuration/https#step-5-verify-the-webhook
+     * @param req
+     * @param secret
+     */
     const verifyHmac = function(req, secret) {
 
         const expected = req.headers['x-shopify-hmac-sha256'];

--- a/src/appmixer/shopify/routes.js
+++ b/src/appmixer/shopify/routes.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
 
                 return new CustomerDataRequest().populate({
                     request: payload,
-                    created: new Date(),
+                    created: new Date()
                 }).save();
             },
             auth: false
@@ -31,7 +31,7 @@ module.exports = function(context) {
 
                 return new CustomerRedactRequest().populate({
                     request: payload,
-                    created: new Date(),
+                    created: new Date()
                 }).save();
             },
             auth: false
@@ -48,7 +48,7 @@ module.exports = function(context) {
 
                 return new ShopRedactRequest().populate({
                     request: payload,
-                    created: new Date(),
+                    created: new Date()
                 }).save();
             },
             auth: false
@@ -59,7 +59,7 @@ module.exports = function(context) {
         method: 'GET',
         path: '/customers/data_request',
         options: {
-            handler: (request, h) => {
+            handler: () => {
                 return CustomerDataRequest.find() || [];
             },
             auth: false
@@ -92,7 +92,7 @@ module.exports = function(context) {
         method: 'GET',
         path: '/',
         options: {
-            handler: (request, h) => {
+            handler: () => {
                 return {
                     version: '1.0',
                     published: new Date().toISOString()


### PR DESCRIPTION
- [x] - endpoint for storing requests 
```
POST [APPMIXER_API]/plugins/appmixer/shopify/customers/data_request
POST [APPMIXER_API]/plugins/appmixer/shopify/customers/redact
POST [APPMIXER_API]/plugins/appmixer/shopify/shop/redact
```
  -  **HOW TO TEST**
 
     - the endpoint above are public try to post some data:
       - customers/data_request: [sample payload](https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-redact-payload)
       - customers/redact: [sample payload](https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-redact-payload)
       - shop/redact: [sample payload](https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#shop-redact)
 
 
- [x] - endpoint for retrieving requests data:
```
GET [APPMIXER_API]/plugins/appmixer/shopify/customers/data_request
GET [APPMIXER_API]/plugins/appmixer/shopify/customers/redact
GET [APPMIXER_API]/plugins/appmixer/shopify/shop/redact
```
  - **HOW TO TEST**
     - the endpoints above require Appmixer bearer token header to authenticate 

- [x] - app Store install URL
  - new key in the backoffice: `appStoreInstallRedirectUri` (for example https://www.appmixer.com/connectors/shopify)
  - new plugin route `https://api.qa.appmixer.com/plugins/appmixer/shopify/install`. Shopify calls this url with the `shop` query param. This params identifies the shopify instance to install the Appmixer app. The `install` route creates the OAuht link for the shop and redirects to the auth url. This will trigger installation app install process. 

  **HOW TO TEST**  
  - got to https://api.qa.appmixer.com/plugins/appmixer/shopify/install?shop=<your shop instance> Where `you shop instance` is for example `appmixer.myshopify.com` 
  - app installation screen should show up
  - install the appmixer app
  - go to the https://admin.shopify.com/store/appmixer/settings/apps?tab=installed and check the Appmixer app is installed


 