### PR TITLE
Jira (bug fix) Issue with scopes when obtaining reporters for Create Issue

### DIFF
--- a/src/appmixer/jira/bundle.json
+++ b/src/appmixer/jira/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jira",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -13,6 +13,9 @@
         ],
         "1.0.4": [
             "Fixed issue with JIRA API scopes when obtaining labels."
+        ],
+        "1.0.5": [
+            "Fixed issue with JIRA API scopes when obtaining reporters."
         ]
     }
 }

--- a/src/appmixer/jira/issues/ListField/ListField.js
+++ b/src/appmixer/jira/issues/ListField/ListField.js
@@ -21,6 +21,14 @@ module.exports = {
             return context.sendJson(response?.values, 'out');
         }
 
+        // Fix reporters endpoint. The one provided by Get create issue metadata is not working
+        if (endpoint.includes('rest/api/3/user/recommend?context=Reporter')) {
+            endpoint = `${apiUrl}users`;
+            const response = await commons.get(endpoint, auth);
+            const filteredReporters = response.filter(user => user.active && user.accountType === 'atlassian');
+            return context.sendJson(filteredReporters, 'out');
+        }
+
         const response = await commons.get(endpoint, auth);
         return context.sendJson(response, 'out');
     },


### PR DESCRIPTION
Updated the ListField code to fix the endpoint that fetches the list of reporters to fix issue with JIRA API scopes when obtaining reporters.