### PR TITLE
utils.XML: fix the input when the input JSON is string

### DIFF
--- a/src/appmixer/utils/xml/JsonToXml/JsonToXml.js
+++ b/src/appmixer/utils/xml/JsonToXml/JsonToXml.js
@@ -1,6 +1,14 @@
 'use strict';
 const { XMLBuilder } = require('fast-xml-parser');
 
+function parseInputJSON(context, jsonString) {
+    try {
+        return typeof jsonString === 'string' ? JSON.parse(jsonString) : jsonString;
+    } catch (e) {
+        throw new context.CancelError(`The input JSON is invalid: ${jsonString}`);
+    }
+}
+
 module.exports = {
 
     async receive(context) {
@@ -45,7 +53,9 @@ module.exports = {
         };
 
         const builder = new XMLBuilder(options);
-        const xml = builder.build(json);
+
+        const xml = builder.build(parseInputJSON(context, json));
+
         return context.sendJson({ xml }, 'out');
     }
 };

--- a/src/appmixer/utils/xml/bundle.json
+++ b/src/appmixer/utils/xml/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.utils.xml",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.2": [
             "Initial version."
+        ],
+        "1.0.3": [
+            "jsonToXml: fix the input json as a string."
         ]
     }
 }


### PR DESCRIPTION
input 
```
{"car":[{"color":"blue"},{"color":"black"}]}
```
is causing error 
![image](https://github.com/user-attachments/assets/26023994-643c-4913-86fc-94388eadaa5c)


