### PR TITLE
Google.gmail updates - Tooltips, Marking Fields Required, Bundle.json update

### DIFF
--- a/src/appmixer/google/gmail/AddLabelsToEmail/component.json
+++ b/src/appmixer/google/gmail/AddLabelsToEmail/component.json
@@ -34,7 +34,7 @@
                             "AND"
                         ],
                         "index": 2,
-                        "tooltip": "Add labels to the email.",
+                        "tooltip": "Insert a label ID or select from the list to add labels to the email.",
                         "fields": {
                             "name": {
                                 "type": "select",
@@ -62,7 +62,11 @@
                     "labels": {
                         "type": "object"
                     }
-                }
+                },
+                "required": [
+                    "emailId",
+                    "labels"
+                ]
             }
         }
     ],

--- a/src/appmixer/google/gmail/CreateDraft/component.json
+++ b/src/appmixer/google/gmail/CreateDraft/component.json
@@ -162,7 +162,11 @@
                         "type": "object"
                     },
                     "attachments": {}
-                }
+                },
+                "required": [
+                    "subject",
+                    "text"
+                ]
             }
         }
     ],

--- a/src/appmixer/google/gmail/DeleteLabel/component.json
+++ b/src/appmixer/google/gmail/DeleteLabel/component.json
@@ -35,7 +35,7 @@
                     "labelId": {
                         "type": "text",
                         "label": "Label",
-                        "tooltip": "Select the Label to delete",
+                        "tooltip": "Provide Label ID or Select the Label to delete from the list. Note that only user created labels can be deleted.",
                         "index": 1,
                         "source": { 
                             "url": "/component/appmixer/google/gmail/ListLabels?outPort=out",

--- a/src/appmixer/google/gmail/FindEmails/component.json
+++ b/src/appmixer/google/gmail/FindEmails/component.json
@@ -79,7 +79,10 @@
                     "limit": {
                         "type": "number"
                     }
-                }
+                },
+                "required": [
+                    "query"
+                ]
             }
         }
     ],

--- a/src/appmixer/google/gmail/GetAttachment/component.json
+++ b/src/appmixer/google/gmail/GetAttachment/component.json
@@ -32,7 +32,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["messageId"]
+                "required": ["messageId", "attachmentId", "fileName"]
             },
             "inspector": {
                 "inputs": {

--- a/src/appmixer/google/gmail/RemoveLabelFromEmail/component.json
+++ b/src/appmixer/google/gmail/RemoveLabelFromEmail/component.json
@@ -41,7 +41,7 @@
                                 "type": "select",
                                 "label": "Name",
                                 "index": 1,
-                                "tooltip": "Select a name of the existing label.",
+                                "tooltip": "Insert a label ID or select from the list to remove labels from the email.",
                                 "source": { 
                                     "url": "/component/appmixer/google/gmail/ListLabels?outPort=out",
                                     "data": {
@@ -63,7 +63,11 @@
                     "labels": {
                         "type": "object"
                     }
-                }
+                },
+                "required": [
+                    "emailId",
+                    "labels"
+                ]
             }
         }
     ],

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -27,7 +27,7 @@
             "Added attachments in outPorts of GetEmail and NewEmail.",
             "Added 'GetAttachment' component."
         ],
-        "2.0.2": [
+        "2.0.3": [
             "NewEmail Trigger - Added support for input of labels",
             "NewAttachment Trigger - Added support for labels input, filter Emails based on selected filters and fetch their attachments",
             "AddLabelsToEmail Action",
@@ -45,7 +45,8 @@
             "DeleteEmail - Breaking Change: Ultimate Scope of mail.google.com added. Will require removal of account from `connected accounts` and re-authentication of Gmail account",
             "CreateDraft - Breaking Change: New Scope of email.modify added. Will require removal of account from `connected accounts` and re-authentication of Gmail account",
             "Breaking change - updating the auth service to appmixer:google:gmail. Will require re authentication",
-            "FindOrCreateLabel - NewAction"
+            "FindOrCreateLabel - NewAction",
+            "Moving auth.js from googleapis to httpRequest, improving tooltips and marking fields required"
         ]
         
         


### PR DESCRIPTION
Made fields required and improved tooltips in 

- AddLabelsToEmail
- CreateDraft
- FindEmails
- GetAttachment
- RemoveLabelsFromEmail

Updated bundle.json
- Includes the latest version for auth.js, findEmails (showing limit only when output type is NOT "first") and above changes