### PR TITLE
Microsoft Dynamics (fix) remove unused code

### DIFF
--- a/src/appmixer/microsoft/dynamics/ListAccounts/ListAccounts.js
+++ b/src/appmixer/microsoft/dynamics/ListAccounts/ListAccounts.js
@@ -9,7 +9,6 @@ module.exports = {
 
     async receive(context) {
 
-        const generateOutputPortOptions = context.properties.generateOutputPortOptions;
         const {
             // Filter paramters
             name, telephone1, address1_city, emailaddress1, maxRecords,
@@ -21,10 +20,6 @@ module.exports = {
             // Appmixer specific
             outputType
         } = context.messages.in.content;
-
-        if (generateOutputPortOptions) {
-            return this.getOutputPortOptions(context, outputType);
-        }
 
         const url = (context.resource || context.auth.resource) + '/api/data/v9.2/accounts';
         // Query params

--- a/src/appmixer/microsoft/dynamics/ListContacts/ListContacts.js
+++ b/src/appmixer/microsoft/dynamics/ListContacts/ListContacts.js
@@ -9,7 +9,6 @@ module.exports = {
 
     async receive(context) {
 
-        const generateOutputPortOptions = context.properties.generateOutputPortOptions;
         const {
             // Filter paramters
             fullname, telephone1, address1_city, emailaddress1, maxRecords,
@@ -21,10 +20,6 @@ module.exports = {
             // Appmixer specific
             outputType
         } = context.messages.in.content;
-
-        if (generateOutputPortOptions) {
-            return this.getOutputPortOptions(context, outputType);
-        }
 
         const url = (context.resource || context.auth.resource) + '/api/data/v9.2/contacts';
         // Query params

--- a/src/appmixer/microsoft/dynamics/ListLeads/ListLeads.js
+++ b/src/appmixer/microsoft/dynamics/ListLeads/ListLeads.js
@@ -8,7 +8,6 @@ module.exports = {
 
     async receive(context) {
 
-        const generateOutputPortOptions = context.properties.generateOutputPortOptions;
         const {
             // Filter paramters
             firstname, lastname, fullname, subject, companyname, email, address, maxRecords,
@@ -20,10 +19,6 @@ module.exports = {
             // Appmixer specific
             outputType
         } = context.messages.in.content;
-
-        if (generateOutputPortOptions) {
-            return this.getOutputPortOptions(context, outputType);
-        }
 
         const url = (context.resource || context.auth.resource) + '/api/data/v9.2/leads';
         // Query params


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/1670

The removed code was not triggered because all three components call `DynamicEntity` to generate outputPortOptions. 

ListContacts/component.json (and other 2)
```json
        {
            "name": "out",
            "source": {
                "url": "/component/appmixer/microsoft/dynamics/DynamicEntity?outPort=out",
                "data": {
                    "messages": {
                        "in/logicalName": "contact",
                        "in/outputType": "inputs/in/outputType"
                    },
                    "properties": {
                        "generateOutputPortOptions": true
                    }
                }
            }
        },
```

There is no code that would trigger `return this.getOutputPortOptions(context, outputType);`, therefore no bundle bump. It is just refactoring and will get released with future updates.