### PR TITLE
ActiveCampaign (patch) CreateDeal, CreateTask, CreateContact

### DIFF
--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -10,6 +10,9 @@
             "CreateTask: Contact/Deal is now required.",
             "UpdateDeal: should no longer require value (Deal amount) to run.",
             "Small fixes to UpdateContact."
+        ],
+        "1.0.4": [
+            "CreateDeal, CreateContact, CreateTask: output now returns all possible properties."
         ]
     }
 }

--- a/src/appmixer/activecampaign/contacts/CreateContact/CreateContact.js
+++ b/src/appmixer/activecampaign/contacts/CreateContact/CreateContact.js
@@ -1,5 +1,4 @@
 'use strict';
-const moment = require('moment');
 const { trimUndefined } = require('../../helpers');
 const ActiveCampaign = require('../../ActiveCampaign');
 
@@ -46,14 +45,15 @@ module.exports = {
             return acc;
         }, {});
 
-        return context.sendJson({
-            id: contact.id,
-            email: contact.email,
-            firstName: contact.firstName,
-            lastName: contact.lastName,
-            phone: contact.phone,
-            createdDate: moment(contact.cdate).toISOString(),
+        const contactResponseModified = {
+            ...contact,
+            createdDate: new Date(contact.cdate).toISOString(),
             ...customFieldsPayload
-        }, 'contact');
+        };
+
+        delete contactResponseModified.cdate;
+        delete contactResponseModified.links;
+
+        return context.sendJson(contactResponseModified, 'contact');
     }
 };

--- a/src/appmixer/activecampaign/deals/CreateDeal/CreateDeal.js
+++ b/src/appmixer/activecampaign/deals/CreateDeal/CreateDeal.js
@@ -1,5 +1,4 @@
 'use strict';
-const moment = require('moment');
 const ActiveCampaign = require('../../ActiveCampaign');
 const { trimUndefined } = require('../../helpers');
 
@@ -47,6 +46,7 @@ module.exports = {
         }
 
         const { data } = await ac.call('post', 'deals', payload);
+
         const { deal } = data;
 
         const customFieldsPayload = fieldValues.reduce((acc, field) => {
@@ -54,18 +54,16 @@ module.exports = {
             return acc;
         }, {});
 
-        return context.sendJson({
-            id: deal.id,
-            contactId: deal.contact,
-            title: deal.title,
-            description: deal.description,
-            currency: deal.currency,
+        const dealResponseModified = {
+            ...deal,
             value: deal.value / 100,
-            owner: deal.owner,
-            stage: deal.stage,
-            status: deal.status,
-            createdDate: moment(data.deal.cdate).toISOString(),
+            createdDate: new Date(deal.cdate).toISOString(),
             ...customFieldsPayload
-        }, 'deal');
+        };
+
+        delete dealResponseModified.cdate;
+        delete dealResponseModified.links;
+
+        return context.sendJson(dealResponseModified, 'deal');
     }
 };

--- a/src/appmixer/activecampaign/tasks/CreateTask/CreateTask.js
+++ b/src/appmixer/activecampaign/tasks/CreateTask/CreateTask.js
@@ -43,17 +43,17 @@ module.exports = {
 
         const { dealTask } = data;
 
-        return context.sendJson({
-            id: dealTask.id,
-            relationship: dealTask.owner.type,
+        const taskResponseModified = {
+            ...dealTask,
             contactId: dealTask.owner.type === 'contact' ? dealTask.relid : undefined,
             dealId: dealTask.owner.type === 'deal' ? dealTask.relid : undefined,
-            title: dealTask.title,
-            note: dealTask.note,
-            taskType: dealTask.dealTasktype,
-            assignee: dealTask.assignee,
-            due: moment(dealTask.duedate).toISOString(),
-            edate: moment(dealTask.edate).toISOString()
-        }, 'newTask');
+            due: new Date(dealTask.duedate).toISOString(),
+            edate: new Date(dealTask.edate).toISOString()
+        };
+
+        delete taskResponseModified.duedate;
+        delete taskResponseModified.links;
+
+        return context.sendJson(taskResponseModified, 'newTask');
     }
 };


### PR DESCRIPTION
Ram was receiving an error "Cannot read properties of undefined (reading 'id')" that I couldn't replicate even with flow set up the same as his and using the same account. This changes make it so the output returns everything it has instead of us picking just some properties. If he will still receive similar error, hopefully this helps us get close to why.