### PR TITLE
google.bigquery: remove redundant scopes

### DIFF
--- a/src/appmixer/google/bigquery/CreateInspector/component.json
+++ b/src/appmixer/google/bigquery/CreateInspector/component.json
@@ -14,9 +14,8 @@
     "auth": {
         "service": "appmixer:google",
         "scope": [
-            "https://www.googleapis.com/auth/cloud-platform.read-only",
             "https://www.googleapis.com/auth/bigquery",
-            "https://www.googleapis.com/auth/devstorage.full_control"
+            "https://www.googleapis.com/auth/bigquery.readonly"
         ]
     },
     "properties": {


### PR DESCRIPTION
- [x] - remove redundant scopes. note that `bigquery.readonly` is needed if the elevated `bigquery` is present. This is likely a bug the scope resolving in the Google endpoint 