### PR TITLE
utils.csv.GetCell (patch) fix no cell error

### DIFF
--- a/src/appmixer/utils/csv/GetCell/GetCell.js
+++ b/src/appmixer/utils/csv/GetCell/GetCell.js
@@ -37,7 +37,7 @@ module.exports = {
         }
 
         const rows = await processor.getRows(options);
-        let row = rows[0] || null;
+        const row = rows[0] || null;
 
         let targetIndex;
 
@@ -47,7 +47,8 @@ module.exports = {
             targetIndex = columnIndex;
         }
 
-        const cell = row[targetIndex];
+        // row is null when no row is found (no match)
+        const cell = row ? row[targetIndex] : null;
 
         return context.sendJson({ fileId, cell }, 'out');
     }

--- a/src/appmixer/utils/csv/bundle.json
+++ b/src/appmixer/utils/csv/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.utils.csv",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "engine": ">=5.0",
   "changelog": {
     "1.0.0": [
@@ -33,11 +33,12 @@
     "1.3.2": [
       "AddRows: use the textarea for rows input, improve error handling, add maximum execution time (60minutes)."
     ],
-    "2.0.0": [
+    "2.0.1": [
       "(breaking change) Fixed incorrect error message when using Filters or Values in these components: AddRow, UpdateRows, DeleteRows, GetCell, GetRow, GetRows. You will need to re-enter the values for these fields again.",
       "CreateCSV: make the `initialContent` required to prevent run-time exception.",
       "Added a warning for the AddRows component when all the added rows are empty.",
-      "Updated description of some components to make them more informative."
+      "Updated description of some components to make them more informative.",
+      "Fixed an issue with GetCell that could result in an error when no rows are found using a filter."
     ]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/1956

When filter returns no rows, the user gets error `TypeError: Cannot read properties of null (reading '0')`

### Before
<img width="636" alt="image" src="https://github.com/user-attachments/assets/0bac9d21-4518-4c27-82a5-5b1ddb987e26">

### After
<img width="568" alt="image" src="https://github.com/user-attachments/assets/59ac1489-647f-4863-9ee8-cc893a41726d">
