### PR TITLE
Slack (major) add webhook payload verification

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -29,6 +29,9 @@
         ],
         "3.2.0": [
             "NewChannelMessageRT: added more output variables such as: channel, channel_type, team, event_ts, blocks, bot_profile."
+        ],
+        "4.0.0": [
+            "(breaking change) Added payload authentication for triggers. Will require setting `signingSecret` in the connector configuration."
         ]
     }
 }

--- a/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
+++ b/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
@@ -4,8 +4,14 @@ module.exports = {
 
     async start(context) {
 
+        const componentName = context.flowDescriptor[context.componentId].label || 'New Channel Message';
+
         if (!context.config?.authToken) {
-            throw new Error('Missing Slack configuration. Please configure the `authToken` with a valid Slack App token.');
+            throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "authToken" with a valid Slack App token.`);
+        }
+
+        if (!context.config.signingSecret) {
+            throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "signingSecret" with a valid Slack App signing secret.`);
         }
 
         return context.addListener(context.properties.channelId, { accessToken: context.auth.accessToken } );

--- a/src/appmixer/slack/list/NewUserWebhook/NewUserWebhook.js
+++ b/src/appmixer/slack/list/NewUserWebhook/NewUserWebhook.js
@@ -9,6 +9,8 @@ module.exports = {
         if (!context.config.signingSecret) {
             throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "signingSecret" with a valid Slack App signing secret.`);
         }
+
+        return context.addListener('slack_team_join', { accessToken: context.auth.accessToken });
     },
 
     async stop(context) {

--- a/src/appmixer/slack/list/NewUserWebhook/NewUserWebhook.js
+++ b/src/appmixer/slack/list/NewUserWebhook/NewUserWebhook.js
@@ -4,7 +4,11 @@ module.exports = {
 
     async start(context) {
 
-        return context.addListener('slack_team_join', { accessToken: context.auth.accessToken });
+        const componentName = context.flowDescriptor[context.componentId].label || 'New User';
+
+        if (!context.config.signingSecret) {
+            throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "signingSecret" with a valid Slack App signing secret.`);
+        }
     },
 
     async stop(context) {


### PR DESCRIPTION
Closes https://github.com/clientIO/appmixer-components/issues/1979

- [x] add payload verification
- [x] add check that `signingSecret` is now present in configuration as it is required - this is a breaking change

Slack docs: https://api.slack.com/authentication/verifying-requests-from-slack#validating-a-request