### PR TITLE
Hubspot (patch) improve webhook handling with delayed listener triggering

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -47,7 +47,7 @@
         "3.0.1": [
             "(breaking change) Improve webhook handling by better event distribution. Affected components: NewContact, UpdatedContact, NewDeal, UpdatedDeal."
         ],
-        "4.0.1": [
+        "4.0.2": [
             "(breaking change) Improve webhook handling by better event distribution using events/listeners (applies to Appmixer version 6+). Affected components: NewContact, UpdatedContact, NewDeal, UpdatedDeal."
         ]
     }

--- a/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
+++ b/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
@@ -19,6 +19,8 @@ class NewDeal extends BaseSubscriptionComponent {
 
         this.configureHubspot(context);
 
+        const eventsByObjectId = context.messages.webhook.content.data;
+
         // Get all objectIds that will be used to fetch the contacts in bulk
         let ids = [];
         // Locking to avoid duplicates. HubSpot payloads can come within milliseconds of each other.


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/1700#issuecomment-2603835331

- don't trigger listeners immediately
- store all create events in MongoDB, each object has its own record
- wait 5 sec
- start processing all events
- skip `update` events if there is a `create` event for the same objectId and `occurredAt` timestamp
- clear the MongoDB records after another 5 sec