### PR TITLE
Quickbooks: Add `realmid` to account description

### DIFF
--- a/src/appmixer/quickbooks/auth.js
+++ b/src/appmixer/quickbooks/auth.js
@@ -29,7 +29,14 @@ module.exports = {
 
             refreshAccessToken: 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
 
-            accountNameFromProfileInfo: context => context.profileInfo.email,
+            accountNameFromProfileInfo: context => {
+
+                const { companyId, email } = context.profileInfo;
+                const obfuscatedCompanyId = companyId.replace(/^(.{4}).*(.{4})$/, '$1...$2');
+
+                // Format: info@acme.com (1284...1416)
+                return `${email} (${obfuscatedCompanyId})`;
+            },
 
             processRedirectionCallback: async params => {
 

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.quickbooks",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.1.0": [
@@ -25,9 +25,10 @@
             "Improved error message when creating an invoice with no line items.",
             "Customer in CreateInvoice component is now selected from a list of existing customers."
         ],
-        "1.4.1": [
+        "1.4.2": [
             "Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact.",
-            "Implemented webhook functionality."
+            "Implemented webhook functionality.",
+            "Added realmId to the Quickbooks account section when connecting a new component."
         ]
     }
 }


### PR DESCRIPTION
# Why
To be able to immediately identify `realmId` (i.e. QBO instance) when viewing a flow. A single QB account can have multiple realms. Some of them might be sandbox companies.

# Before
<img width="398" alt="image" src="https://github.com/clientIO/appmixer-connectors/assets/12988096/349f5237-14d7-4655-943d-b197ad06e6fc">

# After
<img width="405" alt="image" src="https://github.com/clientIO/appmixer-connectors/assets/12988096/beb60143-7e43-4b43-90f5-1b0be0cbf1c5">

# RealmId
To get Realm ID of QBO instance, go to https://app.qbo.intuit.com/app/homepage?locale=en-us -> ⚙️ (top right) -> Additional info

<img width="864" alt="image" src="https://github.com/clientIO/appmixer-connectors/assets/12988096/213bbc1d-ddea-4f3e-970f-7807dd22a4bb">
