### PR TITLE
google.drive: add "supportsAllDrives" option

### DIFF
--- a/src/appmixer/google/drive/CopyFile/CopyFile.js
+++ b/src/appmixer/google/drive/CopyFile/CopyFile.js
@@ -8,7 +8,7 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        let { fileId, fileName, folderLocation } = context.messages.in.content;
+        let { fileId, fileName, folderLocation, supportsAllDrives = true } = context.messages.in.content;
 
         const resource = {
             name: fileName
@@ -27,7 +27,8 @@ module.exports = {
         const response = await drive.files.copy({
             fileId,
             resource,
-            fields: 'id, name, mimeType, webViewLink, createdTime'
+            fields: 'id, name, mimeType, webViewLink, createdTime',
+            supportsAllDrives
         });
         return context.sendJson({
             fileId: response.data.id,

--- a/src/appmixer/google/drive/CopyFile/component.json
+++ b/src/appmixer/google/drive/CopyFile/component.json
@@ -24,6 +24,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "fileId": { "type": "string" },
                     "fileName": { "type": "string" },
                     "folderLocation": {
@@ -37,6 +38,13 @@
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "fileId": {
                         "type": "text",
                         "index": 1,

--- a/src/appmixer/google/drive/CreateFolder/CreateFolder.js
+++ b/src/appmixer/google/drive/CreateFolder/CreateFolder.js
@@ -9,7 +9,7 @@ module.exports = {
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
         const { userId } = context.auth;
-        let { folderName, folderLocation, useExisting } = context.messages.in.content;
+        let { folderName, folderLocation, useExisting, supportsAllDrives = true } = context.messages.in.content;
 
         const resource = {
             name: folderName,
@@ -28,7 +28,8 @@ module.exports = {
         if (useExisting) {
             const query = `name='${folderName}' and mimeType='application/vnd.google-apps.folder' and parents in '${folderLocation ? folderId : 'root'}' and trashed=false`;
             const { data } = await drive.files.list({
-                q: query
+                q: query,
+                supportsAllDrives
             });
             await context.log({ query, data });
             const { files = [] } = data;
@@ -47,7 +48,8 @@ module.exports = {
         const response = await drive.files.create({
             quotaUser: userId,
             resource,
-            fields: 'id, name, mimeType, webViewLink, createdTime'
+            fields: 'id, name, mimeType, webViewLink, createdTime',
+            supportsAllDrives
         });
 
         return context.sendJson({

--- a/src/appmixer/google/drive/CreateFolder/component.json
+++ b/src/appmixer/google/drive/CreateFolder/component.json
@@ -24,6 +24,9 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": {
+                        "type": "boolean"
+                    },
                     "folderName": {
                         "type": "string"
                     },
@@ -40,6 +43,13 @@
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "folderName": {
                         "type": "text",
                         "index": 1,

--- a/src/appmixer/google/drive/DeleteFileOrFolder/DeleteFileOrFolder.js
+++ b/src/appmixer/google/drive/DeleteFileOrFolder/DeleteFileOrFolder.js
@@ -8,9 +8,9 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        let { fileId } = context.messages.in.content;
+        let { fileId, supportsAllDrives = true } = context.messages.in.content;
 
-        await drive.files.delete({ fileId });
+        await drive.files.delete({ fileId, supportsAllDrives });
         return context.sendJson({ fileId }, 'out');
     }
 };

--- a/src/appmixer/google/drive/DeleteFileOrFolder/component.json
+++ b/src/appmixer/google/drive/DeleteFileOrFolder/component.json
@@ -24,12 +24,20 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "fileId": { "type": "string" }
                 },
                 "required": ["fileId"]
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "fileId": {
                         "type": "text",
                         "index": 1,

--- a/src/appmixer/google/drive/DownloadFile/DownloadFile.js
+++ b/src/appmixer/google/drive/DownloadFile/DownloadFile.js
@@ -8,16 +8,18 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        const { fileId, customFileName } = context.messages.in.content;
+        const { fileId, customFileName, supportsAllDrives = true } = context.messages.in.content;
 
         const [{ data: metadata }, { data: stream }] = await Promise.all([
             drive.files.get({
                 fileId: fileId,
-                fields: 'id,name,mimeType,webViewLink,createdTime'
+                fields: 'id,name,mimeType,webViewLink,createdTime',
+                supportsAllDrives
             }),
             drive.files.get({
                 fileId: fileId,
-                alt: 'media'
+                alt: 'media',
+                supportsAllDrives
             }, { responseType: 'stream' })
         ]);
 

--- a/src/appmixer/google/drive/DownloadFile/component.json
+++ b/src/appmixer/google/drive/DownloadFile/component.json
@@ -23,6 +23,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "fileId": {
                         "type": "string"
                     },
@@ -34,6 +35,13 @@
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "fileId": {
                         "type": "text",
                         "index": 1,

--- a/src/appmixer/google/drive/FindFileOrFolder/FindFileOrFolder.js
+++ b/src/appmixer/google/drive/FindFileOrFolder/FindFileOrFolder.js
@@ -8,7 +8,7 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        let { query, searchType, folderLocation } = context.messages.in.content;
+        let { query, searchType, folderLocation, supportsAllDrives = true } = context.messages.in.content;
 
         let folderId;
         if (folderLocation) {
@@ -41,7 +41,7 @@ module.exports = {
 
         await context.log({ q: q });
 
-        const { data } = await drive.files.list({ q, fields: 'files(id, name, mimeType, webViewLink, createdTime)' });
+        const { data } = await drive.files.list({ q, fields: 'files(id, name, mimeType, webViewLink, createdTime)', supportsAllDrives });
         const { files = [] } = data;
         if (files.length > 0) {
             const file = files[0];

--- a/src/appmixer/google/drive/FindFileOrFolder/component.json
+++ b/src/appmixer/google/drive/FindFileOrFolder/component.json
@@ -23,6 +23,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "query": { "type": "string" },
                     "searchType": { "type": "string" },
                     "folderLocation": {
@@ -36,6 +37,13 @@
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "query": {
                         "type": "text",
                         "index": 1,

--- a/src/appmixer/google/drive/GetFile/GetFile.js
+++ b/src/appmixer/google/drive/GetFile/GetFile.js
@@ -8,16 +8,18 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        const { fileId } = context.messages.in.content;
+        const { fileId, supportsAllDrives = true } = context.messages.in.content;
 
         const [{ data: metadata }, { data: content }] = await Promise.all([
             drive.files.get({
                 fileId: fileId,
-                fields: 'id,name,mimeType,webViewLink,createdTime'
+                fields: 'id,name,mimeType,webViewLink,createdTime',
+                supportsAllDrives
             }),
             drive.files.get({
                 fileId: fileId,
-                alt: 'media'
+                alt: 'media',
+                supportsAllDrives
             })
         ]);
 

--- a/src/appmixer/google/drive/GetFile/component.json
+++ b/src/appmixer/google/drive/GetFile/component.json
@@ -25,12 +25,20 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "fileId": { "type": "string" }
                 },
                 "required": ["fileId"]
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "fileId": {
                         "type": "text",
                         "index": 1,

--- a/src/appmixer/google/drive/ListFiles/ListFiles.js
+++ b/src/appmixer/google/drive/ListFiles/ListFiles.js
@@ -13,7 +13,7 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        let { query, searchType, folderLocation, outputType } = context.messages.in.content;
+        let { query, searchType, folderLocation, outputType, supportsAllDrives = true  } = context.messages.in.content;
 
         let folderId;
         if (folderLocation) {
@@ -49,11 +49,17 @@ module.exports = {
         const pageSize = 1000;
         const fields = 'nextPageToken, files(id, name, mimeType, webViewLink, createdTime)';
         // First page.
-        const { data } = await drive.files.list({ q, pageSize, fields });
+        const { data } = await drive.files.list({ q, pageSize, fields, supportsAllDrives });
 
         // While there are more pages, keep fetching them.
         while (data.nextPageToken) {
-            const nextPage = await drive.files.list({ q, pageToken: data.nextPageToken, pageSize, fields });
+            const nextPage = await drive.files.list({
+                q,
+                pageToken: data.nextPageToken,
+                pageSize,
+                fields,
+                supportsAllDrives
+            });
             data.files = data.files.concat(nextPage.data.files);
             data.nextPageToken = nextPage.data.nextPageToken;
         }

--- a/src/appmixer/google/drive/ListFiles/component.json
+++ b/src/appmixer/google/drive/ListFiles/component.json
@@ -25,6 +25,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "folderLocation": {
                         "oneOf": [
                             { "type": "string" },
@@ -39,6 +40,13 @@
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "folderLocation": {
                         "type": "googlepicker",
                         "index": 1,

--- a/src/appmixer/google/drive/MoveFileOrFolder/MoveFileOrFolder.js
+++ b/src/appmixer/google/drive/MoveFileOrFolder/MoveFileOrFolder.js
@@ -10,7 +10,7 @@ module.exports = {
 
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
-        let { fileId, destinationFolder } = context.messages.in.content;
+        let { fileId, destinationFolder, supportsAllDrives = true } = context.messages.in.content;
 
         let folderId;
         if (destinationFolder) {
@@ -24,7 +24,8 @@ module.exports = {
         // Retrieve the existing parents to remove
         const file = await drive.files.get({
             fileId: fileId,
-            fields: 'parents'
+            fields: 'parents',
+            supportsAllDrives
         });
 
         // Move the file to the new folder
@@ -36,7 +37,8 @@ module.exports = {
             fileId: fileId,
             addParents: folderId,
             removeParents: previousParents,
-            fields: 'id, parents'
+            fields: 'id, parents',
+            supportsAllDrives
         };
 
         if (DEBUG) {

--- a/src/appmixer/google/drive/NewFile/component.json
+++ b/src/appmixer/google/drive/NewFile/component.json
@@ -26,6 +26,9 @@
             "properties": {
                 "folder": {
                     "type": "object"
+                },
+                "supportsAllDrives": {
+                    "type": "boolean"
                 }
             }
         },
@@ -38,6 +41,13 @@
                     "tooltip": "You can select a specific folder to watch. If no folder is selected, this component will watch all files.",
                     "view": "FOLDERS",
                     "placeholder": "Choose a folder..."
+                },
+                "supportsAllDrives": {
+                    "type": "toggle",
+                    "label": "Supports All Drives",
+                    "index": 2,
+                    "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                    "defaultValue": true
                 }
             }
         }

--- a/src/appmixer/google/drive/UploadFile/UploadFile.js
+++ b/src/appmixer/google/drive/UploadFile/UploadFile.js
@@ -10,7 +10,13 @@ module.exports = {
         const auth = commons.getOauth2Client(context.auth);
         const drive = google.drive({ version: 'v3', auth });
         const { userId } = context.auth;
-        let { fileId, fileName: fileNameInput, folder, replace } = context.messages.in.content;
+        let {
+            fileId,
+            fileName: fileNameInput,
+            folder,
+            replace,
+            supportsAllDrives = true
+        } = context.messages.in.content;
 
         let filename;
         let contentType;
@@ -43,7 +49,8 @@ module.exports = {
         if (replace) {
             const query = `name='${filename}' and parents in '${folder ? folderId : 'root'}' and trashed=false`;
             const { data } = await drive.files.list({
-                q: query
+                q: query,
+                supportsAllDrives
             });
             const { files = [] } = data;
             if (files.length > 0) {
@@ -55,7 +62,8 @@ module.exports = {
                         mimeType: contentType,
                         body: fileStream
                     },
-                    fields: 'id, name, mimeType, webViewLink, createdTime'
+                    fields: 'id, name, mimeType, webViewLink, createdTime',
+                    supportsAllDrives
                 });
             } else {
                 // If no file exists, just create new file
@@ -66,7 +74,8 @@ module.exports = {
                         mimeType: contentType,
                         body: fileStream
                     },
-                    fields: 'id, name, mimeType, webViewLink, createdTime'
+                    fields: 'id, name, mimeType, webViewLink, createdTime',
+                    supportsAllDrives
                 });
             }
         } else {
@@ -77,7 +86,8 @@ module.exports = {
                     mimeType: contentType,
                     body: fileStream
                 },
-                fields: 'id, name, mimeType, webViewLink, createdTime'
+                fields: 'id, name, mimeType, webViewLink, createdTime',
+                supportsAllDrives
             });
         }
 

--- a/src/appmixer/google/drive/UploadFile/component.json
+++ b/src/appmixer/google/drive/UploadFile/component.json
@@ -24,6 +24,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "supportsAllDrives": { "type": "boolean" },
                     "fileId": {
                         "type": "string"
                     },
@@ -43,6 +44,13 @@
             },
             "inspector": {
                 "inputs": {
+                    "supportsAllDrives": {
+                        "type": "toggle",
+                        "label": "Supports All Drives",
+                        "index": 0,
+                        "tooltip": "Whether the requesting application supports both My Drives and shared drives. By default, it enables all drives.",
+                        "defaultValue": true
+                    },
                     "fileId": {
                         "type": "filepicker",
                         "index": 1,


### PR DESCRIPTION
- Added `supportsAllDrives` option to support both 'My Drives' and 'Shared Drives'(By default, it supports all drives)

- https://github.com/clientIO/appmixer-components/issues/1694