### PR TITLE
google.gmail: FindOrCreateLabel added

### DIFF
--- a/src/appmixer/google/gmail/FindOrCreateLabel/FindOrCreateLabel.js
+++ b/src/appmixer/google/gmail/FindOrCreateLabel/FindOrCreateLabel.js
@@ -1,0 +1,32 @@
+'use strict';
+const commons = require('../gmail-commons');
+
+module.exports = {
+    async receive(context) {
+        const { label, createButton } = context.messages.in.content;
+
+        const endpoint = '/users/me/labels';
+        const response = await commons.callEndpoint(context, endpoint, {
+            headers: { 'Content-Type': 'application/json' }
+        });
+
+        const labels = response.data.labels;
+        const foundLabel = labels.find(l => l.name.toLowerCase() === label.toLowerCase());
+
+        if (foundLabel) {
+            return context.sendJson(foundLabel, 'out');
+        } else if (createButton) {
+            const createEndpoint = '/users/me/labels';
+            const createResponse = await commons.callEndpoint(context, createEndpoint, {
+                method: 'POST',
+                data: { name: label },
+                headers: { 'Content-Type': 'application/json' }
+            });
+
+            return context.sendJson(createResponse.data, 'out');
+        } else {
+
+            return context.send('Label not found', 'notFound');
+        }
+    }
+};

--- a/src/appmixer/google/gmail/FindOrCreateLabel/component.json
+++ b/src/appmixer/google/gmail/FindOrCreateLabel/component.json
@@ -1,0 +1,70 @@
+{
+    "name": "appmixer.google.gmail.FindOrCreateLabel",
+    "author": "Appmixer <info@appmixer.com>",
+    "description": "Searches for a Gmail label by name and returns the Label ID if found. If the label is not found, you can choose to automatically create a new label instead of returning a 'Not Found' response. This component offers flexibility in managing your Gmail labels by either retrieving existing labels or seamlessly creating new ones when needed.",
+    "version": "1.0.0",
+    "auth": {
+        "service": "appmixer:google:gmail",
+        "scope": [
+            "https://www.googleapis.com/auth/gmail.labels"
+        ]
+    },
+    "quota": {
+        "manager": "appmixer:google:gmail",
+        "maxWait": 5000,
+        "resources": "messages.polling",
+        "scope": {
+            "userId": "{{userId}}"
+        }
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "inspector": {
+                "inputs": {
+                    "label": {
+                        "type": "text",
+                        "label": "Label Name",
+                        "index": 1,
+                        "tooltip": "Enter the Label's Name to find"
+                    },
+                    "createButton": {
+                        "type": "toggle",
+                        "index": 2,
+                        "label": "Create if Not Found",
+                        "tooltip": "Toggle to Create Label if not found",
+                        "defaultValue": false
+                    }
+                }
+            },
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "createButton": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "label"
+                ]
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "options": [
+                { "label": "Label ID", "value": "id" },
+                { "label": "Label Name", "value": "name" }
+            ]
+        },
+        {
+            "name": "notFound"
+        }
+    
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBpZD0iR3JvdXBfNTQ1IiBkYXRhLW5hbWU9Ikdyb3VwIDU0NSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTM3NiAtNjQpIj4KICAgIDxyZWN0IGlkPSJSZWN0YW5nbGVfMzMyNyIgZGF0YS1uYW1lPSJSZWN0YW5nbGUgMzMyNyIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNzYgNjQpIiBmaWxsPSJub25lIi8+CiAgICA8ZyBpZD0iR3JvdXBfNTQ0IiBkYXRhLW5hbWU9Ikdyb3VwIDU0NCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNDM5OCA3MjIzLjAxNikiPgogICAgICA8cGF0aCBpZD0iUGF0aF8xNzIiIGRhdGEtbmFtZT0iUGF0aCAxNzIiIGQ9Ik01My4zNjQsNzAuMTM2aDMuMTgyVjYyLjQwOUw1Miw1OXY5Ljc3M0ExLjM2MywxLjM2MywwLDAsMCw1My4zNjQsNzAuMTM2WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTQwNzIgLTcyMTAuMTQ5KSIgZmlsbD0iIzQyODVmNCIvPgogICAgICA8cGF0aCBpZD0iUGF0aF8xNzMiIGRhdGEtbmFtZT0iUGF0aCAxNzMiIGQ9Ik0xMjAsNzAuMTM2aDMuMTgyYTEuMzYzLDEuMzYzLDAsMCwwLDEuMzY0LTEuMzY0VjU5TDEyMCw2Mi40MDlaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNDEyNC41NDUgLTcyMTAuMTQ5KSIgZmlsbD0iIzM0YTg1MyIvPgogICAgICA8cGF0aCBpZD0iUGF0aF8xNzQiIGRhdGEtbmFtZT0iUGF0aCAxNzQiIGQ9Ik0xMjAsNDMuMzUxVjQ5LjI2bDQuNTQ2LTMuNDA5VjQ0LjAzM2EyLjA0NSwyLjA0NSwwLDAsMC0zLjI3My0xLjYzNloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC00MTI0LjU0NSAtNzE5NykiIGZpbGw9IiNmYmJjMDQiLz4KICAgICAgPHBhdGggaWQ9IlBhdGhfMTc1IiBkYXRhLW5hbWU9IlBhdGggMTc1IiBkPSJNNzIsNTMuOTA5VjQ4bDUuNDU1LDQuMDkxTDgyLjkwOSw0OHY1LjkwOUw3Ny40NTUsNThaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNDA4Ny40NTUgLTcyMDEuNjQ5KSIgZmlsbD0iI2VhNDMzNSIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICAgIDxwYXRoIGlkPSJQYXRoXzE3NiIgZGF0YS1uYW1lPSJQYXRoIDE3NiIgZD0iTTUyLDQ0LjAzM3YxLjgxOGw0LjU0NSwzLjQwOVY0My4zNTFMNTUuMjczLDQyLjRBMi4wNDUsMi4wNDUsMCwwLDAsNTIsNDQuMDMzWiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTQwNzIgLTcxOTcpIiBmaWxsPSIjYzUyMjFmIi8+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K"
+}

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -27,7 +27,7 @@
             "Added attachments in outPorts of GetEmail and NewEmail.",
             "Added 'GetAttachment' component."
         ],
-        "2.0.1": [
+        "2.0.2": [
             "NewEmail Trigger - Added support for input of labels",
             "NewAttachment Trigger - Added support for labels input, filter Emails based on selected filters and fetch their attachments",
             "AddLabelsToEmail Action - Input of list of first 20 emails added",
@@ -44,7 +44,8 @@
             "Breaking change - removal of account from `connected accounts` and re-authentication of Gmail account will be required",
             "DeleteEmail - Breaking Change: Ultimate Scope of mail.google.com added. Will require removal of account from `connected accounts` and re-authentication of Gmail account",
             "CreateDraft - Breaking Change: New Scope of email.modify added. Will require removal of account from `connected accounts` and re-authentication of Gmail account",
-            "Breaking change - updating the auth service to appmixer:google:gmail. Will require re authentication"
+            "Breaking change - updating the auth service to appmixer:google:gmail. Will require re authentication",
+            "FindOrCreateLabel - NewAction"
         ]
         
         


### PR DESCRIPTION
Added a new FindOrCreateLabel component for Gmail. It searches for a label by name and returns its ID if found. If the label doesn't exist and the "Create if Not Found" option is enabled, the component will create the label and return the new ID. This makes label management in Gmail easier by automating the process of finding or creating labels.