### PR TITLE
Microsoft.Excel.NewRow (Patch) Bugs Fixed

### DIFF
--- a/src/appmixer/microsoft/excel/ListColumns/component.json
+++ b/src/appmixer/microsoft/excel/ListColumns/component.json
@@ -31,7 +31,13 @@
                 "sheetId": {
                     "type": "select",
                     "index": 1,
-                    "label": "Spreadsheet"
+                    "label": "Spreadsheet",
+                    "source": {
+                        "url": "/component/appmixer/microsoft/excel/ListSheets?outPort=out",
+                        "data": {
+                            "transform": "./ListSheets#sheetsToSelectArray"
+                        }
+                    }
                 },
                 "worksheetId": {
                     "type": "select",
@@ -43,7 +49,7 @@
                             "properties": {
                                 "sheetId": "properties/sheetId"
                             },
-                            "transform": "./ListSheets#sheetsToSelectArray"
+                            "transform": "./ListWorksheets#worksheetsToSelectArray"
                         }
                     }
                 }

--- a/src/appmixer/microsoft/excel/ListSheets/ListSheets.js
+++ b/src/appmixer/microsoft/excel/ListSheets/ListSheets.js
@@ -12,7 +12,7 @@ module.exports = {
         const { accessToken } = context.auth;
         const workbooks = await request({
             method: 'GET',
-            url: 'https://graph.microsoft.com/v1.0/me/drive/root/search(q=\'*.xlsx\')',
+            url: 'https://graph.microsoft.com/v1.0/me/drive/root/search(q=\'xlsx\')',
             auth: { bearer: accessToken },
             headers: { 'Accept': 'application/json' },
             json: true

--- a/src/appmixer/microsoft/excel/bundle.json
+++ b/src/appmixer/microsoft/excel/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.microsoft.excel",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.1": [
             "Initial release"
         ],
         "1.0.2": [
             "Fix for possible connection with empty label."
+        ],
+        "1.0.3": [
+            "Bug fix of listing sheets for NewRow Trigger."
         ]
     }
 }


### PR DESCRIPTION
ListSheets was showing an error `400 - {"error":{"code":"invalidRequest","message":"A potentially dangerous Request.Path value was detected from the client (*).","innerError":{"code":"badArgument","date":"2025-02-11T07:47:16","request-id":"be848855-85fb-495a-b815-0511a4833590","client-request-id":"be848855-85fb-495a-b815-0511a4833590"}}}` 

Which was because of an asterisk * used in the query endpoint.

Then, in the ListColumns (used for output tags of NewRow) there was no source attached to the Sheets input field hence error in this component as well