### PR TITLE
Google.Calendar.ListEvents (patch) Bug fixes

### DIFF
--- a/src/appmixer/google/calendar/ListEvents/component.json
+++ b/src/appmixer/google/calendar/ListEvents/component.json
@@ -27,7 +27,7 @@
     "properties": {
         "schema": {
             "properties": {
-                "sheetId": {
+                "calendarId": {
                     "type": "string"
                 }
             },
@@ -37,15 +37,15 @@
         },
         "inspector": {
             "inputs": {
-                "sheetId": {
+                "calendarId": {
                     "type": "select",
                     "group": "config",
-                    "label": "Spreadsheet",
+                    "label": "Calendars",
                     "index": 1,
                     "source": {
-                        "url": "/component/appmixer/google/spreadsheets/ListCalendars?outPort=out",
+                        "url": "/component/appmixer/google/calendar/ListCalendars?outPort=out",
                         "data": {
-                            "transform": "./ListSheets#sheetsToSelectArray"
+                            "transform": "./transformers#calendarsToSelectArray"
                         }
                     }
                 }

--- a/src/appmixer/google/calendar/bundle.json
+++ b/src/appmixer/google/calendar/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.calendar",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -10,6 +10,9 @@
         ],
         "1.1.0": [
             "Add Google branded sign-in button."
+        ],
+        "1.1.1": [
+            "Bug Fixes. ListEvents was fixed."
         ]
     }
 }


### PR DESCRIPTION
A private component ListCalendards had bugs, the path to source endpoint was wrong which was listing calendars to be selected in the inspector