### PR TITLE
SmartSheet.LIstFolders (patch) Inspector source updates

### DIFF
--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -6,7 +6,9 @@
             "Smartsheet"
         ],
         "1.0.2": [
-            "BugFix: Update of path to ListHomeFolders in multiple component's inspectors."
+            "BugFix: Update of path to ListHomeFolders in multiple component's inspectors.",
+            "Breaking: Added input fields of isAdmin and licensedSheetCreator in AddUser as they are required fields from the API",
+            "Cleanup of descriptions of all components" 
         ]
     }
 }

--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.smartsheet",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
         "1.0.1": [
             "Smartsheet"
+        ],
+        "1.0.2": [
+            "BugFix: Update of path to ListHomeFolders in multiple component's inspectors."
         ]
     }
 }

--- a/src/appmixer/smartsheet/core/AddUser/AddUser.js
+++ b/src/appmixer/smartsheet/core/AddUser/AddUser.js
@@ -24,7 +24,9 @@ module.exports = {
         const inputMapping = {
             'email': input['email'],
             'firstName': input['firstName'],
-            'lastName': input['lastName']
+            'lastName': input['lastName'],
+            'admin': input['isAdmin'],
+            'licensedSheetCreator': input['licensedSheetCreator']
         };
         let requestBody = {};
         lib.setProperties(requestBody, inputMapping);

--- a/src/appmixer/smartsheet/core/AddUser/component.json
+++ b/src/appmixer/smartsheet/core/AddUser/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.AddUser",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Add User</p></label><br/><p>Adds a user to the organization account.</p>\n<ul>\n<li><p><strong><em>This operation is only available to system administrators</em></strong></p></li>\n<li><p><strong>If successful, and user auto provisioning (UAP) is on, and user matches the auto provisioning rules, user is added to the org. If UAP is off, or user does not match UAP rules, user is invited to the org and must explicitly accept the invitation to join.</strong></p></li>\n<li><p><strong>In some specific scenarios, supplied attributes such as firstName and lastName may be ignored. For example, if you are inviting an existing Smartsheet user to join your organization account, and the invited user has not yet accepted your invitation, any supplied firstName and lastName are ignored.</strong></p></li>\n</ul>",
+    "description": "Adds a user to the organization account. This action is available only to system administrators. If User Auto Provisioning (UAP) is enabled and the user matches UAP rules, they are automatically added to the organization. Otherwise, the user receives an invitation and must accept to join. Note that in some cases, attributes like firstName and lastName may be ignored, particularly if inviting an existing Smartsheet user who has not yet accepted a previous invitation.",
     "private": false,
     "inPorts": [
         {
@@ -28,8 +28,22 @@
                         "type": "string",
                         "example": "Doe",
                         "path": "lastName"
+                    },
+                    "isAdmin": {
+                        "description": "Is user an admin.",
+                        "type": "boolean",
+                        "example": "false",
+                        "path": "isAdmin"
+                    },
+                    "licensedSheetCreator": {
+                        "description": "Is user a licensed sheet creator.",
+                        "type": "boolean",
+                        "example": "false",
+                        "path": "licensedSheetCreator"
                     }
-                }
+                },
+                "required": ["licensedSheetCreator","isAdmin","email"]
+                
             },
             "inspector": {
                 "inputs": {
@@ -51,6 +65,19 @@
                         "index": 3,
                         "label": "Last Name",
                         "tooltip": "<p>User's last name. Example: Doe</p>"
+                    },
+                    "isAdmin": {
+                        "type": "toggle",
+                        "index": 4,
+                        "label": "Is Admin",
+                        "tooltip": "true or false"
+                        
+                    },
+                    "licensedSheetCreator": {
+                        "type": "toggle",
+                        "index": 5,
+                        "label": "Is Licensed Sheet Creator",
+                        "tooltip": "true or false"
                     }
                 }
             }

--- a/src/appmixer/smartsheet/core/CopyFolder/component.json
+++ b/src/appmixer/smartsheet/core/CopyFolder/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.CopyFolder",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Copy Folder</p></label><br/><p>Copies a folder.</p>",
+    "description": "Copies a folder.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/CopyFolder/component.json
+++ b/src/appmixer/smartsheet/core/CopyFolder/component.json
@@ -73,9 +73,9 @@
                         "label": "Folder Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                     },
