### PR TITLE
Notion.Create/Update/Find Database Item. (Patch) Converting databaseId inputs to properties

### DIFF
--- a/src/appmixer/notion/bundle.json
+++ b/src/appmixer/notion/bundle.json
@@ -1,9 +1,10 @@
 {
     "name": "appmixer.notion",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial release"
         ]
+        
     }
 }

--- a/src/appmixer/notion/core/CreateDatabaseItem/CreateDatabaseItem.js
+++ b/src/appmixer/notion/core/CreateDatabaseItem/CreateDatabaseItem.js
@@ -4,11 +4,12 @@ const lib = require('../../lib');
 
 module.exports = {
     async receive(context) {
+        const databaseId = context.properties.databaseId;
         if (context.properties.generateInspector) {
-            return generateInspector(context);
+            return generateInspector(context, databaseId);
         }
 
-        const { databaseId, content } = context.messages.in.content;
+        const { content } = context.messages.in.content;
 
         const itemData = await formatPropertiesForNotion(context, databaseId, context.messages.in.content);
 
@@ -46,16 +47,13 @@ module.exports = {
     }
 };
 
-async function generateInspector(context) {
-    const { databaseId } = context.properties;
+async function generateInspector(context, databaseId) {
 
     const schema = {
         type: 'object',
         properties: {
-            databaseId: { type: 'string' },
             content: { type: 'string' }
-        },
-        required: ['databaseId']
+        }
     };
 
     let fieldsInputs = {};
@@ -93,18 +91,6 @@ async function generateInspector(context) {
     }
 
     const inputs = {
-        databaseId: {
-            label: 'Database ID',
-            index: 1,
-            type: 'select',
-            source: {
-                url: '/component/appmixer/notion/core/ListDatabases?outPort=out',
-                data: {
-                    transform: './ListDatabases#databaseToSelectArray'
-                }
-            },
-            tooltip: 'Select the Notion database or insert a Database ID where you want to create a new item.'
-        },
         content: {
             label: 'Content',
             index: 999,  // Ensure this appears last in the form

--- a/src/appmixer/notion/core/CreateDatabaseItem/component.json
+++ b/src/appmixer/notion/core/CreateDatabaseItem/component.json
@@ -14,6 +14,37 @@
             "userId": "{{userId}}"
         }
     },
+    "properties": {
+        "schema": {
+            "properties": {
+                "databaseId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "databaseId"
+            ]
+        },
+        "inspector": {
+            "inputs": {
+                "databaseId": {
+                    "type": "text",
+                    "label": "Database ID",
+                    "index": 1,
+                    "tooltip": "Select a database from the picker or enter a Database ID.",
+                    "source": {
+                        "url": "/component/appmixer/notion/core/ListDatabases?outPort=out",
+                        "data": {
+                            "properties": {
+                                "sendWholeArray": true
+                            },
+                            "transform": "./ListDatabases#databaseToSelectArray"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "inPorts": [
         {
             "name": "in",
@@ -22,7 +53,7 @@
                 "data": {
                     "properties": {
                         "generateInspector": true,
-                        "databaseId": "inputs/in/databaseId"
+                        "databaseId": "properties/databaseId"
                     }
                 }
             }

--- a/src/appmixer/notion/core/FindDatabaseItem/FindDatabaseItem.js
+++ b/src/appmixer/notion/core/FindDatabaseItem/FindDatabaseItem.js
@@ -4,11 +4,12 @@ const lib = require('../../lib');
 
 module.exports = {
     async receive(context) {
+        const databaseId = context.properties.databaseId;
         if (context.properties.generateInspector) {
-            return generateInspector(context);
+            return generateInspector(context, databaseId);
         }
 
-        const { databaseId, dateFilter, dateValue, ...propertyFilters } = context.messages.in.content;
+        const { dateFilter, dateValue, ...propertyFilters } = context.messages.in.content;
 
         const filters = [];
 
@@ -117,16 +118,7 @@ module.exports = {
     }
 };
 
-async function generateInspector(context) {
-    const { databaseId } = context.properties;
-
-    const schema = {
-        type: 'object',
-        properties: {
-            databaseId: { type: 'string' }
-        },
-        required: ['databaseId']
-    };
+async function generateInspector(context, databaseId) {
 
     let fieldsInputs = {};
 
@@ -182,22 +174,10 @@ async function generateInspector(context) {
     }
 
     const inputs = {
-        databaseId: {
-            label: 'Database ID',
-            index: 1,
-            type: 'select',
-            source: {
-                url: '/component/appmixer/notion/core/ListDatabases?outPort=out',
-                data: {
-                    transform: './ListDatabases#databaseToSelectArray'
-                }
-            },
-            tooltip: 'Select the Notion database where you want to search for items.'
-        },
         ...fieldsInputs
     };
 
-    return context.sendJson({ schema, inputs }, 'out');
+    return context.sendJson({ inputs }, 'out');
 }
 
 function getInputType(property) {

--- a/src/appmixer/notion/core/FindDatabaseItem/component.json
+++ b/src/appmixer/notion/core/FindDatabaseItem/component.json
@@ -14,6 +14,37 @@
             "userId": "{{userId}}"
         }
     },
+    "properties": {
+        "schema": {
+            "properties": {
+                "databaseId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "databaseId"
+            ]
+        },
+        "inspector": {
+            "inputs": {
+                "databaseId": {
+                    "type": "text",
+                    "label": "Database ID",
+                    "index": 1,
+                    "tooltip": "Select a database from the picker or enter a Database ID.",
+                    "source": {
+                        "url": "/component/appmixer/notion/core/ListDatabases?outPort=out",
+                        "data": {
+                            "properties": {
+                                "sendWholeArray": true
+                            },
+                            "transform": "./ListDatabases#databaseToSelectArray"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "inPorts": [
         {
             "name": "in",
@@ -22,7 +53,7 @@
                 "data": {
                     "properties": {
                         "generateInspector": true,
-                        "databaseId": "inputs/in/databaseId"
+                        "databaseId": "properties/databaseId"
                     }
                 }
             }

--- a/src/appmixer/notion/core/NewDatabaseItem/component.json
+++ b/src/appmixer/notion/core/NewDatabaseItem/component.json
@@ -18,7 +18,7 @@
     "properties": {
         "schema": {
             "properties": {
-                "databseId": {
+                "databaseId": {
                     "type": "string"
                 }
             },

--- a/src/appmixer/notion/core/UpdateDatabaseItem/UpdateDatabaseItem.js
+++ b/src/appmixer/notion/core/UpdateDatabaseItem/UpdateDatabaseItem.js
@@ -4,11 +4,12 @@ const lib = require('../../lib');
 
 module.exports = {
     async receive(context) {
+        const databaseId = context.properties.databaseId;
         if (context.properties.generateInspector) {
-            return generateInspector(context);
+            return generateInspector(context, databaseId);
         }
 
-        const { databaseId, itemId, content } = context.messages.in.content;
+        const { itemId, content } = context.messages.in.content;
 
         const itemData = await formatPropertiesForNotion(context, databaseId, context.messages.in.content);
 
@@ -34,17 +35,15 @@ module.exports = {
     }
 };
 
-async function generateInspector(context) {
-    const { databaseId } = context.properties;
+async function generateInspector(context, databaseId) {
 
     const schema = {
         type: 'object',
         properties: {
-            databaseId: { type: 'string' },
             itemId: { type: 'string' },
             content: { type: 'string' }
         },
-        required: ['databaseId', 'itemId']  // We need both the database ID and the item ID to update
+        required: ['itemId']  // We need both the database ID and the item ID to update
     };
 
     let fieldsInputs = {};
@@ -83,18 +82,6 @@ async function generateInspector(context) {
     }
 
     const inputs = {
-        databaseId: {
-            label: 'Database ID',
-            index: 1,
-            type: 'select',
-            source: {
-                url: '/component/appmixer/notion/core/ListDatabases?outPort=out',
-                data: {
-                    transform: './ListDatabases#databaseToSelectArray'
-                }
-            },
-            tooltip: 'Select the Notion database or insert a Database ID where the item you want to update is located.'
-        },
         itemId: {
             label: 'Item ID',
             index: 2,
@@ -103,7 +90,7 @@ async function generateInspector(context) {
                 url: '/component/appmixer/notion/core/ListDatabaseItems?outPort=out',
                 data: {
                     messages: {
-                        'in/databaseId': 'inputs/in/databaseId'
+                        'in/databaseId': 'properties/databaseId'
                     },
                     properties: {
                         'sendWholeArray': true

--- a/src/appmixer/notion/core/UpdateDatabaseItem/component.json
+++ b/src/appmixer/notion/core/UpdateDatabaseItem/component.json
@@ -14,6 +14,37 @@
             "userId": "{{userId}}"
         }
     },
+    "properties": {
+        "schema": {
+            "properties": {
+                "databaseId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "databaseId"
+            ]
+        },
+        "inspector": {
+            "inputs": {
+                "databaseId": {
+                    "type": "text",
+                    "label": "Database ID",
+                    "index": 1,
+                    "tooltip": "Select a database from the picker or enter a Database ID.",
+                    "source": {
+                        "url": "/component/appmixer/notion/core/ListDatabases?outPort=out",
+                        "data": {
+                            "properties": {
+                                "sendWholeArray": true
+                            },
+                            "transform": "./ListDatabases#databaseToSelectArray"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "inPorts": [
         {
             "name": "in",
@@ -22,7 +53,7 @@
                 "data": {
                     "properties": {
                         "generateInspector": true,
-                        "databaseId": "inputs/in/databaseId"
+                        "databaseId": "properties/databaseId"
                     }
                 }
             }


### PR DESCRIPTION
the database ID was originally an input field, allowing users to pass values via tags or variables from previous components. However, since these values only resolve at design time, we couldn’t generate the inspector dynamically, meaning the dependent input fields for that database wouldn't appear.

To resolve this, I changed the database ID from an input port field to a property field, so it now only displays a dropdown of databases, preventing the issue of unresolved tags or variables at design time and ensuring proper inspector generation.