### PR TITLE
Xero (patch) triggers use AuthHub

### DIFF
--- a/src/appmixer/xero/accounting/NewContact/NewContact.js
+++ b/src/appmixer/xero/accounting/NewContact/NewContact.js
@@ -7,21 +7,17 @@ module.exports = {
     start: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'CONTACT.CREATE:' + tenantId;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = 'CONTACT.CREATE:' + tenantId;
+        await context.log({ step: 'Registering webhook', eventName });
+        return context.addListener(eventName);
     },
 
     stop: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'CONTACT.CREATE:' + tenantId;
-        await context.log({ step: 'Unregistering webhook', flowId, componentId, webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = 'CONTACT.CREATE:' + tenantId;
+        await context.log({ step: 'Unregistering webhook', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: async function(context) {

--- a/src/appmixer/xero/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/xero/accounting/NewInvoice/NewInvoice.js
@@ -7,21 +7,17 @@ module.exports = {
     start: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'INVOICE.CREATE:' + tenantId;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = 'INVOICE.CREATE:' + tenantId;
+        await context.log({ step: 'Registering webhook', eventName });
+        return context.addListener(eventName);
     },
 
     stop: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'INVOICE.CREATE:' + tenantId;
-        await context.log({ step: 'Unregistering webhook', flowId, componentId, webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = 'INVOICE.CREATE:' + tenantId;
+        await context.log({ step: 'Unregistering webhook', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: async function(context) {

--- a/src/appmixer/xero/accounting/UpdatedContact/UpdatedContact.js
+++ b/src/appmixer/xero/accounting/UpdatedContact/UpdatedContact.js
@@ -7,21 +7,17 @@ module.exports = {
     start: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'CONTACT.UPDATE:' + tenantId;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = 'CONTACT.UPDATE:' + tenantId;
+        await context.log({ step: 'Registering webhook', eventName });
+        return context.addListener(eventName);
     },
 
     stop: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'CONTACT.UPDATE:' + tenantId;
-        await context.log({ step: 'Unregistering webhook', flowId, componentId, webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = 'CONTACT.UPDATE:' + tenantId;
+        await context.log({ step: 'Unregistering webhook', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: async function(context) {

--- a/src/appmixer/xero/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/xero/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -7,21 +7,17 @@ module.exports = {
     start: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'INVOICE.UPDATE:' + tenantId;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = 'INVOICE.UPDATE:' + tenantId;
+        await context.log({ step: 'Registering webhook', eventName });
+        return context.addListener(eventName);
     },
 
     stop: async function(context) {
 
         const { tenantId } = context.properties;
-        const { componentId, flowId } = context;
-        const webhook = 'INVOICE.UPDATE:' + tenantId;
-        await context.log({ step: 'Unregistering webhook', flowId, componentId, webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = 'INVOICE.UPDATE:' + tenantId;
+        await context.log({ step: 'Unregistering webhook', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: async function(context) {

--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -1,10 +1,12 @@
 {
     "name": "appmixer.xero",
-    "version": "1.1.2",
+    "version": "1.1.3",
+    "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.0.3": ["Fixed type of ExpectedPaymentDate and PlannedPaymentDate fields in inspector to be date instead of string for CreateInvoice and UpdateInvoice components."],
         "1.1.1": ["Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact."],
-        "1.1.2": ["Fixed currency enumerations in CreateInvoice and UpdateInvoice components."]
+        "1.1.2": ["Fixed currency enumerations in CreateInvoice and UpdateInvoice components."],
+        "1.1.3": ["Fixed issue with NewInvoice and UpdatedInvoice components not working properly with the default configuration."]
     }
 }

--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -7,6 +7,6 @@
         "1.0.3": ["Fixed type of ExpectedPaymentDate and PlannedPaymentDate fields in inspector to be date instead of string for CreateInvoice and UpdateInvoice components."],
         "1.1.1": ["Added components: NewInvoice, UpdatedInvoice, NewContact, UpdatedContact."],
         "1.1.2": ["Fixed currency enumerations in CreateInvoice and UpdateInvoice components."],
-        "1.1.3": ["Fixed issue with NewInvoice and UpdatedInvoice components not working properly with the default configuration."]
+        "1.1.3": ["Fixed issue with all trigger components not working properly with the default configuration."]
     }
 }


### PR DESCRIPTION
Fix for Issue 3 in https://github.com/clientIO/appmixer-components/issues/2019#issuecomment-2513522119
- [x] triggers (un)register using `context.addListener` and `context.removeListener`
- this allows the triggers to work for all hosted tenants without any Xero app configuration
