### PR TITLE
Mongo: Remove tmp files when connection fails

### DIFF
--- a/src/appmixer/mongodb/bundle.json
+++ b/src/appmixer/mongodb/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.mongodb",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -28,6 +28,9 @@
         ],
         "1.2.2": [
             "Update dependencies: mongodb."
+        ],
+        "1.2.3": [
+            "Remove temporary files after failed connection attempt."
         ]
     }
 }

--- a/src/appmixer/mongodb/common.js
+++ b/src/appmixer/mongodb/common.js
@@ -31,27 +31,13 @@ module.exports = {
         } catch (error) {
             if (context.tlsCAFileContent) {
                 // Removing the temporary file and directory if the connection fails
-                await new Promise((resolve, reject) => {
-                    fs.rm(tmpDir.name, { recursive: true }, (err) => {
-                        if (err) {
-                            reject(err);
-                        }
-                        resolve();
-                    });
-                });
+                await removeTmpFolder(tmpDir);
             }
             throw error;
         }
 
         if (context.tlsCAFileContent) {
-            await new Promise((resolve, reject) => {
-                fs.rm(tmpDir.name, { recursive: true }, (err) => {
-                    if (err) {
-                        reject(err);
-                    }
-                    resolve();
-                });
-            });
+            await removeTmpFolder(tmpDir);
         }
         return client;
     },
@@ -141,3 +127,17 @@ module.exports = {
         }
     }
 };
+
+async function removeTmpFolder(tmpDir) {
+
+    await new Promise((resolve, reject) => {
+
+        fs.rm(tmpDir.name, { recursive: true }, (err) => {
+
+            if (err) {
+                reject(err);
+            }
+            resolve();
+        });
+    });
+}


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/1768

### Notes
- The issue exists when the connection is **not** successful.
- I tried using `tmp.setGracefulCleanup();` but it inly removes the files on process end. Not immediately.