### PR TITLE
Microsoft.Sharepoint (patch) NewFile triggers for files only

### DIFF
--- a/src/appmixer/microsoft/sharepoint/NewFile/NewFile.js
+++ b/src/appmixer/microsoft/sharepoint/NewFile/NewFile.js
@@ -98,9 +98,11 @@ module.exports = {
                         const promises = [];
 
                         latest.value.forEach((file) => {
+                            const isFile = Object.keys(file).includes('file');
                             const createdDateTime = file.createdDateTime;
+
                             if (
-                                createdDateTime &&
+                                isFile && createdDateTime &&
                                 moment(lastUpdated).isSameOrBefore(createdDateTime)
                             ) {
                                 promises.push(context.sendJson(file, 'file'));

--- a/src/appmixer/microsoft/sharepoint/bundle.json
+++ b/src/appmixer/microsoft/sharepoint/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.sharepoint",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "changelog": {
         "1.0.0": ["Initial version"],
         "1.0.1": ["Updated component name and file picker."],
@@ -8,6 +8,7 @@
         "1.0.3": ["Updated the tooltips."],
         "1.1.0": ["ListFiles: The recursive flag has been added. When set to true, the component will list all files, including those within sub-folders."],
         "1.1.1": ["NewFile: fix for tracking changes on a custom drive."],
-        "1.1.2": ["Fix for possible connection with empty label."]
+        "1.1.2": ["Fix for possible connection with empty label."],
+        "1.1.3": ["NewFile: triggers only for new files in the watched Drive, not folders."]
     }
 }


### PR DESCRIPTION
Comparing the object for folder and file I have noticed, that when it is a file, it has "file" property, when a folder, it has "folder" property. The component now returns only objects with "file" property.