### PR TITLE
MsSql (patch) Fix for Non SELECT Queries

### DIFF
--- a/src/appmixer/mssql/bundle.json
+++ b/src/appmixer/mssql/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.mssql",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
         ],
         "1.0.2": [
             "Added a new port `info` for `Query` component."
+        ],
+        "1.0.3":[
+            "Added support for non SELECT Queries in `Query` component."
         ]
     }
 }

--- a/src/appmixer/mssql/bundle.json
+++ b/src/appmixer/mssql/bundle.json
@@ -9,7 +9,7 @@
             "Added a new port `info` for `Query` component."
         ],
         "1.0.3":[
-            "Added support for non SELECT Queries in `Query` component."
+            "Bug Fix: Support for non SELECT Queries in `Query` component."
         ]
     }
 }

--- a/src/appmixer/mssql/db/Query/component.json
+++ b/src/appmixer/mssql/db/Query/component.json
@@ -69,12 +69,12 @@
             "options": [
                 {
                     "label": "Message",
-                    "value": "Message"
+                    "value": "message"
 
                 },
                 {
                     "label": "Rows Affected",
-                    "value": "RowsAffected"
+                    "value": "rowsAffected"
                 }
             ]
         }


### PR DESCRIPTION
The component encountered an error (`TypeError: queryResponse.recordset is not iterable`) when executing non-`SELECT` queries like `INSERT`, `UPDATE`, or `DELETE`. This happened because such queries do not return a `recordset`, and the code incorrectly assumed its presence, leading to runtime failures. https://github.com/clientIO/appmixer-components/issues/2020

## What Changes Were Made
1. **Conditional Handling for `recordset`:**
   - Added a check to handle scenarios where the `recordset` is absent (for non-`SELECT` queries).
   - Non-`SELECT` queries now rely on `rowsAffected` to report the results.
2. **Improved Output Logic:**
   - Ensured that `rowsAffected` is sent as output for non-`SELECT` queries.
   - Preserved the handling of `recordset` for `SELECT` queries.

## What These Changes Fix
- Prevents errors when running non-`SELECT` queries.