### PR TITLE
utils.csv: AddRow fix

### DIFF
--- a/src/appmixer/utils/csv/AddRow/AddRow.js
+++ b/src/appmixer/utils/csv/AddRow/AddRow.js
@@ -23,15 +23,9 @@ module.exports = {
             parseNumbers,
             parseBooleans
         });
-        const savedFile = await processor.addRows(
-            { rows: withHeaders ? [convertRowWithColumnsToObject(rowWithColumns)] : row.split(delimiter) },
-            (idx, currentRow, isEndOfFile) => {
-                return isEndOfFile;
-            },
-            context
-        );
 
-        await context.log({ stage: 'savedFile', savedFile})
+        const rows = withHeaders ? [convertRowWithColumnsToObject(rowWithColumns)] : [row.split(delimiter)];
+        const savedFile = await processor.addRows({ rows });
         return context.sendJson({ fileId: savedFile.fileId }, 'fileId');
     }
 };

--- a/src/appmixer/utils/csv/AddRow/AddRow.js
+++ b/src/appmixer/utils/csv/AddRow/AddRow.js
@@ -27,8 +27,11 @@ module.exports = {
             { rows: withHeaders ? [convertRowWithColumnsToObject(rowWithColumns)] : row.split(delimiter) },
             (idx, currentRow, isEndOfFile) => {
                 return isEndOfFile;
-            }
+            },
+            context
         );
+
+        await context.log({ stage: 'savedFile', savedFile})
         return context.sendJson({ fileId: savedFile.fileId }, 'fileId');
     }
 };

--- a/src/appmixer/utils/csv/AddRows/AddRows.js
+++ b/src/appmixer/utils/csv/AddRows/AddRows.js
@@ -27,7 +27,7 @@ module.exports = {
             }
         }
 
-        // check if it withHeaders or not(if rows is an array of array string or array of objects)
+        // true if the first row represents column names (CSV header) and you want to use them to identify the columns
         const withHeaders = !Array.isArray(rowsArray[0]);
 
         const processor = new CSVProcessor(context, fileId, {

--- a/src/appmixer/utils/csv/AddRows/AddRows.js
+++ b/src/appmixer/utils/csv/AddRows/AddRows.js
@@ -13,15 +13,6 @@ module.exports = {
             parseBooleans
         } = context.messages.in.content;
 
-        // check if it withHeaders or not(if rows is an array of array string or array of objects)
-        const withHeaders = !Array.isArray(rows[0]);
-
-        const processor = new CSVProcessor(context, fileId, {
-            withHeaders,
-            delimiter,
-            parseNumbers,
-            parseBooleans
-        });
         let rowsArray = rows;
         if (typeof rows === 'string') {
             // Try to parse string as JSON.
@@ -35,10 +26,18 @@ module.exports = {
                 );
             }
         }
-        const savedFile = await processor.addRows({ rows: rowsArray }, (idx, currentRow, isEndOfFile) => {
-            return isEndOfFile;
+
+        // check if it withHeaders or not(if rows is an array of array string or array of objects)
+        const withHeaders = !Array.isArray(rowsArray[0]);
+
+        const processor = new CSVProcessor(context, fileId, {
+            withHeaders,
+            delimiter,
+            parseNumbers,
+            parseBooleans
         });
 
+        const savedFile = await processor.addRows({ rows: rowsArray });
         return context.sendJson({ fileId: savedFile.fileId }, 'fileId');
     }
 };

--- a/src/appmixer/utils/csv/AddRows/component.json
+++ b/src/appmixer/utils/csv/AddRows/component.json
@@ -67,13 +67,6 @@
                         "defaultValue": ",",
                         "tooltip": "A character to use as a delimiter between columns."
                     },
