### PR TITLE
quickbooks: fix of sandboxURL selection vs prod

### DIFF
--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.quickbooks",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.1.0": [
@@ -33,6 +33,9 @@
         ],
         "1.5.0": [
             "Added components: CreateCustomer."
+        ],
+        "1.5.1": [
+            "Fixed sandbox configuration to accurately determine and use the correct environment URLs based on the sandbox setting."
         ]
     }
 }

--- a/src/appmixer/quickbooks/commons.js
+++ b/src/appmixer/quickbooks/commons.js
@@ -7,15 +7,17 @@ function getBaseUrl(context, auth) {
     const sandboxBaseURL = 'https://sandbox-accounts.platform.intuit.com';
     const sandboxApiURL = 'https://sandbox-quickbooks.api.intuit.com';
     const prodBaseURL = 'https://accounts.platform.intuit.com';
-    const prodApiURL = 'https://quickbooks.api.intuit.com';
+    const prodApiURL = 'https://quickbooks.api.intuit.com'
 
-    const baseUrl = context.config.sandbox ?
+    const isSandbox = context.config.sandbox === true || context.config.sandbox === 'true'; // Ensure sandbox is correctly interpreted
+
+    const baseUrl = isSandbox ?
         context.config.sandboxBaseURL || sandboxBaseURL :
         context.config.prodBaseURL || prodBaseURL;
-    const apiUrl = context.config.sandbox ?
+    const apiUrl = isSandbox ?
         context.config.sandboxApiURL || sandboxApiURL :
         context.config.prodApiUrl || prodApiURL;
-
+        
     return auth ? baseUrl : apiUrl;
 }
 

--- a/src/appmixer/quickbooks/commons.js
+++ b/src/appmixer/quickbooks/commons.js
@@ -7,7 +7,7 @@ function getBaseUrl(context, auth) {
     const sandboxBaseURL = 'https://sandbox-accounts.platform.intuit.com';
     const sandboxApiURL = 'https://sandbox-quickbooks.api.intuit.com';
     const prodBaseURL = 'https://accounts.platform.intuit.com';
-    const prodApiURL = 'https://quickbooks.api.intuit.com'
+    const prodApiURL = 'https://quickbooks.api.intuit.com';
 
     const isSandbox = context.config.sandbox === true || context.config.sandbox === 'true'; // Ensure sandbox is correctly interpreted
 
@@ -17,7 +17,7 @@ function getBaseUrl(context, auth) {
     const apiUrl = isSandbox ?
         context.config.sandboxApiURL || sandboxApiURL :
         context.config.prodApiUrl || prodApiURL;
-        
+
     return auth ? baseUrl : apiUrl;
 }
 


### PR DESCRIPTION
Issue Fixed:
Addressed a bug (reported by customer on slack) where the sandbox setting, when set to false, was still causing API calls to be directed to sandbox URLs due to the truthy nature of the false value.

Solution:
Updated the logic to accurately determine the sandbox state by explicitly checking for true or 'true'. This ensures that only when sandbox is intentionally set to true, the sandbox URLs are used.

Changes Made:

Added a check to correctly interpret the sandbox configuration.
Updated URL assignment logic based on the revised sandbox check.