### PR TITLE
Slack (patch) add option to ignore bot messages to NewChannelMessageRT trigger

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -30,9 +30,10 @@
         "3.2.0": [
             "NewChannelMessageRT: added more output variables such as: channel, channel_type, team, event_ts, blocks, bot_profile."
         ],
-        "4.1.1": [
+        "4.1.2": [
             "(breaking change) Added payload authentication for triggers. Will require setting `signingSecret` in the connector configuration.",
-            "Added options to SendChannelMessage and SendPrivateChannelMessage to send messages as a bot user."
+            "Added options to SendChannelMessage and SendPrivateChannelMessage to send messages as a bot user.",
+            "Fixed and issue when NewChannelMessageRT trigger did not register messages containing some special UTF characters."
         ]
     }
 }

--- a/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
+++ b/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
@@ -25,6 +25,10 @@ module.exports = {
     async receive(context) {
 
         if (context.messages.webhook) {
+            if (context.properties.ignoreBotMessages && context.messages.webhook.content.data.subtype === 'bot_message') {
+                // Ignore bot messages.
+                return;
+            }
             await context.sendJson(context.messages.webhook.content.data, 'message');
         }
     }

--- a/src/appmixer/slack/list/NewChannelMessageRT/component.json
+++ b/src/appmixer/slack/list/NewChannelMessageRT/component.json
@@ -99,7 +99,8 @@
     "properties": {
         "schema": {
             "properties": {
-                "channelId": { "type": "string" }
+                "channelId": { "type": "string" },
+                "ignoreBotMessages": { "type": "boolean" }
             },
             "required": [
                 "channelId"
@@ -118,6 +119,12 @@
                         }
                     },
                     "tooltip": "Select a channel."
+                },
+                "ignoreBotMessages": {
+                    "type": "toggle",
+                    "label": "Ignore bot messages. If enabled, the trigger will not fire when a bot posts a message.",
+                    "defaultValue": true,
+                    "index": 2
                 }
             }
         }

--- a/src/appmixer/slack/routes.js
+++ b/src/appmixer/slack/routes.js
@@ -48,8 +48,11 @@ module.exports = async context => {
                     context.log('error', 'slack-plugin-route-webhook-missing-signingSecret');
                     return h.response(undefined).code(401);
                 }
-                // Use the raw request body from `req.payload`, without headers, before it has been deserialized from JSON or other forms.
-                const payloadString = JSON.stringify(req.payload);
+                // Use the raw request body from `req.payload`, without headers, before it has been deserialized from JSON or other forms. See https://stackoverflow.com/questions/70653161/unable-to-correctly-verify-slack-requests.
+                const payloadString = JSON.stringify(req.payload)
+                    .replace(/\//g, '\\/')
+                    .replace(/[\u007f-\uffff]/g, (c) => '\\u' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4));
+
                 const timestamp = req.headers['x-slack-request-timestamp'];
                 const baseString = `v0:${timestamp}:${payloadString}`;
                 const mySignature = 'v0=' + createHmac('sha256', signingSecret).update(baseString).digest('hex');


### PR DESCRIPTION
Closes https://github.com/clientIO/appmixer-components/issues/2119

Also adds a fix for a bug when message with special UTF characters (eg `ščř`) was not sent.

![image](https://github.com/user-attachments/assets/6017524c-bb98-4b18-86a8-79aac2234c36)
