### PR TITLE
Gmail.ListSignatures.CreateDraft (patch update) Fix for signatures dropdown input field

### DIFF
--- a/src/appmixer/google/gmail/CreateDraft/component.json
+++ b/src/appmixer/google/gmail/CreateDraft/component.json
@@ -164,8 +164,7 @@
                     "attachments": {}
                 },
                 "required": [
-                    "subject",
-                    "text"
+                    "subject"
                 ]
             }
         }

--- a/src/appmixer/google/gmail/ListSignatures/ListSignatures.js
+++ b/src/appmixer/google/gmail/ListSignatures/ListSignatures.js
@@ -8,27 +8,29 @@ module.exports = {
             method: 'GET'
         });
 
-        // Extract signatures from sendAs
-        const signatures = data.sendAs.map(item => ({
+        // Check if sendAs array exists and map signatures
+        const signatures = Array.isArray(data.sendAs) ? data.sendAs.filter(item => item.signature).map(item => ({
             email: item.sendAsEmail,
-            signature: item.signature
-        }));
+            signature: item.signature // Only include signatures that exist
+        })) : [];
 
+        // Send the signatures or an empty array if none exist
         return context.sendJson(signatures, 'out');
     },
 
     signaturesToSelectArray(signatures) {
         return Array.isArray(signatures) ? signatures.reduce((result, sign) => {
-            let plainSignature = sign.signature
-                .replace(/<\/div><div[^>]*>/g, '\n')
-                .replace(/<[^>]+>/g, '')
-                .substring(0, 50);
+            if (sign.signature) { // Only create a label if signature exists
+                let plainSignature = sign.signature
+                    .replace(/<\/div><div[^>]*>/g, '\n') // Convert HTML div tags to line breaks
+                    .replace(/<[^>]+>/g, '') // Strip other HTML tags
+                    .substring(0, 50); // Limit signature length
 
-            result.push({
-                label: `${sign.email} ( ${plainSignature} )`,
-                value: sign.signature
-            });
-
+                result.push({
+                    label: `${sign.email} ( ${plainSignature} )`,
+                    value: sign.signature
+                });
+            }
             return result;
         }, []) : [];
     }

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -27,7 +27,7 @@
             "Added attachments in outPorts of GetEmail and NewEmail.",
             "Added 'GetAttachment' component."
         ],
-        "2.0.5": [
+        "2.0.6": [
             "NewEmail Trigger - Added support for input of labels",
             "NewAttachment Trigger - Added support for labels input, filter Emails based on selected filters and fetch their attachments",
             "AddLabelsToEmail Action",


### PR DESCRIPTION
If an Alias existed without a signature, then it's email address would show but the signature wont have any value. So the label in the dropdown of signatures select field would show the email address but behind it there wouldnt be any value. 
This was causing a breakage.

Since David's account had multiple aliases and some had signatures and some didnt, this was discovered. 

This has been fixed by checking the alias, if it has a signature, only then we work with it's signature