### PR TITLE
Zendesk chat: authentication using global keys 

### DIFF
--- a/src/appmixer/zendesk/auth.js
+++ b/src/appmixer/zendesk/auth.js
@@ -15,25 +15,39 @@ module.exports = {
             return context.profileInfo['email'];
         },
 
-        pre: {
-            zendeskId: {
-                type: 'text',
-                name: 'Client ID',
-                tooltip: 'Enter your Zendesk client ID',
-                required: true
-            },
-            zendeskSecret: {
-                type: 'text',
-                name: 'Client Secret',
-                tooltip: 'Enter your Zendesk client secret',
-                required: true
-            },
-            subdomain: {
+        pre: function(context) {
+
+            console.log(context.config);
+            console.log(context.callbackUrl);
+            console.log(arguments, new Error().stack);
+
+            const fields = {};
+
+            const subdomain = {
                 type: 'text',
                 name: 'Subdomain',
                 tooltip: 'Your Zendesk subdomain - e.g. if the domain is <i>https://example.zendesk.com</i> just type <b>example</b> inside this field',
                 required: true
+            };
+
+            if (context.config?.private || true) {
+
+                fields.zendeskId = {
+                    type: 'text',
+                    name: 'Client ID',
+                    tooltip: 'Enter your Zendesk client ID',
+                    required: true
+                };
+
+                fields.zendeskSecret = {
+                    type: 'text',
+                    name: 'Client Secret',
+                    tooltip: 'Enter your Zendesk client secret',
+                    required: true
+                };
             }
+
+            return { ...fields, subdomain };
         },
 
         authUrl: context => {

--- a/src/appmixer/zendesk/auth.js
+++ b/src/appmixer/zendesk/auth.js
@@ -15,37 +15,25 @@ module.exports = {
             return context.profileInfo['email'];
         },
 
-        pre: function(context) {
-
-            const fields = {};
-
-            const subdomain = {
+        pre: {
+            zendeskId: {
+                type: 'text',
+                name: 'Client ID',
+                tooltip: 'Enter your Zendesk client ID',
+                required: true
+            },
+            zendeskSecret: {
+                type: 'text',
+                name: 'Client Secret',
+                tooltip: 'Enter your Zendesk client secret',
+                required: true
+            },
+            subdomain: {
                 type: 'text',
                 name: 'Subdomain',
                 tooltip: 'Your Zendesk subdomain - e.g. if the domain is <i>https://example.zendesk.com</i> just type <b>example</b> inside this field',
                 required: true
-            };
-
-            const globalKeys = context.config?.globalKeys === 'true' || false;
-
-            if (!globalKeys) {
-
-                fields.zendeskId = {
-                    type: 'text',
-                    name: 'Client ID',
-                    tooltip: 'Enter your Zendesk client ID',
-                    required: true
-                };
-
-                fields.zendeskSecret = {
-                    type: 'text',
-                    name: 'Client Secret',
-                    tooltip: 'Enter your Zendesk client secret',
-                    required: true
-                };
             }
-
-            return { ...fields, subdomain };
         },
 
         authUrl: context => {

--- a/src/appmixer/zendesk/auth.js
+++ b/src/appmixer/zendesk/auth.js
@@ -17,10 +17,6 @@ module.exports = {
 
         pre: function(context) {
 
-            console.log(context.config);
-            console.log(context.callbackUrl);
-            console.log(arguments, new Error().stack);
-
             const fields = {};
 
             const subdomain = {
@@ -30,7 +26,9 @@ module.exports = {
                 required: true
             };
 
-            if (context.config?.private || true) {
+            const globalKeys = context.config?.globalKeys === 'true' || false;
+
+            if (!globalKeys) {
 
                 fields.zendeskId = {
                     type: 'text',

--- a/src/appmixer/zendesktickets/auth.js
+++ b/src/appmixer/zendesktickets/auth.js
@@ -3,7 +3,7 @@
 const lib = require('./lib');
 
 const hasGlobalKeys = function(context) {
-    return context.config?.globalKeys === 'true' || false;
+    return context.config?.globalKeys === true || context.config?.globalKeys === 'true' || false;
 };
 
 module.exports = {

--- a/src/appmixer/zendesktickets/auth.js
+++ b/src/appmixer/zendesktickets/auth.js
@@ -2,6 +2,10 @@
 
 const lib = require('./lib');
 
+const hasGlobalKeys = function(context) {
+    return context.config?.globalKeys === 'true' || false;
+};
+
 module.exports = {
 
     type: 'oauth2',
@@ -12,32 +16,62 @@ module.exports = {
 
         scopeDelimiter: ' ',
 
+        pre: function(context) {
+
+            const fields = {
+                subdomain: {
+                    type: 'text',
+                    name: 'Subdomain',
+                    tooltip: 'Your Zendesk subdomain - e.g. if the domain is <i>https://example.zendesk.com</i> just type <b>example</b> inside this field',
+                    required: true
+                }
+            };
+
+            if (!hasGlobalKeys(context)) {
+
+                fields.zendeskId = {
+                    type: 'text',
+                    name: 'Client ID',
+                    tooltip: 'Enter your Zendesk client ID',
+                    required: true
+                };
+
+                fields.zendeskSecret = {
+                    type: 'text',
+                    name: 'Client Secret',
+                    tooltip: 'Enter your Zendesk client secret',
+                    required: true
+                };
+            }
+
+            return { ...fields };
+        },
+
         authUrl: (context) => {
 
-            let url = 'https://{subdomain}.zendesk.com/oauth/authorizations/new?client_id={clientId}&response_type=code&redirect_uri={callbackUrl}&state={state}&scope={scope}';
-            url = url.replaceAll('{domain}', context.auth?.domain || context.config?.domain || 'zendesk');
-            url = url.replaceAll('{subdomain}', context.auth?.subdomain || context.config?.subdomain || 'example');
+            const clientId = hasGlobalKeys(context) ? encodeURIComponent(context.clientId) : '{{zendeskId}}';
 
-            url = url.replaceAll('{clientId}', context.clientId);
-            url = url.replaceAll('{callbackUrl}', context.callbackUrl);
-            url = url.replaceAll('{state}', context.ticket);
-            url = url.replaceAll('{scope}', context.scope.join(module.exports.definition.scopeDelimiter));
-
-            return url;
+            return 'https://{{subdomain}}.zendesk.com/oauth/authorizations/new'
+                + `?client_id=${clientId}`
+                + '&response_type=code'
+                + `&redirect_uri=${context.callbackUrl}`
+                + `&state=${context.ticket}`
+                + `&scope=${context.scope.join(module.exports.definition.scopeDelimiter)}`;
         },
 
         requestAccessToken: async (context) => {
-            const { clientId, clientSecret, authorizationCode } = context;
 
-            let url = 'https://{subdomain}.zendesk.com/oauth/tokens';
-            url = url.replaceAll('{domain}', context.auth?.domain || context.config?.domain || 'zendesk');
-            url = url.replaceAll('{subdomain}', context.auth?.subdomain || context.config?.subdomain || 'example');
+            const { authorizationCode } = context;
+            const url = `https://${context.subdomain}.zendesk.com/oauth/tokens`;
+            const isGlobal = hasGlobalKeys(context);
+            const clientId = encodeURIComponent(isGlobal ? context.clientId : context.zendeskId);
+            const clientSecret = encodeURIComponent(isGlobal ? context.clientSecret : context.zendeskSecret);
 
-            const tokenRequestData = `client_id=${encodeURIComponent(clientId)}`
-            + `&client_secret=${encodeURIComponent(clientSecret)}`
-            + `&code=${encodeURIComponent(authorizationCode)}`
-            + '&grant_type=authorization_code'
-            + `&redirect_uri=${encodeURIComponent(context.callbackUrl)}`;
+            const tokenRequestData = `client_id=${clientId}`
+                + `&client_secret=${clientSecret}`
+                + `&code=${encodeURIComponent(authorizationCode)}`
+                + '&grant_type=authorization_code'
+                + `&redirect_uri=${encodeURIComponent(context.callbackUrl)}`;
 
             const options = {
                 url,

--- a/src/appmixer/zendesktickets/auth.js
+++ b/src/appmixer/zendesktickets/auth.js
@@ -3,7 +3,7 @@
 const lib = require('./lib');
 
 const hasGlobalKeys = function(context) {
-    return context.config?.globalKeys === true || context.config?.globalKeys === 'true' || false;
+    return context.config?.globalKeys === true || context.config?.globalKeys?.toLowerCase() === 'true' || false;
 };
 
 module.exports = {

--- a/src/appmixer/zendesktickets/bundle.json
+++ b/src/appmixer/zendesktickets/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.zendesktickets",
-    "version": "1.0.1",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Support API"
+        ],
+        "2.0.0": [
+            "Support for the 'Global OAuth client' (see more at https://developer.zendesk.com/documentation/marketplace/building-a-marketplace-app/set-up-a-global-oauth-client/#requesting-a-global-oauth-client)"
         ]
     }
 }

--- a/src/appmixer/zendesktickets/lib.js
+++ b/src/appmixer/zendesktickets/lib.js
@@ -12,9 +12,8 @@ module.exports = {
 
     getBaseUrl: function(context) {
 
-        let url = 'https://{subdomain}.zendesk.com';
-        url = url.replaceAll('{subdomain}', context.subdomain || 'example');
-        return url;
+        const subdomain = context.subdomain || context.auth?.subdomain || 'example';
+        return `https://${subdomain}.zendesk.com`;
     },
 
     setProperty: function(obj, path, value) {

--- a/src/appmixer/zendesktickets/lib.js
+++ b/src/appmixer/zendesktickets/lib.js
@@ -12,9 +12,8 @@ module.exports = {
 
     getBaseUrl: function(context) {
 
-        let url = 'https://{subdomain}.{domain}.com';
-        url = url.replaceAll('{domain}', context.auth?.domain || context.config?.domain || 'zendesk');
-        url = url.replaceAll('{subdomain}', context.auth?.subdomain || context.config?.subdomain || 'example');
+        let url = 'https://{subdomain}.zendesk.com';
+        url = url.replaceAll('{subdomain}', context.subdomain || 'example');
         return url;
     },
 

--- a/src/appmixer/zendesktickets/service.json
+++ b/src/appmixer/zendesktickets/service.json
@@ -7,20 +7,16 @@
     "icon": "data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxNjQgMTY0IiBoZWlnaHQ9IjE2NCIgdmlld0JveD0iMCAwIDE2NCAxNjQiIHdpZHRoPSIxNjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTg1LjcgNjAuMS0yNS43LTcuMy02LjcgMjMuOS03LjggMjcuNCAyNS43IDcuMiA3LjItMjUuNnoiIGZpbGw9IiM3OGEzMDAiLz48cGF0aCBkPSJtOTIuOCAxMTEuMyAyNS43LTcuMi03LjMtMjUuNi0yNS42IDcuMnoiIGZpbGw9IiMwMDM2M2QiLz48L3N2Zz4=",
     "configuration": {
         "properties": {
+            "globalKeys": {
+                "type": "boolean"
+            },
             "clientId": {
                 "type": "string"
             },
             "clientSecret": {
                 "type": "string"
-            },
-            "subdomain": {
-                "type": "string"
             }
         },
-        "required": [
-            "clientId",
-            "clientSecret",
-            "subdomain"
-        ]
+        "required": []
     }
 }


### PR DESCRIPTION
new config `globalKeys` 
when truthy, `pre` renders the input for the `subdomain` only, otherwise renders `clientId`, `clientSecret` and `subdomain`

