### PR TITLE
Xero: fix LineItems parsing for Invoices 

### DIFF
--- a/src/appmixer/xero/accounting/CreateInvoice/CreateInvoice.js
+++ b/src/appmixer/xero/accounting/CreateInvoice/CreateInvoice.js
@@ -55,8 +55,7 @@ module.exports = {
                 data.Invoices[0].LineItems = JSON.parse(LineItems);
             } catch (e) {
                 // If the value is not a valid JSON, throw an error.
-                context.log({ step: 'parseLineItems', LineItems });
-                throw context.CancelError('Error parsing LineItems. Please check the syntax.', e);
+                throw new context.CancelError('Error parsing LineItems. Please check the syntax.', e);
             }
         }
 

--- a/src/appmixer/xero/accounting/CreateInvoice/component.json
+++ b/src/appmixer/xero/accounting/CreateInvoice/component.json
@@ -115,7 +115,7 @@
                     "LineItems": {
                         "type": "textarea",
                         "label": "Line Items",
-                        "tooltip": "See <a target=\"_blank\"href=\"https://developer.xero.com/documentation/api/accounting/invoices#creating-updating-and-deleting-line-items-when-updating-invoices\">Line Items</a>",
+                        "tooltip": "See <a target=\"_blank\"href=\"https://developer.xero.com/documentation/api/accounting/invoices#creating-updating-and-deleting-line-items-when-updating-invoices\">Line Items</a>. Example: [{\"Description\":\"Consulting services\",\"Quantity\":1,\"UnitAmount\":100.00}]",
                         "index": 4
                     },
                     "Date": {

--- a/src/appmixer/xero/accounting/UpdateInvoice/UpdateInvoice.js
+++ b/src/appmixer/xero/accounting/UpdateInvoice/UpdateInvoice.js
@@ -60,8 +60,7 @@ module.exports = {
                 data.Invoices[0].LineItems = JSON.parse(LineItems);
             } catch (e) {
                 // If the value is not a valid JSON, throw an error.
-                context.log({ step: 'parseLineItems', LineItems });
-                throw context.CancelError('Error parsing LineItems. Please check the syntax.', e);
+                throw new context.CancelError('Error parsing LineItems. Please check the syntax.', e);
             }
         }
 

--- a/src/appmixer/xero/accounting/UpdateInvoice/component.json
+++ b/src/appmixer/xero/accounting/UpdateInvoice/component.json
@@ -121,7 +121,7 @@
                     "LineItems": {
                         "type": "textarea",
                         "label": "Line Items",
-                        "tooltip": "See <a target=\"_blank\"href=\"https://developer.xero.com/documentation/api/accounting/invoices#creating-updating-and-deleting-line-items-when-updating-invoices\">Line Items</a>",
+                        "tooltip": "See <a target=\"_blank\"href=\"https://developer.xero.com/documentation/api/accounting/invoices#creating-updating-and-deleting-line-items-when-updating-invoices\">Line Items</a>. Example: [{\"Description\":\"Consulting services\",\"Quantity\":1,\"UnitAmount\":100.00}]",
                         "index": 4
                     },
                     "Date": {

--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -1,9 +1,9 @@
 {
     "name": "appmixer.xero",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.0.3": ["Fixed type of ExpectedPaymentDate and PlannedPaymentDate fields in inspector to be date instead of string for CreateInvoice and UpdateInvoice components."],
-        "1.1.0": ["Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact."]
+        "1.1.1": ["Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact."]
     }
 }


### PR DESCRIPTION
Fix for: https://github.com/clientIO/appmixer-components/issues/1763#issuecomment-2090469658

- [x] propagate error when parsing LineItems
- [x] add example for LineItems

# Error handling
## Before
Only a log message appeared. No error message even though it failed on JSON parsing
![image](https://github.com/clientIO/appmixer-connectors/assets/12988096/7146ee82-54b8-4c32-a473-bdb772442604)

## After
![image](https://github.com/clientIO/appmixer-connectors/assets/12988096/0d1c20c8-954c-401d-8c76-d3dc8657b05d)
![image](https://github.com/clientIO/appmixer-connectors/assets/12988096/830e2cc7-41d6-49cb-a8e4-02642badcf61)

# Component description
## Before
![image](https://github.com/clientIO/appmixer-connectors/assets/12988096/ab114722-bece-4321-a8df-feeb30fce782)

## After
![image](https://github.com/clientIO/appmixer-connectors/assets/12988096/7b0a9abf-6d5b-4dc2-8963-a9e2cc663736)
