### PR TITLE
Tasks (patch) - fix no config duplicates

### DIFF
--- a/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
+++ b/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
@@ -205,6 +205,11 @@ module.exports = {
 
     async receive(context) {
 
+        // Ensure proper configuration first.
+        if (!config.peopleTasksDashboard) {
+            throw new context.http.HttpError.badRequest('People Task dashboard URL is not configured. Please see the documentation for Tasks connector.');
+        }
+
         if (context.messages.webhook) {
             const webhookData = context.messages.webhook.content;
             const { data } = webhookData;

--- a/src/appmixer/utils/tasks/bundle.json
+++ b/src/appmixer/utils/tasks/bundle.json
@@ -1,12 +1,13 @@
 {
     "name": "appmixer.utils.tasks",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "changelog": {
         "1.0.2": [
             "Using new context.job.lock function."
         ],
-        "1.0.3": [
-            "Update RequestApprovalEmail component to use Appmixer Cloud with the default configuration."
+        "1.0.4": [
+            "Update RequestApprovalEmail component to use Appmixer Cloud with the default configuration.",
+            "Fix an issue with the RequestApprovalEmail component creating duplicate tasks when no configuration is provided."
         ]
     },
     "engine": ">=5.1"


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/1999#issuecomment-2566093171 - issue 2

The duplicate tasks were created because Appmixer retried the failed component runs of `RequestApprovalEmail`. Even thou it failed, the POST actions to create tasks were run before it, thus creating the tasks.

On properly configured environment this is not a problem. This can happen on a self-hosted instance without `PEOPLE_TASKS_DASHBOARD_URL` ENV.