### PR TITLE
Google.spreadsheets: update release notes

### DIFF
--- a/src/appmixer/google/spreadsheets/bundle.json
+++ b/src/appmixer/google/spreadsheets/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.spreadsheets",
-    "version": "3.1.1",
+    "version": "3.0.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -51,11 +51,9 @@
         "2.0.2": [
             "Updated the CreateRow action to append new row at the end of the spreadsheet, removing the need to fetch all range of rows."
         ],
-        "3.0.0": [
-            "(Breaking Change): The `drive.metadata.readonly` scope has been added wherever it was previously missing. Affected components: CountRows, CreateRow, DeleteRow, FindRow, GetRows, NewRow, UpdatedRow. \nMigration: you need to re-authenticate affected components mentioned above."
-        ],
-        "3.1.1": [
-            "Breaking Change: Updated the NewRow trigger to include a required input field, Index Column, used to monitor a specific column for detecting new rows in the spreadsheet."
+        "3.0.1": [
+            "(Breaking Change): The `drive.metadata.readonly` scope has been added wherever it was previously missing. Affected components: CountRows, CreateRow, DeleteRow, FindRow, GetRows, NewRow, UpdatedRow. \nMigration: you need to re-authenticate affected components mentioned above.",
+            "(Breaking Change): Updated the NewRow trigger to include a required input field, Index Column, used to monitor a specific column for detecting new rows in the spreadsheet."
         ]
     }
 }


### PR DESCRIPTION
follow-up for the https://github.com/clientIO/appmixer-connectors/pull/182 

change introduced in the https://github.com/clientIO/appmixer-connectors/pull/182 is breaking therefore the version should be 4. However, as the version 3.0.0 is not released yet, we can include the changes from the https://github.com/clientIO/appmixer-connectors/pull/182 into the version 3.0.1