### PR TITLE
Slack update changelog

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -23,10 +23,9 @@
             "(breaking change) SendChannelMessage, SendPrivateChannelMessage: Channel field now accepts values from other components.",
             "SendChannelMessage, SendPrivateChannelMessage: Migration to v3 - The Channel field needs to be filled again.",
             "(breaking change) New Channel Message trigger: added scope groups:read. Will require removal of account from `connected accounts` and re-authentication of Slack account.",
-            "(breaking change) New User trigger now uses webhooks. The old version is now called NewUser - Legacy and will be deprecated.",
+            "(breaking change) New User trigger now uses webhooks. The old version is now called 'NewUser - Legacy' and will be deprecated. It requiers additional configuration in your Slack account, please see the documentation.",
             "Existing triggers NewChannelMessage and NewPrivateChannelMessage are now deprecated.",
-            "Updated labels to make them better to read in some components.",
-            "NewUser - Legacy: now checks for up to 1000 users."
+            "Updated labels to make them better to read in some components."
         ]
     }
 }


### PR DESCRIPTION
`NewUserWebhook` is a new trigger using Slack Events Subscription. It requires additional permission granted in Slack App configuration.
- [x] mention the breaking change for `NewUserWebhook`. Maybe a link to the docs?
- [ ] mention required App Token needed for message access authorization in `NewChannelMessageRT`? It is already released. Mentioning it in Appmixer docs should be enough.

### Slack Event Subscription
Without this change Slack will not send any messages to `/plugins/appmixer/slack/events`
![image](https://github.com/user-attachments/assets/e055924c-069a-4735-aa3d-99d4b20f6b8b)
