### PR TITLE
utils.csv.AddRows:  use textarea for the rows

### DIFF
--- a/src/appmixer/utils/csv/AddRows/AddRows.js
+++ b/src/appmixer/utils/csv/AddRows/AddRows.js
@@ -37,7 +37,7 @@ module.exports = {
         }
         const savedFile = await processor.addRows({ rows: rowsArray }, (idx, currentRow, isEndOfFile) => {
             return isEndOfFile;
-        }, context);
+        });
 
         return context.sendJson({ fileId: savedFile.fileId }, 'fileId');
     }

--- a/src/appmixer/utils/csv/AddRows/AddRows.js
+++ b/src/appmixer/utils/csv/AddRows/AddRows.js
@@ -37,7 +37,7 @@ module.exports = {
         }
         const savedFile = await processor.addRows({ rows: rowsArray }, (idx, currentRow, isEndOfFile) => {
             return isEndOfFile;
-        });
+        }, context);
 
         return context.sendJson({ fileId: savedFile.fileId }, 'fileId');
     }

--- a/src/appmixer/utils/csv/AddRows/component.json
+++ b/src/appmixer/utils/csv/AddRows/component.json
@@ -79,7 +79,7 @@
                         "label": "Rows",
                         "index": 4,
                         "defaultValue": "[]",
-                        "tooltip": "The rows to append (an array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}, { ...row2 }, ...] or an array of strings i.e `[[\"row1_value1\", \"row1_value2\"], [\"row2_value1\", \"row2_value2\"]]` )."
+                        "tooltip": "The rows to append (an array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}, { ...row2 }, ...] or an array of strings i.e [[\"row1_value1\", \"row1_value2\"], [\"row2_value1\", \"row2_value2\"]] )."
                     },
                     "parseNumbers": {
                         "type": "toggle",

--- a/src/appmixer/utils/csv/AddRows/component.json
+++ b/src/appmixer/utils/csv/AddRows/component.json
@@ -67,13 +67,6 @@
                         "defaultValue": ",",
                         "tooltip": "A character to use as a delimiter between columns."
                     },
-                    "withHeaders": {
-                        "type": "toggle",
-                        "label": "Use column names",
-                        "index": 3,
-                        "defaultValue": false,
-                        "tooltip": "Set to true if the first row represents column names (CSV header) and you want to use them to identify the columns(If true, make sure you pass array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}...])."
-                    },
                     "rows": {
                         "type": "textarea",
                         "label": "Rows",

--- a/src/appmixer/utils/csv/AddRows/component.json
+++ b/src/appmixer/utils/csv/AddRows/component.json
@@ -67,6 +67,13 @@
                         "defaultValue": ",",
                         "tooltip": "A character to use as a delimiter between columns."
                     },
+                    "withHeaders": {
+                        "type": "toggle",
+                        "label": "Use column names",
+                        "index": 3,
+                        "defaultValue": false,
+                        "tooltip": "Set to true if the first row represents column names (CSV header) and you want to use them to identify the columns(If true, make sure you pass array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}...])."
+                    },
                     "rows": {
                         "type": "textarea",
                         "label": "Rows",

--- a/src/appmixer/utils/csv/AddRows/component.json
+++ b/src/appmixer/utils/csv/AddRows/component.json
@@ -75,11 +75,11 @@
                         "tooltip": "Set to true if the first row represents column names (CSV header) and you want to use them to identify the columns(If true, make sure you pass array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}...])."
                     },
                     "rows": {
-                        "type": "text",
+                        "type": "textarea",
                         "label": "Rows",
                         "index": 4,
                         "defaultValue": "[]",
-                        "tooltip": "The rows to append(an array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}...] or an array of strings i.e [\"value1\", \"value2\"])."
+                        "tooltip": "The rows to append (an array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}, { ...row2 }, ...] or an array of strings i.e `[[\"row1_value1\", \"row1_value2\"], [\"row2_value1\", \"row2_value2\"]]` )."
                     },
                     "parseNumbers": {
                         "type": "toggle",

--- a/src/appmixer/utils/csv/CSVProcessor.js
+++ b/src/appmixer/utils/csv/CSVProcessor.js
@@ -459,8 +459,7 @@ module.exports = class CSVProcessor {
                 destroy();
                 reject(err);
             } finally {
-                // clearInterval(lockExtendInterval);
-                lock && lock.unlock();
+                destroy();
                 resolve();
             }
         });

--- a/src/appmixer/utils/csv/CSVProcessor.js
+++ b/src/appmixer/utils/csv/CSVProcessor.js
@@ -369,7 +369,7 @@ module.exports = class CSVProcessor {
      */
     async addRows({ rows }, closure) {
 
-        const config = this.context.config;
+        const config = this.context.config;/**/
         const lockOptions = {
             ttl: parseInt(config.lockTTL, 10) || 60000, // Default 1 minute TTL
             retryDelay: 500

--- a/src/appmixer/utils/csv/CSVProcessor.js
+++ b/src/appmixer/utils/csv/CSVProcessor.js
@@ -369,7 +369,7 @@ module.exports = class CSVProcessor {
      */
     async addRows({ rows }, closure) {
 
-        const config = this.context.config;/**/
+        const config = this.context.config;
         const lockOptions = {
             ttl: parseInt(config.lockTTL, 10) || 60000, // Default 1 minute TTL
             retryDelay: 500

--- a/src/appmixer/utils/csv/bundle.json
+++ b/src/appmixer/utils/csv/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.utils.csv",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "engine": ">=5.0",
   "changelog": {
     "1.0.0": [
@@ -29,6 +29,9 @@
     ],
     "1.3.0": [
       "Added a new component 'AddRows' that allows you to append multiple rows to the end of a CSV file."
+    ],
+    "1.3.1": [
+      "AddRows: use the textarea for rows input, improve error handling, add maximum execution time (60minutes)."
     ]
   }
 }

--- a/src/appmixer/utils/csv/quota.js
+++ b/src/appmixer/utils/csv/quota.js
@@ -4,7 +4,7 @@ module.exports = {
 
     rules: [
         {
-            limit: 5,
+            limit: 15,
             throttling: 'limit-concurrency',
             queueing: 'fifo',
             resource: 'loadFiles'


### PR DESCRIPTION
> Q2: Is it possible to replace the "Rows" text box with a text area that includes a scroll bar? I experimented with a large number of rows, approximately 700, and noticed that the text box isn't suitable for this purpose.

https://github.com/clientIO/appmixer-components/issues/1769#issuecomment-2100691470 

fixes:
 - [x] fix error handling - when an exception occurs in the `stream.on...` handlers, the exception wasn't propagated to the component. It resulted in the infinite expanding the lock. Solution: added the `Promise`.
 - [x] fix releasing the streams and intervals (added local function `destroy`)
 - [x] add maximum execution time (setInteral to max 1 hour of execution)

