### PR TITLE
Hubspot (patch) handle duplicate events

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -47,7 +47,7 @@
         "3.0.1": [
             "(breaking change) Improve webhook handling by better event distribution. Affected components: NewContact, UpdatedContact, NewDeal, UpdatedDeal."
         ],
-        "4.0.0": [
+        "4.0.1": [
             "(breaking change) Improve webhook handling by better event distribution using events/listeners (applies to Appmixer version 6+). Affected components: NewContact, UpdatedContact, NewDeal, UpdatedDeal."
         ]
     }

--- a/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
+++ b/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
@@ -19,10 +19,36 @@ class NewDeal extends BaseSubscriptionComponent {
 
         this.configureHubspot(context);
 
-        const eventsByObjectId = context.messages.webhook.content.data;;
+        // Get all objectIds that will be used to fetch the contacts in bulk
+        let ids = [];
+        // Locking to avoid duplicates. HubSpot payloads can come within milliseconds of each other.
+        let lock;
 
-        // Get all objectIds
-        const ids = Object.keys(eventsByObjectId);
+        try {
+            lock = await context.lock(context.componentId, {
+                ttl: 1000 * 10,
+                retryDelay: 500,
+                maxRetryCount: 3
+            });
+
+            for (const [dealId] of Object.entries(eventsByObjectId)) {
+                const cacheKey = 'hubspot-deal-created-' + dealId;
+                const cached = await context.staticCache.get(cacheKey);
+                if (cached) {
+                    continue;
+                }
+                // Cache the event for 5s to avoid duplicates
+                await context.staticCache.set(cacheKey, dealId, context.config?.eventCacheTTL || 5000);
+                ids.push(dealId);
+            }
+        } finally {
+            await lock?.unlock();
+        }
+
+        if (!ids.length) {
+            // No new contacts to fetch
+            return context.response();
+        }
 
         // Call the API to get the contacts in bulk
         const { data } = await this.hubspot.call('post', 'crm/v3/objects/deals/batch/read', {

--- a/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
+++ b/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
@@ -37,7 +37,7 @@ class UpdatedContact extends BaseSubscriptionComponent {
             });
 
             for (const [contactId, event] of Object.entries(eventsByObjectId)) {
-                const cacheKey = 'hubspot-deal-updated-' + contactId;
+                const cacheKey = 'hubspot-contact-updated-' + contactId;
                 // Only track changes in these properties. These are the ones present in the CreateContact inspector.
                 // Even if we limit the subscriptions for these properties only, we need this for flows that
                 // are already running and all the subscriptions.
@@ -46,6 +46,8 @@ class UpdatedContact extends BaseSubscriptionComponent {
                     if (cached && event.occurredAt <= cached) {
                         continue;
                     }
+                    // Cache the event for 5s to avoid duplicates
+                    await context.staticCache.set(cacheKey, event.occurredAt, context.config?.eventCacheTTL || 5000);
                     events[contactId] = { occurredAt: event.occurredAt };
                 }
             }

--- a/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
@@ -46,7 +46,6 @@ class UpdatedDeal extends BaseSubscriptionComponent {
                     }
                     // Cache the event for 5s to avoid duplicates
                     await context.staticCache.set(cacheKey, event.occurredAt, context.config?.eventCacheTTL || 5000);
-                    // Store the event to send it later
                     events[dealId] = { occurredAt: event.occurredAt };
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/1700#issuecomment-2573312483

The problem is that HubSpot can send the same event more than once

- [x] added caching of newly created deals and contacts
- [x] fixed an issue for updated contacts (deals were ok) that triggered multiple times for same object