### PR TITLE
Xero (patch) fix currency enums for invoice components

### DIFF
--- a/src/appmixer/xero/accounting/CreateInvoice/component.json
+++ b/src/appmixer/xero/accounting/CreateInvoice/component.json
@@ -179,6 +179,7 @@
                         "label": "Currency Code",
                         "tooltip": "3 letter alpha code for the currency – see <a target=\"_blank\"href=\"https://developer.xero.com/documentation/api/accounting/currencies\">Currency Codes</a>",
                         "options": [
+                            { "clearItem": true, "content": "None" },
                             { "content": "AED", "value": "AED" },
                             { "content": "AFN", "value": "AFN" },
                             { "content": "ALL", "value": "ALL" },
@@ -346,8 +347,7 @@
                             { "content": "ZAR", "value": "ZAR" },
                             { "content": "ZMW", "value": "ZMW" },
                             { "content": "ZMK", "value": "ZMK" },
-                            { "content": "ZWD", "value": "ZWD" },
-                            { "content": "", "value": "" }
+                            { "content": "ZWD", "value": "ZWD" }
                         ]
                     },
                     "CurrencyRate": {

--- a/src/appmixer/xero/accounting/UpdateInvoice/component.json
+++ b/src/appmixer/xero/accounting/UpdateInvoice/component.json
@@ -185,6 +185,7 @@
                         "label": "Currency Code",
                         "tooltip": "3 letter alpha code for the currency – see <a target=\"_blank\"href=\"https://developer.xero.com/documentation/api/accounting/currencies\">Currency Codes</a>",
                         "options": [
+                            { "clearItem": true, "content": "None" },
                             { "content": "AED", "value": "AED" },
                             { "content": "AFN", "value": "AFN" },
                             { "content": "ALL", "value": "ALL" },
@@ -352,8 +353,7 @@
                             { "content": "ZAR", "value": "ZAR" },
                             { "content": "ZMW", "value": "ZMW" },
                             { "content": "ZMK", "value": "ZMK" },
-                            { "content": "ZWD", "value": "ZWD" },
-                            { "content": "", "value": "" }
+                            { "content": "ZWD", "value": "ZWD" }
                         ]
                     },
                     "CurrencyRate": {

--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -1,9 +1,10 @@
 {
     "name": "appmixer.xero",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.0.3": ["Fixed type of ExpectedPaymentDate and PlannedPaymentDate fields in inspector to be date instead of string for CreateInvoice and UpdateInvoice components."],
-        "1.1.1": ["Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact."]
+        "1.1.1": ["Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact."],
+        "1.1.2": ["Fixed currency enumerations in CreateInvoice and UpdateInvoice components."]
     }
 }


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/2019#issuecomment-2513522119 Issue 2

## Fix
- replaced the empty option with proper `clearItem`

### Before
![Image](https://github.com/user-attachments/assets/2d828afc-591e-4f85-8683-98a708c492c2)

### After
The start of the enumeration
<img width="389" alt="image" src="https://github.com/user-attachments/assets/d9ef7e79-3012-411c-9d93-6ac534e324a5">

The end of the enumeration
<img width="410" alt="image" src="https://github.com/user-attachments/assets/1d5beb06-8f5c-4b65-883a-b21a88c2cc14">
