### PR TITLE
Microsoft.Sharepoint.NewFile: update toolitp

### DIFF
--- a/src/appmixer/microsoft/sharepoint/NewFile/component.json
+++ b/src/appmixer/microsoft/sharepoint/NewFile/component.json
@@ -1,7 +1,7 @@
 {
     "name": "appmixer.microsoft.sharepoint.NewFile",
     "author": "Harsha Surisetty <harsha@client.io>",
-    "description": "This trigger fires every time there's a new file uploaded.",
+    "description": "This trigger fires every time there's a new file uploaded to the selected Drive. Files uploaded to sub-folders of the Drive won't trigger.",
     "version": "1.0.0",
     "private": false,
     "webhook": true,


### PR DESCRIPTION
I have checked documentation of the API: https://learn.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=javascript and haven't found a way or mention of how to make the trigger trigger for sub-folders. Updated the tooltip to make it clear.