### PR TITLE
microsoft.onedrive: improve file downloading

### DIFF
--- a/src/appmixer/microsoft/onedrive/ExportFile/ExportFile.js
+++ b/src/appmixer/microsoft/onedrive/ExportFile/ExportFile.js
@@ -18,13 +18,15 @@ module.exports = {
         const { accessToken, profileInfo } = context.auth;
 
         // If the file is a string, it means it's an item ID that was provided dynamically.
+        // Alternatively, it could be an object with an ID property. It's an object provided by OneDrive picker from the front-end.
+        // Basically `file` is the same as `file.id` in this case.
         // We need to fetch the metadata of the item to get the download URL.
-        // Otherwise we assume it's an object provided by OneDrive picker from the front-end.
-        if (typeof file === 'string') {
+        if (typeof file === 'string' || (typeof file === 'object' && file.id)) {
+            const itemId = typeof file === 'string' ? file : file.id;
             const data = await commons.formatError(() => {
                 return oneDriveAPI.items.getMetadata({
                     accessToken,
-                    itemId: file
+                    itemId
                 });
             }, `The selected file could not be found in your OneDrive account (${profileInfo.userPrincipalName})`);
 

--- a/src/appmixer/microsoft/onedrive/bundle.json
+++ b/src/appmixer/microsoft/onedrive/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.microsoft.onedrive",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "changelog": {
     "1.0.0": ["Initial version"],
     "1.0.2": [
@@ -21,6 +21,9 @@
     ],
     "1.2.1": [
       "Added `redirectUri` to OneDrivePicker component."
+    ],
+    "1.2.2": [
+      "Improved download file in ExportFile component."
     ]
   }
 }


### PR DESCRIPTION
Issue: https://github.com/clientIO/appmixer-components/issues/1637

- [x] ExportFile using dynamic - passing `itemId` string as a `file`
- [x] ExportFile using file selected from OneDrivePicker - passing object as a `file`

This means that every time we do a call to get metadata with `@microsoft.graph.downloadUrl` and `size` property. When both exist we do a call to the pre-signed URL. Otherwise we fallback to the original behavior. The original behavior seems to be also working on our hosted tenants.

It might be broken on more strict environments though.