### PR TITLE
Smartsheet CopyFolder/MoveFolder (patch) Updating select to multiselect in inspector

### DIFF
--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -1,11 +1,11 @@
 {
     "name": "appmixer.smartsheet",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "changelog": {
         "1.0.1": [
             "Smartsheet"
         ],
-        "2.0.0": [
+        "2.0.1": [
             "BugFix: Update of path to ListHomeFolders in multiple component's inspectors.",
             "Breaking: Added input fields of isAdmin and licensedSheetCreator in AddUser as they are required fields from the API.",
             "Cleanup of descriptions of all components.",

--- a/src/appmixer/smartsheet/core/CopyFolder/component.json
+++ b/src/appmixer/smartsheet/core/CopyFolder/component.json
@@ -18,18 +18,7 @@
                         "type": "number"
                     },
                     "include": {
-                        "type": "string",
-                        "enum": [
-                            "attachments",
-                            "cellLinks",
-                            "data",
-                            "discussions",
-                            "filters",
-                            "forms",
-                            "ruleRecipients",
-                            "rules",
-                            "shares"
-                        ]
+                        "type": "array"
                     },
                     "exclude": {
                         "type": "string",
@@ -38,13 +27,7 @@
                         ]
                     },
                     "skipRemap": {
-                        "type": "string",
-                        "enum": [
-                            "cellLinks",
-                            "reports",
-                            "sheetHyperlinks",
-                            "sights"
-                        ]
+                        "type": "array"
                     },
                     "destinationFolderId": {
                         "type": "number"
@@ -81,7 +64,7 @@
                     },
                     
                     "include": {
-                        "type": "select",
+                        "type": "multiselect",
                         "index": 2,
                         "label": "Include",
                         "tooltip": "<p>A comma-separated list of elements to copy:</p>\n<ul>\n<li><strong>attachments</strong></li>\n<li><strong>cellLinks</strong> - includes cross-sheet references</li>\n<li><strong>data</strong> - includes formatting</li>\n<li><strong>discussions</strong> - includes comments</li>\n<li><strong>filters</strong></li>\n<li><strong>forms</strong></li>\n<li><strong>ruleRecipients</strong> -- includes notification recipients, must also include\nrules when using this attribute</li>\n<li><strong>rules</strong> -- includes notifications and workflow rules</li>\n<li><strong>shares</strong> |\nNOTE: Cell history is not copied, regardless of which include parameter values are specified.</li>\n</ul>",
@@ -137,7 +120,7 @@
                         ]
                     },
                     "skipRemap": {
-                        "type": "select",
+                        "type": "multiselect",
                         "index": 4,
                         "label": "Skip Remap",
                         "tooltip": "<p>A comma-separated list of references to NOT re-map for the newly created folder.</p>",

--- a/src/appmixer/smartsheet/core/CopySheet/component.json
+++ b/src/appmixer/smartsheet/core/CopySheet/component.json
@@ -20,18 +20,7 @@
                     
                     
                     "include": {
-                        "type": "string",
-                        "enum": [
-                            "attachments",
-                            "cellLinks",
-                            "data",
-                            "discussions",
-                            "filters",
-                            "forms",
-                            "ruleRecipients",
-                            "rules",
-                            "shares"
-                        ]
+                        "type": "array"
                     },
                     "exclude": {
                         "type": "string",
@@ -76,7 +65,7 @@
                     },
                     
                     "include": {
-                        "type": "select",
+                        "type": "multiselect",
                         "index": 2,
                         "label": "Include",
                         "tooltip": "<p>A comma-separated list of elements to copy:</p>\n<ul>\n<li><strong>attachments</strong></li>\n<li><strong>cellLinks</strong> - includes cross-sheet references</li>\n<li><strong>data</strong> - includes formatting</li>\n<li><strong>discussions</strong> - includes comments</li>\n<li><strong>filters</strong></li>\n<li><strong>forms</strong></li>\n<li><strong>ruleRecipients</strong> -- includes notification recipients, must also include\nrules when using this attribute</li>\n<li><strong>rules</strong> -- includes notifications and workflow rules</li>\n<li><strong>shares</strong> |\nNOTE: Cell history is not copied, regardless of which include parameter values are specified.</li>\n</ul>",

--- a/src/appmixer/smartsheet/core/MoveRows/component.json
+++ b/src/appmixer/smartsheet/core/MoveRows/component.json
@@ -20,11 +20,7 @@
                     
                     
                     "include": {
-                        "type": "string",
-                        "enum": [
-                            "attachments",
-                            "discussions"
-                        ]
+                        "type": "array"
                     },
                     "ignoreRowsNotFound": {
                         "type": "boolean",
@@ -61,7 +57,7 @@
                     },
                     
                     "include": {
-                        "type": "select",
+                        "type": "multiselect",
                         "index": 2,
                         "label": "Include",
                         "tooltip": "<p>A comma-separate list of row elements to move in addition to the cell data.</p>",

--- a/src/appmixer/smartsheet/core/UpdateFolder/UpdateFolder.js
+++ b/src/appmixer/smartsheet/core/UpdateFolder/UpdateFolder.js
@@ -20,12 +20,12 @@ module.exports = {
 
         const headers = {};
 
-        const inputMapping = {
-
+        // Define the request body with folderName
+        const requestBody = {
+            'name': input['folderName'] // Include the folderName provided by the user
         };
-        let requestBody = {};
-        lib.setProperties(requestBody, inputMapping);
 
+        // Set authorization header
         headers['Authorization'] = 'Bearer ' + context.auth.accessToken;
 
         const req = {
@@ -37,6 +37,7 @@ module.exports = {
 
         try {
             const response = await context.httpRequest(req);
+
             const log = {
                 step: 'http-request-success',
                 request: {
@@ -74,5 +75,4 @@ module.exports = {
             throw err;
         }
     }
-
 };

--- a/src/appmixer/smartsheet/core/UpdateFolder/component.json
+++ b/src/appmixer/smartsheet/core/UpdateFolder/component.json
@@ -4,19 +4,21 @@
     "author": "Appmixer <info@appmixer.com>",
     "description": "Updates a folder.",
     "private": false,
-   
     "inPorts": [
         {
             "name": "in",
             "schema": {
                 "type": "object",
                 "required": [
-                    "folderId"
+                    "folderId",
+                    "folderName"
                 ],
                 "properties": {
-                    
                     "folderId": {
                         "type": "number"
+                    },
+                    "folderName": {
+                        "type": "string"
                     }
                 }
             },
@@ -25,8 +27,20 @@
                     "folderId": {
                         "type": "number",
                         "index": 0,
-                        "label": "Folder Id",
-                        "tooltip": "<p>Folder Id where you can create sheets, sights, reports, templates, and other folders.</p>"
+                        "label": "Folder ID",
+                        "tooltip": "<p>Folder where you can create sheets, sights, reports, templates, and other folders.</p>",
+                        "source": {
+                            "url": "/component/appmixer/smartsheet/core/ListHomeFolders?outPort=out",
+                            "data": {
+                                "transform": "./ListHomeFolders#foldersToSelectArray"
+                            }
+                        }
+                    },
+                    "folderName": {
+                        "type": "text",
+                        "index": 1,
+                        "label": "New Folder Name",
+                        "tooltip": "<p>Provide the new name for the folder you want to update.</p>"
                     }
                 }
             }
@@ -96,7 +110,6 @@
             ]
         }
     ],
-   
     "auth": {
         "service": "appmixer:smartsheet"
     },


### PR DESCRIPTION
In input fields like "include" the input is being taken as "select" but it should be multiselect. It is fixed https://github.com/clientIO/appmixer-components/issues/1938#issuecomment-2519401350