### PR TITLE
Snowflake SDK update

### DIFF
--- a/src/appmixer/snowflake/bundle.json
+++ b/src/appmixer/snowflake/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.snowflake",
-    "version": "1.1.11",
+    "version": "1.1.12",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -43,6 +43,9 @@
         ],
         "1.1.11": [
             "Update snowflake-sdk dependency to v1.6.21."
+        ],
+        "1.1.12": [
+            "Update snowflake-sdk dependency to v1.11.0."
         ]
     }
 }

--- a/src/appmixer/snowflake/package.json
+++ b/src/appmixer/snowflake/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "dependencies": {
     "csv-stringify": "6.2.3",
-    "snowflake-sdk": "1.6.21"
+    "snowflake-sdk": "1.11.0"
   }
 }


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/1813

## Before
```
jirihofman@Jiri-MacBook-Pro AddRow % node 
Welcome to Node.js v18.18.2.
Type ".help" for more information.
> require('./AddRow')
Uncaught TypeError: Object.setPrototypeOf called on null or undefined
    at setPrototypeOf (<anonymous>)
    at inherits (node:util:260:3)
    at Object.<anonymous> (/Users/jirihofman/prace/clientio/appmixer-connectors/src/appmixer/snowflake/node_modules/snowflake-sdk/lib/agent/https_proxy_ocsp_agent.js:89:1)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18)
```

## After
```
jirihofman@Jiri-MacBook-Pro AddRow % node
Welcome to Node.js v18.18.2.
Type ".help" for more information.
> require('./AddRow')
{
  receive: [AsyncFunction: receive],
  getOutputPortOptions: [AsyncFunction: getOutputPortOptions]
}
> 

```