### PR TITLE
Cloudflare lists: fix ttl

### DIFF
--- a/src/appmixer/cloudflare/bundle.json
+++ b/src/appmixer/cloudflare/bundle.json
@@ -1,5 +1,12 @@
 {
-  "name": "appmixer.cloudflare",
-  "version": "1.0.0",
-  "changelog": []
+    "name": "appmixer.cloudflare",
+    "version": "1.0.1",
+    "changelog": {
+        "1.0.0": [
+            "Initial version."
+        ],
+        "1.0.1": [
+            "AddIpToList: fix ttl input."
+        ]
+    }
 }

--- a/src/appmixer/cloudflare/lists/AddToIPList/component.json
+++ b/src/appmixer/cloudflare/lists/AddToIPList/component.json
@@ -68,7 +68,6 @@
                         "type": "number",
                         "label": "TTL",
                         "index": 3,
-                        "min": 60,
                         "tooltip": "Time to live in seconds. The rule will be automatically removed after this time."
                     },
                     "ips": {


### PR DESCRIPTION
- when `min` is define, it's not possible to input a value - it always immediately jumps back to `60`