### PR TITLE
Google.Bigquery.(patch update).Fix for error "Cannot read properties of undefined (reading 'id')"

### DIFF
--- a/src/appmixer/google/bigquery/DeletedRow/DeletedRow.js
+++ b/src/appmixer/google/bigquery/DeletedRow/DeletedRow.js
@@ -24,11 +24,9 @@ module.exports = {
 
     async start(context) {
 
-        const { query, idField } = context.properties;
+        const { query, idField, projectId } = context.properties;
 
         const storeId = await moduleCommons.ensureStore(context, 'DeletedRow');
-
-        const projectId = await moduleCommons.getProjectId(context);
 
         const client = new BigQuery({
             authClient: commons.getAuthLibraryOAuth2Client(context.auth),
@@ -61,11 +59,9 @@ module.exports = {
             return;
         }
 
-        const { query, idField } = context.properties;
+        const { query, idField, projectId } = context.properties;
 
         const storeId = await moduleCommons.getStoreId(context);
-
-        const projectId = await moduleCommons.getProjectId(context);
 
         const client = new BigQuery({
             authClient: commons.getAuthLibraryOAuth2Client(context.auth),

--- a/src/appmixer/google/bigquery/DeletedRow/component.json
+++ b/src/appmixer/google/bigquery/DeletedRow/component.json
@@ -22,6 +22,7 @@
         "schema": {
             "type": "object",
             "properties": {
+                "projectId":{ "type": "string" },
                 "storeId": { "type": "string" },
                 "query": { "type": "string" },
                 "idField": { "type": "string" }
@@ -30,10 +31,22 @@
         },
         "inspector": {
             "inputs": {
+                "projectId": {
+                    "type": "select",
+                    "label": "Project",
+                    "index": 1,
+                    "source": {
+                        "url": "/component/appmixer/google/bigquery/ListProjects?outPort=out",
+                        "data": {
+                            "transform": "./ListProjects#projectsToSelectArray"
+                        }
+                    },
+                    "tooltip": "Select a BigQuery project from the list to run your query in."
+                },
                 "storeId": {
                     "type": "select",
                     "label": "Storage",
-                    "index": 1,
+                    "index": 2,
                     "source": {
                         "url": "/component/appmixer/utils/storage/ListStores?outPort=out",
                         "data": {
@@ -44,14 +57,14 @@
                 },
                 "query": {
                     "type": "textarea",
-                    "index": 2,
+                    "index": 3,
                     "label": "SQL Query",
                     "tooltip": "Enter an SQL query."
                 },
                 "idField": {
                     "type": "text",
                     "label": "ID field",
-                    "index": 3,
+                    "index": 4,
                     "tooltip": "Select a column that will be used as reference to detect deleted rows. It should an unique field."
                 }
             }

--- a/src/appmixer/google/bigquery/DeletedRow/component.json
+++ b/src/appmixer/google/bigquery/DeletedRow/component.json
@@ -27,7 +27,7 @@
                 "query": { "type": "string" },
                 "idField": { "type": "string" }
             },
-            "required": ["query", "idField"]
+            "required": ["query", "idField", "projectId"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/google/bigquery/ListProjects/ListProjects.js
+++ b/src/appmixer/google/bigquery/ListProjects/ListProjects.js
@@ -17,6 +17,14 @@ module.exports = {
         return projects.map(project => {
             return { label: project.id, value: project.id };
         });
+    },
+    projectsToSelectArray({ projects }) {
+
+        return projects.map(project => {
+            return { label: project.friendlyName, value: project.id };
+        }
+
+        );
     }
 
 };

--- a/src/appmixer/google/bigquery/NewRow/NewRow.js
+++ b/src/appmixer/google/bigquery/NewRow/NewRow.js
@@ -32,11 +32,9 @@ async function runQuery(client, query, params) {
 
 async function startRoutine(context) {
 
-    const { query, idField, detectOnStop } = context.properties;
+    const { query, idField, detectOnStop, projectId } = context.properties;
 
     const storeId = await moduleCommons.ensureStore(context, 'NewRow');
-
-    const projectId = await moduleCommons.getProjectId(context);
 
     const client = new BigQuery({
         authClient: commons.getAuthLibraryOAuth2Client(context.auth),
@@ -101,11 +99,9 @@ module.exports = {
             return startRoutine(context);
         }
 
-        const { query, idField } = context.properties;
+        const { query, idField, projectId } = context.properties;
 
         const storeId = await moduleCommons.getStoreId(context);
-
-        const projectId = await moduleCommons.getProjectId(context);
 
         const client = new BigQuery({
             authClient: commons.getAuthLibraryOAuth2Client(context.auth),

--- a/src/appmixer/google/bigquery/NewRow/component.json
+++ b/src/appmixer/google/bigquery/NewRow/component.json
@@ -25,6 +25,7 @@
         "schema": {
             "type": "object",
             "properties": {
+                "projectId":{ "type": "string" },
                 "storeId": { "type": "string" },
                 "query": { "type": "string" },
                 "idField": { "type": "string" },
@@ -34,10 +35,22 @@
         },
         "inspector": {
             "inputs": {
+                "projectId": {
+                    "type": "select",
+                    "label": "Project",
+                    "index": 1,
+                    "source": {
+                        "url": "/component/appmixer/google/bigquery/ListProjects?outPort=out",
+                        "data": {
+                            "transform": "./ListProjects#projectsToSelectArray"
+                        }
+                    },
+                    "tooltip": "Select a BigQuery project from the list to run your query in."
+                },
                 "storeId": {
                     "type": "select",
                     "label": "Storage",
-                    "index": 1,
+                    "index": 2,
                     "source": {
                         "url": "/component/appmixer/utils/storage/ListStores?outPort=out",
                         "data": {
@@ -48,20 +61,20 @@
                 },
                 "detectOnStop": {
                     "type": "toggle",
-                    "index": 2,
+                    "index": 3,
                     "label": "Detect new rows while stopped",
                     "tooltip": "If this is set to true, rows that are added while the flow was stopped will be processed next time the flow is started."
                 },
                 "query": {
                     "type": "textarea",
-                    "index": 3,
+                    "index": 4,
                     "label": "SQL Query",
                     "tooltip": "Enter an SQL query. If your query contains a <code>?</code> character placeholder, then the NewRow component replaces the placeholder with the last timestamp (milliseconds since epoch) the component was triggered to query only data that has been added since the the last time the component was triggered. Note that the replaced timestamp is an integer, so you might need to use a function like TIMESTAMP_MILLIS to make date comparisons. Also note that this is only possible if your result set contains an \"created_at\" type of field. A typical use case is, e.g. <code>select * from myproject.mydataset.mytable where created_at > TIMESTAMP_MILLIS(?)</code>. If you do not provide the <code>?</code> placeholder, then the component will always query all data periodically."
                 },
                 "idField": {
                     "type": "text",
                     "label": "ID field",
-                    "index": 4,
+                    "index": 5,
                     "tooltip": "Select a column that will be used as reference to detect new rows. It should be an unique field."
                 }
             }

--- a/src/appmixer/google/bigquery/NewRow/component.json
+++ b/src/appmixer/google/bigquery/NewRow/component.json
@@ -31,7 +31,7 @@
                 "idField": { "type": "string" },
                 "detectOnStop": { "type": "boolean" }
             },
-            "required": ["query", "idField"]
+            "required": ["query", "idField", "projectId"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/google/bigquery/UpdatedRow/UpdatedRow.js
+++ b/src/appmixer/google/bigquery/UpdatedRow/UpdatedRow.js
@@ -20,15 +20,13 @@ async function processUpdateRowStream(rowsStream, context, storeId, idField, loc
 
 async function startRoutine(context) {
 
-    const { query, idField, detectOnStop, recordOldValues } = context.properties;
+    const { query, idField, detectOnStop, recordOldValues, projectId } = context.properties;
     const storeId = await moduleCommons.ensureStore(context, 'UpdatedRow');
 
     const isInitialized = await context.stateGet('initialized');
     const preRegisterWebhook = isInitialized && detectOnStop;
 
     const webhookEvents = recordOldValues ? ['update'] : ['insert', 'update'];
-
-    const projectId = await moduleCommons.getProjectId(context);
 
     // Date.now returns timestamp in ms, but MySQL uses timestamp in seconds
     const now = Date.now();
@@ -99,10 +97,8 @@ module.exports = {
             return startRoutine(context);
         }
 
-        const { query, idField } = context.properties;
+        const { query, idField, projectId } = context.properties;
         const storeId = await moduleCommons.getStoreId(context);
-
-        const projectId = await moduleCommons.getProjectId(context);
 
         const client = new BigQuery({
             authClient: commons.getAuthLibraryOAuth2Client(context.auth),

--- a/src/appmixer/google/bigquery/UpdatedRow/component.json
+++ b/src/appmixer/google/bigquery/UpdatedRow/component.json
@@ -25,6 +25,7 @@
         "schema": {
             "type": "object",
             "properties": {
+                "projectId":{ "type": "string" },
                 "storeId": { "type": "string" },
                 "query": { "type": "string" },
                 "idField": { "type": "string" },
@@ -34,10 +35,22 @@
         },
         "inspector": {
             "inputs": {
+                "projectId": {
+                    "type": "select",
+                    "label": "Project",
+                    "index": 1,
+                    "source": {
+                        "url": "/component/appmixer/google/bigquery/ListProjects?outPort=out",
+                        "data": {
+                            "transform": "./ListProjects#projectsToSelectArray"
+                        }
+                    },
+                    "tooltip": "Select a BigQuery project from the list to run your query in."
+                },
                 "storeId": {
                     "type": "select",
                     "label": "Storage",
-                    "index": 1,
+                    "index": 2,
                     "source": {
                         "url": "/component/appmixer/utils/storage/ListStores?outPort=out",
                         "data": {
@@ -49,32 +62,32 @@
                 "recordOldValues": {
                     "type": "toggle",
                     "label": "Record old values",
-                    "index": 2,
+                    "index": 3,
                     "defaultValue": false,
                     "tooltip": "Include each updated row previous value in the output. In order to do this, is necessary to download all the existing rows to the store, which can be detrimental with very large tables"
                 },
                 "detectOnStop": {
                     "type": "toggle",
-                    "index": 3,
+                    "index": 4,
                     "label": "Detect updated rows while stopped",
                     "tooltip": "If this is set to true, rows that are updated while the flow was stopped will be processed next time the flow is started."
                 },
                 "query": {
                     "type": "textarea",
-                    "index": 4,
+                    "index": 5,
                     "label": "SQL Query",
                     "tooltip": "Enter an SQL query. If your query contains a <code>?</code> character placeholder, then the UpdatedRow component replaces the placeholder with the last timestamp (milliseconds since epoch) the component was triggered to query only data that has been added since the the last time the component was triggered. Note that the replaced timestamp is an integer, so you might need to use a function like TIMESTAMP_MILLIS to make date comparisons. Also note that this is only possible if your result set contains an \"updated_at\" type of field. A typical use case is, e.g. <code>select * from myproject.mydataset.mytable where updated_at > TIMESTAMP_MILLIS(?)</code>. If you do not provide the <code>?</code> placeholder, then the component will always query all data periodically."
                 },
                 "idField": {
                     "type": "text",
                     "label": "ID field",
-                    "index": 5,
+                    "index": 6,
                     "tooltip": "Select a column that will be used as reference to detect updated rows. It should be an unique field."
                 },
                 "referenceFields": {
                     "when": { "eq": { "./recordOldValues": true } },
                     "type": "text",
-                    "index": 6,
+                    "index": 7,
                     "label": "Reference Fields",
                     "tooltip": "A comma separated list of fields from the query result set that will be used to check for changes in rows. If you do not provide Reference Fields, any change in any field is detected."
                 }

--- a/src/appmixer/google/bigquery/UpdatedRow/component.json
+++ b/src/appmixer/google/bigquery/UpdatedRow/component.json
@@ -31,7 +31,7 @@
                 "idField": { "type": "string" },
                 "referenceFields": { "type": "string" }
             },
-            "required": ["query", "idField"]
+            "required": ["query", "idField", "projectId"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/google/bigquery/bundle.json
+++ b/src/appmixer/google/bigquery/bundle.json
@@ -32,7 +32,7 @@
             "Add quotas for all components."
         ],
         "4.0.0": [
-            "(breaking) Added Projects list in the input properties of NewRow, UpdatedRow, DeletedRow to fix error of projectId not found. See more here"
+            "(breaking) Added Projects list in the input properties of NewRow, UpdatedRow, DeletedRow to fix error of projectId not found. See more here https://github.com/clientIO/appmixer-connectors/pull/218"
         ]
     }
 }

--- a/src/appmixer/google/bigquery/bundle.json
+++ b/src/appmixer/google/bigquery/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.bigquery",
-    "version": "3.0.1",
+    "version": "4.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -30,6 +30,9 @@
         ],
         "3.0.1": [
             "Add quotas for all components."
+        ],
+        "4.0.0": [
+            "(breaking) Added Projects list in the input properties of NewRow, UpdatedRow, DeletedRow to fix error of projectId not found. See more here"
         ]
     }
 }

--- a/src/appmixer/google/bigquery/common.js
+++ b/src/appmixer/google/bigquery/common.js
@@ -1,7 +1,5 @@
 const Promise = require('bluebird');
-const commons = require('../google-commons');
 const EventEmitter = require('events');
-
 
 module.exports.getInterval = function(context) {
 

--- a/src/appmixer/google/bigquery/common.js
+++ b/src/appmixer/google/bigquery/common.js
@@ -2,18 +2,6 @@ const Promise = require('bluebird');
 const commons = require('../google-commons');
 const EventEmitter = require('events');
 
-module.exports.getProjectId = async function(context) {
-
-    const { clientId } = context.auth;
-    const [projectNumber] = clientId.split('-');
-
-    const authClient = commons.getAuthLibraryOAuth2Client(context.auth);
-    const res = await authClient.request({ url: 'https://bigquery.googleapis.com/bigquery/v2/projects' });
-    const { projects } = res.data;
-
-    const project = projects.find(project => project.numericId === projectNumber);
-    return project.id;
-};
 
 module.exports.getInterval = function(context) {
 


### PR DESCRIPTION
In the Triggers NewRow, UpdatedRow and DeletedRow
The SQL Query needs project ID. which was being fetched using a function getProjectId. In this function we were trying to find the project ID out of a list of all projects as whichever projects numericid would match the first part of clientID, we would take that project's projectID.

This approach was not working as none of the projects' numeric ID was matching anything in the list of projects

Hence, now an input field of select type has been introduced in the triggers which helps the user to select one project out of all the projects in their bigQuery playground and then the query is run on this project's ID.

