### PR TITLE
util.controls.onError: use SearchAfter  - port from the https://github.com/clientIO/appmixer-components/pull/1690

### DIFF
--- a/src/appmixer/utils/controls/OnError/component.json
+++ b/src/appmixer/utils/controls/OnError/component.json
@@ -3,6 +3,31 @@
     "author": "Martin Krčmář <martin@client.io>",
     "description": "This trigger fires when there is an error in the flow.",
     "tick": true,
+    "state": {
+        "persistent": true
+    },
+    "properties": {
+        "schema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "number"
+                }
+            }
+        },
+        "inspector": {
+            "inputs": {
+                "limit": {
+                    "type": "number",
+                    "label": "Limit",
+                    "index": 1,
+                    "defualtValue": 100,
+                    "tooltip": "Limit the number of errors to display."
+                    
+                }
+            }
+        }
+    },
     "outPorts": [
         {
             "name": "out",


### PR DESCRIPTION
- Handled pagination with `searchAfter` ( Appmixer 6.0 introduces a new query parameter `searchAfter`)
- Used locks to handle a large number of logs.
- https://github.com/clientIO/appmixer-components/issues/1466

original PR https://github.com/clientIO/appmixer-components/pull/1690