@@ -188,9 +188,9 @@
                         "label": "Destination Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                         

--- a/src/appmixer/smartsheet/core/CopySheet/component.json
+++ b/src/appmixer/smartsheet/core/CopySheet/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.CopySheet",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Copy Sheet</p></label><br/><p>Creates a copy of the specified sheet.</p>",
+    "description": "Creates a copy of the specified sheet.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/CopySheet/component.json
+++ b/src/appmixer/smartsheet/core/CopySheet/component.json
@@ -159,9 +159,9 @@
                         "label": "Destination Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                         

--- a/src/appmixer/smartsheet/core/DeleteFolder/component.json
+++ b/src/appmixer/smartsheet/core/DeleteFolder/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.DeleteFolder",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Delete Folder</p></label><br/><p>Deletes a folder.</p>",
+    "description": "Deletes a folder.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/DeleteFolder/component.json
+++ b/src/appmixer/smartsheet/core/DeleteFolder/component.json
@@ -28,9 +28,9 @@
                         "label": "Folder Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                     }

--- a/src/appmixer/smartsheet/core/DeleteRows/component.json
+++ b/src/appmixer/smartsheet/core/DeleteRows/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.DeleteRows",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Delete Rows</p></label><br/><p>Deletes one or more rows from the sheet specified in the URL.</p>",
+    "description": "Deletes one or more rows from the sheet specified in the URL.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/GetContact/component.json
+++ b/src/appmixer/smartsheet/core/GetContact/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetContact",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Contact</p></label><br/><p>Gets the specified contact.</p>",
+    "description": "Gets the specified contact.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/GetCurrentUser/component.json
+++ b/src/appmixer/smartsheet/core/GetCurrentUser/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetCurrentUser",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Current User</p></label><br/><p>Gets the current user</p>\n<p><strong>NOTE:</strong> For system administrators, the following UserProfile attributes are included in the response:</p>\n<ul>\n<li><strong>customWelcomeScreenViewed</strong> (only returned when an Enterprise user has\nviewed the <a href=\"https://help.smartsheet.com/articles/1392225-customizing-a-welcome-message-upgrade-screen-enterprise-only\" rel=\"noopener noreferrer\" target=\"_blank\">Custom Welcome Screen</a>)</li>\n<li><strong>lastLogin</strong> (only returned if the user has logged in)</li>\n<li><strong>sheetCount</strong> (only returned if the status attribute is ACTIVE)</li>\n</ul>",
+    "description": "Retrieves details of the current user. For system administrators, the response includes additional attributes like customWelcomeScreenViewed (only if an Enterprise user has viewed the Custom Welcome Screen), lastLogin (if the user has logged in), and sheetCount (if the user’s status is ACTIVE).",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/GetFolder/component.json
+++ b/src/appmixer/smartsheet/core/GetFolder/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetFolder",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Folder</p></label><br/><p>Gets a Folder object.</p>",
+    "description": "Gets a Folder object.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/GetFolder/component.json
+++ b/src/appmixer/smartsheet/core/GetFolder/component.json
@@ -38,9 +38,9 @@
                         "label": "Folder Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                     },

