### PR TITLE
Microsoft.SharePoint (minor) moving from onedrive API in some components

### DIFF
--- a/src/appmixer/microsoft/sharepoint/ListSites/component.json
+++ b/src/appmixer/microsoft/sharepoint/ListSites/component.json
@@ -13,11 +13,17 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "query": { "type": "string"},
                     "limit": { "type": "number" }
                 }
             },
             "inspector": {
                 "inputs": {
+                    "query": {
+                        "type": "text",
+                        "label": "Search text",
+                        "index": 0
+                    },
                     "limit": {
                         "type": "number",
                         "label": "Limit",

--- a/src/appmixer/microsoft/sharepoint/MoveFileOrFolder/MoveFileOrFolder.js
+++ b/src/appmixer/microsoft/sharepoint/MoveFileOrFolder/MoveFileOrFolder.js
@@ -1,30 +1,35 @@
 'use strict';
-const oneDriveAPI = require('onedrive-api');
-const commons = require('../../microsoft-commons');
 
 module.exports = {
 
     async receive(context) {
 
         const { driveId, itemId, itemPath, newName, folderId } = context.messages.in.content;
-        const { accessToken, profileInfo } = context.auth;
+        const { accessToken } = context.auth;
 
-        const renameFile = await commons.formatError(async () => {
-            return oneDriveAPI.items.update({
-                accessToken,
-                itemId,
-                itemPath,
-                drive: 'drive',
-                driveId,
-                toUpdate: {
-                    name: newName,
-                    parentReference: folderId && {
-                        id: folderId
-                    }
-                }
-            });
-        }, `Failed to rename the file with ID "${itemId}" in your SharePoint account (${profileInfo.userPrincipalName}).`);
+        let url = '';
+        if (itemId) {
+            url = `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${itemId}`;
+        } else {
+            url = `https://graph.microsoft.com/v1.0/drives/${driveId}/root:/${itemPath}`;
+        }
 
-        return context.sendJson(renameFile, 'out');
+        const body = {
+            parentReference: {
+                id: folderId
+            },
+            name: newName
+        };
+
+        const { data } = await context.httpRequest({
+            method: 'PATCH',
+            url,
+            headers: {
+                'Authorization': 'Bearer ' + accessToken
+            },
+            data: body
+        });
+
+        return await context.sendJson(data, 'out');
     }
 };

--- a/src/appmixer/microsoft/sharepoint/MoveFileOrFolder/component.json
+++ b/src/appmixer/microsoft/sharepoint/MoveFileOrFolder/component.json
@@ -41,7 +41,7 @@
                         "index": 3,
                         "label": "Folder ID or File ID",
                         "group": "item",
-                        "tooltip": "ID of the File or Folder to be moved."
+                        "tooltip": "ID of the File or Folder to be moved. Caution: Moving Folder or File between drives will result in an error."
                     },
                     "itemPath": {
                         "type": "text",

--- a/src/appmixer/microsoft/sharepoint/MoveFileOrFolder/component.json
+++ b/src/appmixer/microsoft/sharepoint/MoveFileOrFolder/component.json
@@ -39,9 +39,9 @@
                     "itemId": {
                         "type": "text",
                         "index": 3,
-                        "label": "Item ID",
+                        "label": "Folder ID or File ID",
                         "group": "item",
-                        "tooltip": "ID assigned to a file or folder in SharePoint."
+                        "tooltip": "ID of the File or Folder to be moved."
                     },
                     "itemPath": {
                         "type": "text",
@@ -55,7 +55,7 @@
                         "label": " Site ID",
                         "group": "drive",
                         "index": 1,
-                        "tooltip": "Provide a site ID.",
+                        "tooltip": "Site ID where the file to be moved is located.",
                         "source": {
                             "url": "/component/appmixer/microsoft/sharepoint/ListSites?outPort=out",
                             "data": {
@@ -68,7 +68,7 @@
                         "index": 2,
                         "label": "Drive ID",
                         "group": "drive",
-                        "tooltip": "ID of the drive where the file is located.",
+                        "tooltip": "Drive ID where the file to be moved is located.",
                         "source": {
                             "url": "/component/appmixer/microsoft/sharepoint/ListDrives?outPort=out",
                             "data": {
@@ -89,7 +89,7 @@
                         "type": "text",
                         "index": 6,
                         "label": "New Name",
-                        "tooltip": "New name for the file"
+                        "tooltip": "If the moved item is a File, make sure to add extension of the file. Example: movedFile<strong>.txt</strong>"
                     }
                 },
                 "groups": {


### PR DESCRIPTION
There are reported issues in 4 components:
 - [x] **ListSites**
 - [x] **GetFile**
 - [x] **DownloadFile**
 - [x] **MoveFileOrFolder**

In multiple of them there was reported error "Circular reference" I found out that it is from the _onedrive-api_ library, so I had to change the components to using REST API, affected components:
**ListSites**
**GetFile**
**MoveFileOrFolder** (currenly returns an error when the move is successful)

**DownloadFile** and **GetFile** are reported to trigger multiple times for 1 file, I couldn't replicate this issue