### PR TITLE
Smartsheet Movefolder Copyfolder (patch) Bug Fixes

### DIFF
--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.smartsheet",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "changelog": {
         "1.0.1": [
             "Smartsheet"
@@ -12,8 +12,9 @@
             "Breaking: Updated input field of GetFolders to have multiselect instead of single select.",
             "BugFix: Fixed GetSheet." 
         ],
-        "2.0.2": [
-            "Breaking change: Updated the input ports of AddRowsToSheet to fix the display of correct columns to input value in the inspector"
+        "2.0.3": [
+            "Breaking change: Updated the input ports of AddRowsToSheet to fix the display of correct columns to input value in the inspector",
+            "Breaking change: Bug fix in input fields of Copyfolder and MoveFolder"
         ]
     }
 }

--- a/src/appmixer/smartsheet/core/CopyFolder/component.json
+++ b/src/appmixer/smartsheet/core/CopyFolder/component.json
@@ -11,7 +11,7 @@
             "schema": {
                 "type": "object",
                 "required": [
-                    "folderId"
+                    "folderId", "destinationType"
                 ],
                 "properties": {
                     "folderId": {

--- a/src/appmixer/smartsheet/core/MoveFolder/component.json
+++ b/src/appmixer/smartsheet/core/MoveFolder/component.json
@@ -11,11 +11,20 @@
             "schema": {
                 "type": "object",
                 "required": [
-                    "folderId"
+                    "folderId", "destinationType"
                 ],
                 "properties": {
                     
                     "folderId": {
+                        "type": "number"
+                    },
+                    "destinationType": {
+                        "type": "string"
+                    },
+                    "destinationFolderId": {
+                        "type": "number"
+                    },
+                    "destinationWorkspaceId": {
                         "type": "number"
                     }
                 }


### PR DESCRIPTION
MoveFolder was showing transformation related error as properties were not defined in the component.json
CopyFolder did not have DestinationType marked required although it is marked required by the smartSheet API