### PR TITLE
Freshdesk: fix ListTickets filtering by dates

### DIFF
--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.0.2": [
             "Fixed incorrect icons for `ListAgents` and `ListContacts`."
+        ],
+        "1.0.3": [
+            "Fixed an issue with the `ListContacts` component when using 'Created At' and 'Updated At' filters."
         ]
     }
 }

--- a/src/appmixer/freshdesk/tickets/ListTickets/ListTickets.js
+++ b/src/appmixer/freshdesk/tickets/ListTickets/ListTickets.js
@@ -27,10 +27,10 @@ function andMemberConvertor(andMember) {
             return convertOperatorField('due_by', andMember.dueByOperator, `'${moment(andMember.dueByValue).format('YYYY-MM-DD')}'`);
         case 'frDueBy':
             return convertOperatorField('fr_due_by', andMember.frDueByOperator, `'${moment(andMember.frDueByValue).format('YYYY-MM-DD')}'`);
-        case 'created_at':
+        case 'createdAt':
             return convertOperatorField('created_at', andMember.createdAtOperator, `'${moment(andMember.createdAtValue).format('YYYY-MM-DD')}'`);
-        case 'updated_at':
-            return convertOperatorField('created_at', andMember.updatedAtOperator, `'${moment(andMember.updatedAtValue).format('YYYY-MM-DD')}'`);
+        case 'updatedAt':
+            return convertOperatorField('updated_at', andMember.updatedAtOperator, `'${moment(andMember.updatedAtValue).format('YYYY-MM-DD')}'`);
         default:
             return null;
     }
@@ -121,6 +121,8 @@ module.exports = {
         }
         return context.sendJson({ tickets }, 'tickets');
     },
+
+    getQuery,
 
     ticketsToSelectArray({ tickets }) {
         return tickets.map(ticket => {


### PR DESCRIPTION
Issue: https://github.com/clientIO/appmixer-components/issues/1884

## What
Fixed filtering by `created_at` and `updated_at` which now result in error. 

### Before
```
"query": "\"(( AND ))\"",
```

### After
```
"query": "\"((created_at:>'2024-08-25' AND updated_at:>'2024-08-25'))\"",
```
