### PR TITLE
JIRA: Fix labels in inspector for `CreateIssue` and `UpdateIssue`

### DIFF
--- a/src/appmixer/jira/bundle.json
+++ b/src/appmixer/jira/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jira",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -10,6 +10,9 @@
         ],
         "1.0.3": [
             "Updated links to JIRA documentation to open in new tab."
+        ],
+        "1.0.4": [
+            "Fixed issue with JIRA API scopes when obtaining labels."
         ]
     }
 }

--- a/src/appmixer/jira/issues/CreateIssue/component.json
+++ b/src/appmixer/jira/issues/CreateIssue/component.json
@@ -2,6 +2,7 @@
     "name": "appmixer.jira.issues.CreateIssue",
     "description": "Creates an issue on Jira.",
     "author": "Jimoh Damilola <jimoh@client.io>",
+    "version": "1.0.1",
     "auth": {
         "service": "appmixer:jira",
         "scope": [

--- a/src/appmixer/jira/issues/ListField/ListField.js
+++ b/src/appmixer/jira/issues/ListField/ListField.js
@@ -13,6 +13,14 @@ module.exports = {
             endpoint = `${apiUrl}user/search?query=`;
         }
 
+        // Fix labels endpoint. The one provided by Get create issue metadata is not working.
+        if (endpoint.includes('rest/api/1.0/labels/suggest')) {
+            endpoint = `${apiUrl}label`;
+            const response = await commons.get(endpoint, auth);
+
+            return context.sendJson(response?.values, 'out');
+        }
+
         const response = await commons.get(endpoint, auth);
         return context.sendJson(response, 'out');
     },
@@ -20,6 +28,16 @@ module.exports = {
     fieldToSelectArray(response) {
 
         if (Array.isArray(response)) {
+
+            // If response is an array of strings, eg. for labels
+            if (typeof response[0] === 'string') {
+                return response.map(res => {
+                    return {
+                        label: res,
+                        value: res
+                    };
+                });
+            }
 
             const filtered = response.filter(res => {
                 if (res.emailAddress) {

--- a/src/appmixer/jira/issues/ListField/component.json
+++ b/src/appmixer/jira/issues/ListField/component.json
@@ -3,6 +3,7 @@
     "description": "Fetches information about field.",
     "author": "Jimoh Damilola <jimoh@client.io>",
     "private": true,
+    "version": "1.0.1",
     "auth": {
         "service": "appmixer:jira",
         "scope": [

--- a/src/appmixer/jira/issues/UpdateIssue/component.json
+++ b/src/appmixer/jira/issues/UpdateIssue/component.json
@@ -2,6 +2,7 @@
     "name": "appmixer.jira.issues.UpdateIssue",
     "description": "Updates an issue.",
     "author": "Jimoh Damilola <jimoh@client.io>",
+    "version": "1.0.1",
     "auth": {
         "service": "appmixer:jira",
         "scope": [

--- a/src/appmixer/jira/jira-commons.js
+++ b/src/appmixer/jira/jira-commons.js
@@ -99,6 +99,7 @@ module.exports = {
         };
     },
 
+    // See IssueMetadata.js
     toInspector(fields, excludeFields) {
 
         const inspector = {


### PR DESCRIPTION
Issue: https://github.com/clientIO/appmixer-components/issues/1748

Reason: The value of `autoCompleteUrl` for `labels` field is incorrect (see [here](https://community.developer.atlassian.com/t/autocompleteurl-in-editmeta-of-some-fields/36667) and [here](https://community.developer.atlassian.com/t/how-to-filter-labels-based-on-query-or-project-in-rest-api-3/73536))

# Before
<img width="400" alt="image" src="https://github.com/clientIO/appmixer-connectors/assets/12988096/d6a4a49b-8436-4c08-b779-4c82b546feca">

# After
<img width="384" alt="image" src="https://github.com/clientIO/appmixer-connectors/assets/12988096/5473dcee-9111-495b-87da-1f4f85cb8faf">