-                    "withHeaders": {
-                        "type": "toggle",
-                        "label": "Use column names",
-                        "index": 3,
-                        "defaultValue": false,
-                        "tooltip": "Set to true if the first row represents column names (CSV header) and you want to use them to identify the columns(If true, make sure you pass array of row objects i.e [{\"column1\": \"value1\", \"column2\": \"value2\"}...])."
-                    },
                     "rows": {
                         "type": "textarea",
                         "label": "Rows",

--- a/src/appmixer/utils/csv/CSVProcessor.js
+++ b/src/appmixer/utils/csv/CSVProcessor.js
@@ -371,10 +371,12 @@ module.exports = class CSVProcessor {
 
         const config = this.context.config;
         const lock = await this.context.lock(this.fileId, {
-            ttl: parseInt(config.lockTTL, 10) || 60000, // Default 1 minute TTL
+            ttl: parseInt(config.lockTTL, 10) || 60000 // Default 1 minute TTL
         });
 
-        let stream, writeStream, lockExtendInterval;
+        let stream;
+        let writeStream;
+        let lockExtendInterval;
 
         const destroy = function() {
 

--- a/src/appmixer/utils/csv/CSVProcessor.js
+++ b/src/appmixer/utils/csv/CSVProcessor.js
@@ -367,17 +367,14 @@ module.exports = class CSVProcessor {
      * @return {Promise<*>}
      * @public
      */
-    async addRows({ rows }, closure, context) {
+    async addRows({ rows }) {
 
         const config = this.context.config;
         const lock = await this.context.lock(this.fileId, {
             ttl: parseInt(config.lockTTL, 10) || 60000, // Default 1 minute TTL
-            retryDelay: 500
         });
 
-        let lockExtendInterval;
-        let writeStream;
-        let stream;
+        let stream, writeStream, lockExtendInterval;
 
         const destroy = function() {
 
@@ -387,81 +384,57 @@ module.exports = class CSVProcessor {
             if (lockExtendInterval) clearInterval(lockExtendInterval);
         };
 
-        return new Promise(async (resolve, reject) => {
+        try {
 
-            try {
-                const lockExtendTime = parseInt(config.lockExtendTime, 10) || 1000 * 60 * 1;
-                const max = Math.ceil((1000 * 60 * 60) / lockExtendTime); // max execution time 1 hour
-                let i = 0;
+            const lockExtendTime = parseInt(config.lockExtendTime, 10) || 1000 * 60 * 1;
+            const max = Math.ceil((1000 * 60 * 60) / lockExtendTime); // max execution time 1 hour
+            let i = 0;
 
-                lockExtendInterval = setInterval(async () => {
-                    i++;
-                    if (i > max) {
-                        destroy();
-                        reject({ message: 'Lock extend failed. Max attempts reached.' });
-                        return;
-                    }
-                    await lock.extend(lockExtendTime);
-                }, config.lockExtendInterval || 10000);
-
-                stream = await this.loadFile();
-                writeStream = new PassThrough();
-
-                await this.loadHeaders();
-
-                const rowsToAdd = this.withHeaders ? this.addHeaders(rows, this.getHeaders()) : rows;
-
-                let idx = 0;
-                stream.on('data', (rowData) => {
-                    try {
-                        writeStream.write(rowData.join(this.delimiter) + '\n');
-                        if (closure(idx, rowData, false)) {
-                            rowsToAdd.forEach(newRow => {
-                                const line = newRow.join(this.delimiter) + '\n';
-                                return writeStream.write(line);
-                            });
-                        }
-                        idx++;
-                    } catch (err) {
-                        destroy();
-                        reject({ error: err, row: rowData });
-                    }
-                });
-
-                stream.on('end', () => {
-                    try {
-                        if (closure(idx, null, true)) {
-                            rowsToAdd.forEach(newRow => {
-                                const line = newRow.join(this.delimiter) + '\n';
-                                writeStream.write(line);
-                            });
-                        }
-                        writeStream.end();
-                    } catch (err) {
-                        destroy();
-                        reject({ error: err });
-                    }
-                });
-
-                stream.on('error', (err) => {
+            lockExtendInterval = setInterval(async () => {
+                i++;
+                if (i > max) {
                     destroy();
-                    reject(err);
-                });
+                    throw new Error('Lock extend failed. Max attempts reached.');
+                }
+                await lock.extend(lockExtendTime);
+            }, config.lockExtendInterval || 10000);
 
-                writeStream.on('error', (err) => {
-                    destroy();
-                    reject(err);
-                });
+            await this.loadHeaders();
+            stream = await this.loadFile();
+            writeStream = new PassThrough();
 
-                // Replace file stream with writeStream
-                const savedFile = await this.context.replaceFileStream(this.fileId, writeStream);
-                destroy();
-                resolve(savedFile);
-            } catch (err) {
-                destroy();
-                reject(err);
+            const rowsToAdd = this.withHeaders ? this.addHeaders(rows, this.getHeaders()) : rows;
+
+            // append existing rows
+            for await (const rowData of stream) {
+                writeStream.write(this.formatRow(rowData));
             }
-        });
+
+            // append new rows
+            this.writeRows(writeStream, rowsToAdd);
+
+            writeStream.end();
+
+            return await this.context.replaceFileStream(this.fileId, writeStream);
+        } catch (err) {
+            destroy();
+            throw err;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    formatRow(rowData) {
+        if (!Array.isArray(rowData)) {
+            throw new Error('Unexpected row data format: ' + JSON.stringify(rowData));
+        }
+        return rowData.join(this.delimiter) + '\n';
+    }
+
+    writeRows(writeStream, rows) {
+        for (const row of rows) {
+            writeStream.write(this.formatRow(row));
+        }
     }
 
     /**

--- a/src/appmixer/utils/csv/CSVProcessor.js
+++ b/src/appmixer/utils/csv/CSVProcessor.js
@@ -367,7 +367,7 @@ module.exports = class CSVProcessor {
      * @return {Promise<*>}
      * @public
      */
-    async addRows({ rows }, closure) {
+    async addRows({ rows }, closure, context) {
 
         const config = this.context.config;
         const lock = await this.context.lock(this.fileId, {
@@ -454,16 +454,14 @@ module.exports = class CSVProcessor {
                 });
 
                 // Replace file stream with writeStream
-                return await this.context.replaceFileStream(this.fileId, writeStream);
+                const savedFile = await this.context.replaceFileStream(this.fileId, writeStream);
+                destroy();
+                resolve(savedFile);
             } catch (err) {
                 destroy();
                 reject(err);
-            } finally {
-                destroy();
-                resolve();
             }
         });
-
     }
 
     /**

--- a/src/appmixer/utils/csv/CreateInspector/CreateInspector.js
+++ b/src/appmixer/utils/csv/CreateInspector/CreateInspector.js
@@ -346,7 +346,7 @@ module.exports = {
                 type: 'text',
                 label: 'Row',
                 index: 3,
-                tooltip: 'Comma separated row values.'
+                tooltip: 'Row values separated by a specified delimiter. For example: foo,bar,baz'
             };
         }
 

--- a/src/appmixer/utils/csv/bundle.json
+++ b/src/appmixer/utils/csv/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.utils.csv",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "engine": ">=5.0",
   "changelog": {
     "1.0.0": [
@@ -30,7 +30,7 @@
     "1.3.0": [
       "Added a new component 'AddRows' that allows you to append multiple rows to the end of a CSV file."
     ],
-    "1.3.1": [
+    "1.3.2": [
       "AddRows: use the textarea for rows input, improve error handling, add maximum execution time (60minutes)."
     ]
   }


### PR DESCRIPTION
- CSVProcessor.addRows: 
  - remove dummy `closure` 
  - refactor working with streams
- AddRows component 
  - remove `withHeaders` - this input was ignored anyway  (https://github.com/clientIO/appmixer-connectors/pull/106/files#diff-589b5c64d7c756bc5cacb1ddc4ba51cc520ed7d79d46e99d4eb4d515b8e3a034L17)
  - fix resolving `withHeaders` property 