### PR TITLE
ActiveCampaign (patch) multiple components fixes

### DIFF
--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -1,7 +1,15 @@
 {
     "name": "appmixer.activecampaign",
-    "version": "1.0.1",
-    "changelog": [
-        "Initial version"
-    ]
+    "version": "1.0.2",
+    "changelog": {
+        "1.0.0": [
+            "Initial version"
+        ],
+        "1.0.2": [
+            "CreateDeal: Deal amount and Currency are now required",
+            "CreateTask: Contact/Deal is now required",
+            "UpdateDeal: should no longer require value (Deal amount) to run",
+            "Small fixes to UpdateContact"
+        ]
+    }
 }

--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -6,10 +6,10 @@
             "Initial version"
         ],
         "1.0.2": [
-            "CreateDeal: Deal amount and Currency are now required",
-            "CreateTask: Contact/Deal is now required",
-            "UpdateDeal: should no longer require value (Deal amount) to run",
-            "Small fixes to UpdateContact"
+            "CreateDeal: Deal amount and Currency are now required.",
+            "CreateTask: Contact/Deal is now required.",
+            "UpdateDeal: should no longer require value (Deal amount) to run.",
+            "Small fixes to UpdateContact."
         ]
     }
 }

--- a/src/appmixer/activecampaign/contacts/UpdateContact/UpdateContact.js
+++ b/src/appmixer/activecampaign/contacts/UpdateContact/UpdateContact.js
@@ -12,7 +12,7 @@ module.exports = {
             firstName,
             lastName,
             phone,
-            customFields
+            customFields = {}
         } = context.messages.in.content;
 
         const ac = new ActiveCampaign(auth.url, auth.apiKey);
@@ -37,7 +37,7 @@ module.exports = {
 
         const { data } = await ac.call('put', `contacts/${contactId}`, payload);
 
-        const customFieldsPayload = data.fieldValues.reduce((acc, field) => {
+        const customFieldsPayload = data.fieldValues?.reduce((acc, field) => {
             acc[`customField_${field.field}`] = field.value;
             return acc;
         }, {});

--- a/src/appmixer/activecampaign/deals/CreateDeal/component.json
+++ b/src/appmixer/activecampaign/deals/CreateDeal/component.json
@@ -34,7 +34,9 @@
                     "contactId",
                     "title",
                     "owner",
-                    "stage"
+                    "stage",
+                    "value",
+                    "currency"
                 ]
             },
             "inspector": {

--- a/src/appmixer/activecampaign/deals/UpdateDeal/UpdateDeal.js
+++ b/src/appmixer/activecampaign/deals/UpdateDeal/UpdateDeal.js
@@ -23,6 +23,9 @@ module.exports = {
         const { auth } = context;
         const ac = new ActiveCampaign(auth.url, auth.apiKey);
 
+        const originalDealData = await ac.call('get', `deals/${dealId}`);
+        const originalDealValue = originalDealData.data.deal.value;
+
         const payload = {
             deal: trimUndefined(
                 {
@@ -30,7 +33,7 @@ module.exports = {
                     title,
                     description,
                     currency: currency ? currency.toLowerCase() : currency,
-                    value: value * 100,
+                    value: value ? value * 100 : originalDealValue,
                     owner,
                     stage,
                     status
@@ -47,7 +50,7 @@ module.exports = {
             payload.deal.fields = fieldValues;
         }
 
-        const { data } = await ac.call('put', `deals/${dealId}`, payload);
+        const { data } = await ac.call('put', `deals/${dealId}`, JSON.stringify(payload));
         const { deal } = data;
 
         const customFieldsPayload = fieldValues.reduce((acc, field) => {

--- a/src/appmixer/activecampaign/deals/UpdateDeal/component.json
+++ b/src/appmixer/activecampaign/deals/UpdateDeal/component.json
@@ -9,7 +9,7 @@
     },
     "quota": {
         "manager": "appmixer:activecampaign",
-        "resources": "requests",
+        "resources": "update-deal",
         "scope": {
             "userId": "{{userId}}"
         }

--- a/src/appmixer/activecampaign/quota.js
+++ b/src/appmixer/activecampaign/quota.js
@@ -10,6 +10,13 @@ module.exports = {
             throttling: 'window-sliding',
             queueing: 'fifo',
             resource: 'requests'
+        },
+        {
+            limit: 2.5, // the quota is 5 per second
+            window: 1000, //1 sec
+            throttling: 'window-sliding',
+            queueing: 'fifo',
+            resource: 'update-deal'
         }
     ]
 };

--- a/src/appmixer/activecampaign/tasks/CreateTask/component.json
+++ b/src/appmixer/activecampaign/tasks/CreateTask/component.json
@@ -31,6 +31,8 @@
                     "durationUnits": { "type": "string" }
                 },
                 "required": [
+                    "contactId",
+                    "dealId",
                     "relationship",
                     "taskType",
                     "title",


### PR DESCRIPTION
The UpdateDeal component requires for Deal amount to be filled, however as this is update component, it shouldn't be required on our side. My current workaround is the GET deal/dealId for the original amount and then either use it or send the new value.