### PR TITLE
util.controls.onError: use SearchAfter

### DIFF
--- a/src/appmixer/utils/controls/OnError/OnError.js
+++ b/src/appmixer/utils/controls/OnError/OnError.js
@@ -63,14 +63,15 @@ module.exports = {
 
             for await (const batch of fetchErrorsGenerator(context, lock, limit, lastLogId, gridTimestamp)) {
                 if (batch.length > 0) {
-                    // Update state with the _id of the last log in the page
-                    const newLastLogId = batch[batch.length - 1]['_id'];
-                    const newGridTimestamp = batch[batch.length - 1]['gridTimestamp'];
-                    await context.saveState({ lastLogId: newLastLogId, gridTimestamp: newGridTimestamp });
 
                     // Process and send the errors to outport
                     const labeledErrors = addLabels(context, batch);
                     await context.sendArray(labeledErrors, 'out');
+
+                    // Update state with the _id of the last log in the page
+                    const newLastLogId = batch[batch.length - 1]['_id'];
+                    const newGridTimestamp = batch[batch.length - 1]['gridTimestamp'];
+                    await context.saveState({ lastLogId: newLastLogId, gridTimestamp: newGridTimestamp });
                 }
             }
         } finally {

--- a/src/appmixer/utils/controls/OnError/component.json
+++ b/src/appmixer/utils/controls/OnError/component.json
@@ -3,6 +3,7 @@
     "author": "Martin Krčmář <martin@client.io>",
     "description": "This trigger fires when there is an error in the flow.",
     "tick": true,
+    "version": "1.1.0",
     "state": {
         "persistent": true
     },

--- a/src/appmixer/utils/controls/bundle.json
+++ b/src/appmixer/utils/controls/bundle.json
@@ -1,7 +1,7 @@
 {
     "name": "appmixer.utils.controls",
     "engine": ">=6.0",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -68,6 +68,9 @@
         ],
         "1.8.2": [
             "Fix SetVariable: Handles all types of variables."
+        ],
+        "1.8.3": [
+            "Enhance OnError to handle large number of errors and added limit."
         ]
     }
 }

--- a/src/appmixer/utils/controls/bundle.json
+++ b/src/appmixer/utils/controls/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.controls",
-    "engine": ">=5.1.1",
+    "engine": ">=6.0",
     "version": "1.8.2",
     "changelog": {
         "1.0.0": [


### PR DESCRIPTION
- Handled pagination with `searchAfter` ( Appmixer 6.0 introduces a new query parameter `searchAfter`)
- Used locks to handle a large number of logs.
- https://github.com/clientIO/appmixer-components/issues/1466

original PR https://github.com/clientIO/appmixer-components/pull/1690