### PR TITLE
Snowflake (patch) prevent engine crash

### DIFF
--- a/src/appmixer/snowflake/bundle.json
+++ b/src/appmixer/snowflake/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.snowflake",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -46,6 +46,9 @@
         ],
         "1.1.12": [
             "Update snowflake-sdk dependency to v1.11.0."
+        ],
+        "1.1.13": [
+            "Fixed an issue when invalid query could cause the engine to crash."
         ]
     }
 }

--- a/src/appmixer/snowflake/package.json
+++ b/src/appmixer/snowflake/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "dependencies": {
     "csv-stringify": "6.2.3",
-    "snowflake-sdk": "1.11.0"
+    "snowflake-sdk": "2.0.2"
   }
 }


### PR DESCRIPTION
Closes https://github.com/clientIO/appmixer-components/issues/2032

- [x] `getRows()` - call asynchronously, get results. If it fails, throw custom error instead of original one from Snowflake that will crash the node process
- [x] remove unused function `runQuery`
- [x] updated `snowflake-sdk` to enable executing [queries asynchronously](https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute#execute-queries-asynchronously)

This is due to combination of an awesome [Winston feature of killing the node process](https://github.com/winstonjs/winston?tab=readme-ov-file#to-exit-or-not-to-exit) by default and Snowflake SDK being not able to change that default configuration.

The major `snowflake-sdk` update should not have any effect for our connector

<img width="898" alt="image" src="https://github.com/user-attachments/assets/1b3599b4-8e26-4650-b2bf-5fa05d0d7a3d" />
