### PR TITLE
Facebook businesss lock dependencies

### DIFF
--- a/src/appmixer/facebookbusiness/package.json
+++ b/src/appmixer/facebookbusiness/package.json
@@ -2,7 +2,7 @@
     "name": "appmixer.facebookbusiness",
     "version": "1.0.0",
     "dependencies": {
-        "csv-parser": "^3.0.0",
-        "fbgraph": "^1.4.4"
+        "csv-parser": "3.0.0",
+        "fbgraph": "1.4.4"
     }
 }


### PR DESCRIPTION
We want to have package versions locked. Discovered in https://github.com/clientIO/appmixer-components/actions/runs/10571123923/job/29286698458