### PR TITLE
Monday.com GetItem/AddFileToUpdate (Major) Bug fixes

### DIFF
--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",
@@ -53,6 +53,10 @@
         ],
         "2.1.2": [
             "Fixed 'AddFileToUpdate' component."
+        ],
+        "2.1.3": [
+            "Breaking Change: Updated the 'file ID' field of 'AddFileToUpdate' component to be a filepicker.",
+            "Updated the query of GetItem to correctly include 'Title'."
         ]
     }
 }

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "2.1.3",
+    "version": "3.0.0",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",
@@ -54,7 +54,7 @@
         "2.1.2": [
             "Fixed 'AddFileToUpdate' component."
         ],
-        "2.1.3": [
+        "3.0.0": [
             "Breaking Change: Updated the 'file ID' field of 'AddFileToUpdate' component to be a filepicker.",
             "Updated the query of GetItem to correctly include 'Title'."
         ]

--- a/src/appmixer/monday/core/AddFileToUpdate/component.json
+++ b/src/appmixer/monday/core/AddFileToUpdate/component.json
@@ -13,7 +13,7 @@
             "schema": {
                 "type": "object",
                     "properties": {
-                        "fileId": { "type": "string" },
+                        "fileId": {},
                         "fileName": { "type": "string" },
                         "updateId": { "type": "string" }
                     },
@@ -22,8 +22,9 @@
                 "inspector": {
                     "inputs": {
                         "fileId": {
-                            "type": "text",
+                            "type": "filepicker",
                             "label": "File ID",
+                            "tooltip": "Add a file ID or upload/select a file from the system",
                             "index": 1
                         },
                         "fileName": {

--- a/src/appmixer/monday/core/GetItem/GetItem.js
+++ b/src/appmixer/monday/core/GetItem/GetItem.js
@@ -21,10 +21,14 @@ module.exports = {
         item?.column_values?.map(val => {
             item[`column_value_${val.id}_id`] = val.id,
             item[`column_value_${val.id}_text`] = val.text,
-            item[`column_value_${val.id}_title`] = val.title,
             item[`column_value_${val.id}_type`] = val.type,
             item[`column_value_${val.id}_value`] = val.value,
             item[`column_value_${val.id}_additional_info`] = val.additional_info;
+
+            // Access title from the nested column field
+            if (val.column && val.column.title) {
+                item[`column_value_${val.id}_title`] = val.column.title;
+            }
         });
 
         if (context.properties.generateOutputPortOptions) {

--- a/src/appmixer/monday/queries.js
+++ b/src/appmixer/monday/queries.js
@@ -321,10 +321,12 @@ module.exports = {
         column_values {
             id
             value
-            title
             type
-            additional_info
             text
+            column {
+                id
+                title
+            }
         }
         email
         }


### PR DESCRIPTION
fixes for https://github.com/clientIO/appmixer-connectors/issues/265

1. Seems like there was a mistake in the way we were fetching the title of item as according to this article it is further layered https://community.monday.com/t/title-of-column-in-new-api/65575
I have hence fixed the query that fetches the item and it should work now

2. I have added the filepicker option in AddFileToUpdate component. It should work as well 
