### PR TITLE
utils.AI.DescribeImages (patch): Images property is now required

### DIFF
--- a/src/appmixer/utils/ai/DescribeImages/component.json
+++ b/src/appmixer/utils/ai/DescribeImages/component.json
@@ -10,7 +10,7 @@
                 "prompt": { "type": "string" },
                 "images": {}
             },
-            "required": ["prompt"]
+            "required": ["prompt", "images"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/utils/ai/bundle.json
+++ b/src/appmixer/utils/ai/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.utils.ai",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.0": [
             "Initial version."
         ],
         "1.1.0": [
             "CreateTranscription: add Response Format configuration field (text/srt/vtt)."
+        ],
+        "1.1.1": [
+            "DescribeImages: images are now required"
         ]
     }
 }


### PR DESCRIPTION
I think that it make sense that if you want to describe images that you should also upload at least one image :)