--- a/src/appmixer/smartsheet/core/GetRow/component.json
+++ b/src/appmixer/smartsheet/core/GetRow/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetRow",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Row</p></label><br/><p>Gets the row specified in the URL.</p>",
+    "description": "Gets the row specified in the URL.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/GetUser/component.json
+++ b/src/appmixer/smartsheet/core/GetUser/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetUser",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get User</p></label><br/><p>Gets the user specified in the URL.</p>\n<ul>\n<li>NOTE: For system administrators, the following UserProfile attributes are included in the response):</li>\n<li><strong>admin</strong></li>\n<li><strong>customWelcomeScreenViewed</strong> (only returned when an Enterprise user has\nviewed the <a href=\"https://help.smartsheet.com/articles/1392225-customizing-a-welcome-message-upgrade-screen-enterprise-only\" rel=\"noopener noreferrer\" target=\"_blank\">Custom Welcome Screen</a>)</li>\n<li><strong>groupAdmin</strong></li>\n<li><strong>lastLogin</strong> (only returned if the user has logged in)</li>\n<li><strong>licensedSheetCreator</strong></li>\n<li><strong>resourceViewer</strong></li>\n<li><strong>sheetCount</strong> (only returned if the status attribute is ACTIVE)</li>\n<li><strong>status</strong></li>\n</ul>",
+    "description": "Retrieves details of the specified user. For system administrators, additional UserProfile attributes in the response include admin, customWelcomeScreenViewed (only if an Enterprise user has viewed the Custom Welcome Screen), groupAdmin, lastLogin (if the user has logged in), licensedSheetCreator, resourceViewer, sheetCount (if the user’s status is ACTIVE), and status.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/GetWorkspace/component.json
+++ b/src/appmixer/smartsheet/core/GetWorkspace/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetWorkspace",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Workspace</p></label><br/><p>Gets a Workspace object.</p>",
+    "description": "Gets a Workspace object.",
     "private": false,
    
     "inPorts": [
@@ -23,14 +23,7 @@
                         "default": 0
                     },
                     "include": {
-                        "type": "string",
-                        "enum": [
-                            "source",
-                            "distributionLink",
-                            "ownerInfo",
-                            "sheetVersion",
-                            "permalinks"
-                        ]
+                        "type": "array"
                     },
                     "loadAll": {
                         "type": "boolean",
@@ -60,10 +53,10 @@
                         "defaultValue": 0
                     },
                     "include": {
-                        "type": "select",
+                        "type": "multiselect",
                         "index": 2,
                         "label": "Include",
-                        "tooltip": "<p>A comma-separated list of optional elements to include in the response:</p>\n<ul>\n<li><strong>source</strong> - adds the Source object indicating which object the folder\nwas created from, if any</li>\n<li><strong>distributionLink</strong></li>\n<li><strong>ownerInfo</strong></li>\n<li><strong>sheetVersion</strong></li>\n<li><strong>permalinks</strong></li>\n</ul>",
+                        "tooltip": "<p>A list of optional elements to include in the response:</p>\n<ul>\n<li><strong>source</strong> - adds the Source object indicating which object the folder\nwas created from, if any</li>\n<li><strong>distributionLink</strong></li>\n<li><strong>ownerInfo</strong></li>\n<li><strong>sheetVersion</strong></li>\n<li><strong>permalinks</strong></li>\n</ul>",
                         "options": [
                             {
                                 "content": "source",

--- a/src/appmixer/smartsheet/core/GetWorkspaceFolders/component.json
+++ b/src/appmixer/smartsheet/core/GetWorkspaceFolders/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetWorkspaceFolders",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Workspace folders</p></label><br/><p>Gets a workspace's folders.</p>",
+    "description": "Gets a workspace's folders.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListColumnsOnSheet/component.json
+++ b/src/appmixer/smartsheet/core/ListColumnsOnSheet/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListColumnsOnSheet",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Columns</p></label><br/><p>Gets a list of all columns belonging to the sheet specified in the URL.</p>",
+    "description": "Gets a list of all columns belonging to the sheet specified in the URL.",
     "private": false,
     "inPorts": [
         {

--- a/src/appmixer/smartsheet/core/ListContacts/component.json
+++ b/src/appmixer/smartsheet/core/ListContacts/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListContacts",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Contacts</p></label><br/><p>Gets a list of the user's Smartsheet contacts.</p>",
+    "description": "Gets a list of the user's Smartsheet contacts.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListFolders/component.json
+++ b/src/appmixer/smartsheet/core/ListFolders/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListFolders",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Folders</p></label><br/><p>Gets a list of folders in a given folder. The list contains an abbreviated Folder object for each folder.</p>",
+    "description": "Gets a list of folders in a given folder. The list contains an abbreviated Folder object for each folder.",
     "private": false,
     "inPorts": [
         {

--- a/src/appmixer/smartsheet/core/ListFolders/component.json
+++ b/src/appmixer/smartsheet/core/ListFolders/component.json
@@ -11,7 +11,7 @@
                 "type": "object",
                 "properties": {
                     "folderId": {
-                        "type": "number"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -21,14 +21,14 @@
             "inspector": {
                 "inputs": {
                     "folderId": {
-                        "type": "number",
+                        "type": "select",
                         "index": 0,
                         "label": "Folder Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                     }

--- a/src/appmixer/smartsheet/core/ListHomeContents/component.json
+++ b/src/appmixer/smartsheet/core/ListHomeContents/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListHomeContents",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Contents</p></label><br/><p>Gets a nested list of all Home objects, including dashboards, folders, reports, sheets, templates, and workspaces, as shown on the \"Home\" tab.</p>",
+    "description": "Gets a nested list of all Home objects, including dashboards, folders, reports, sheets, templates, and workspaces, as shown on the \"Home\" tab.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListSearch/component.json
+++ b/src/appmixer/smartsheet/core/ListSearch/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListSearch",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Search Everything</p></label><br/><p>Searches all sheets that the user can access, for the specified text. If you have not used the public API in a while, we will need to provision your data. This could take up to 24 hours so please check back later!</p>",
+    "description": "Searches all sheets that the user can access, for the specified text. If you have not used the public API in a while, we will need to provision your data. This could take up to 24 hours so please check back later!",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListSearchSheet/component.json
+++ b/src/appmixer/smartsheet/core/ListSearchSheet/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListSearchSheet",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Search Sheet</p></label><br/><p>Gets a list of the user's search results in a sheet based on query. The list contains an abbreviated row object for each search result in a sheet. If you have not used the public API in a while, we will need to provision your data. This could take up to 24 hours so please check back later! <em>Note</em> Newly created or recently updated data may not be immediately discoverable via search.</p>",
+    "description": "Gets a list of the user's search results in a sheet based on query. The list contains an abbreviated row object for each search result in a sheet. If you have not used the public API in a while, we will need to provision your data. This could take up to 24 hours so please check back later! Newly created or recently updated data may not be immediately discoverable via search.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListSheets/component.json
+++ b/src/appmixer/smartsheet/core/ListSheets/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListSheets",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Sheets</p></label><br/><p>Gets a list of all sheets that the user has access to. The list contains an abbreviated Sheet object for each sheet.</p>",
+    "description": "Gets a list of all sheets that the user has access to. The list contains an abbreviated Sheet object for each sheet.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListWebhooks/component.json
+++ b/src/appmixer/smartsheet/core/ListWebhooks/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListWebhooks",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Webhooks</p></label><br/><p>Gets the list of all <em>webhooks</em> that the user owns (if a user-generated token was used to make the request) or the list of all webhooks associated with the third-party app (if a third-party app made the request). Items in the response are ordered by API cient name &gt; webhook name &gt; creation date.</p>",
+    "description": "Gets the list of all <em>webhooks</em> that the user owns (if a user-generated token was used to make the request) or the list of all webhooks associated with the third-party app (if a third-party app made the request). Items in the response are ordered by API cient name &gt; webhook name &gt; creation date.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/ListWorkspaces/component.json
+++ b/src/appmixer/smartsheet/core/ListWorkspaces/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.ListWorkspaces",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>List Workspaces</p></label><br/><p>Gets a list of workspaces that the user has access to. The list contains an abbreviated Workspace object for each workspace.</p>",
+    "description": "Gets a list of workspaces that the user has access to. The list contains an abbreviated Workspace object for each workspace.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/MoveFolder/component.json
+++ b/src/appmixer/smartsheet/core/MoveFolder/component.json
@@ -28,9 +28,9 @@
                         "label": "Folder Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                     },
@@ -62,9 +62,9 @@
                         "label": "Destination Id",
                         "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>",
                         "source": {
-                            "url": "/component/appmixer/smartsheet/core/HomeListFolders?outPort=out",
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
                             "data": {
-                                "transform": "./HomeListFolders#foldersToSelectArray"
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
                             }
                         }
                         

--- a/src/appmixer/smartsheet/core/MoveFolder/component.json
+++ b/src/appmixer/smartsheet/core/MoveFolder/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.MoveFolder",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Move Folder</p></label><br/><p>Moves a folder.</p>",
+    "description": "Moves a folder.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/MoveRows/component.json
+++ b/src/appmixer/smartsheet/core/MoveRows/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.MoveRows",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Move Rows to Another Sheet</p></label><br/><p>Moves rows from the sheet specified in the URL to (the bottom of) another sheet.</p>",
+    "description": "Moves rows from the sheet specified in the URL to (the bottom of) another sheet.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/MoveSheet/component.json
+++ b/src/appmixer/smartsheet/core/MoveSheet/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.MoveSheet",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Move Sheet</p></label><br/><p>Moves the specified sheet to a new location.\nWhen a sheet that is shared to one or more users and/or groups is moved into or out of a workspace, those sheet-level shares are preserved.</p>",
+    "description": "Moves the specified sheet to a new location.\nWhen a sheet that is shared to one or more users and/or groups is moved into or out of a workspace, those sheet-level shares are preserved.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/UpdateColumn/component.json
+++ b/src/appmixer/smartsheet/core/UpdateColumn/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.UpdateColumn",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Update Column</p></label><br/><p>Updates properties of the column, moves the column, or renames the column.</p>\n<p><strong>NOTE:</strong></p>\n<ul>\n<li>You cannot change the type of a Primary column.</li>\n<li>While dependencies are enabled on a sheet, you can't change the type of any special calendar/Gantt columns.</li>\n<li>If the column type is changed, all cells in the column are converted to the new column type and column validation is cleared.</li>\n<li>Type is optional when moving or renaming, but required when changing type or dropdown values.</li>\n</ul>",
+    "description": "Modifies column properties, moves, or renames it. Note: You cannot change the type of a Primary column. With dependencies enabled, special calendar/Gantt columns cannot have their type changed. Changing the column type converts all cells and clears validation. Type is optional for moving or renaming but required when changing type or dropdown values.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/UpdateFolder/component.json
+++ b/src/appmixer/smartsheet/core/UpdateFolder/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.UpdateFolder",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Update Folder</p></label><br/><p>Updates a folder.</p>",
+    "description": "Updates a folder.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/UpdateRows/component.json
+++ b/src/appmixer/smartsheet/core/UpdateRows/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.UpdateRows",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Update Rows</p></label><br/><p>Updates cell values in the specified rows, expands/collapses the specified rows, or modifies the position of specified rows (including indenting/outdenting). For detailed information about changing row positions, see <a href=\"../../tag/rowsRelated#section/Specify-Row-Location\" rel=\"noopener noreferrer\" target=\"_blank\">location-specifier attributes</a>.</p>",
+    "description": "Updates cell values, expands or collapses rows, or modifies the position of specified rows (including indenting/outdenting). For details on changing row positions, see location-specifier attributes.",
     "private": false,
    
     "inPorts": [

--- a/src/appmixer/smartsheet/core/UpdateWorkspace/component.json
+++ b/src/appmixer/smartsheet/core/UpdateWorkspace/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.UpdateWorkspace",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Update Workspace</p></label><br/><p>Updates a workspace.</p>",
+    "description": "Updates a workspace.",
     "private": false,
     "inPorts": [
         {

--- a/src/appmixer/smartsheet/core/getSheet/component.json
+++ b/src/appmixer/smartsheet/core/getSheet/component.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "name": "appmixer.smartsheet.core.GetSheet",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "<label><p>Get Sheet</p></label><br/><p>Gets a sheet in the format specified, based on the sheet Id.</p>",
+    "description": "Gets a sheet in the format specified, based on the sheet Id.",
     "private": false,
    
     "inPorts": [


### PR DESCRIPTION
Looks like the component ListHomeFolders (which is responsible to list folders in multiple component inputs inspectors) was called as HomeListFolders which was no where to be found hence an error of missing component was constantly faced.

I have updated the source paths in all these inspectors



Rest of the details are as follows: 

1. ListFolders: Error has been fixed
2. Descriptions of all components had html tags in them causing them to appear large, I have shortened, simplified and made them all in paragraphs so they are easy to view
3. GetWorkspace: Added multiselect so that there could be selection of more than one parameters.
4. Getfolder: Error fixed, this is the same as ListFolders, the error was because a component ListHomeFolders wrongly named in the inspector
5. GetSheet: Same as above. the component ListHomeFolders was written wrong
6. AddUser: Fixed the description
7. AddUser: Added the required properties IsAdmin and licensedSheetCreator as they are requierd by the API