### PR TITLE
OpenAI (patch) deprecate CreateEdit

### DIFF
--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.openai",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "changelog": {
         "1.1.0": [
             "OpenAI API"
@@ -11,6 +11,9 @@
         "1.2.3": [
             "CreateCompletion: fixed 'invalid obj param' error that sometimes occured + added dynamic list for models.",
             "RetrieveModel: added dynamic list for models."
+        ],
+        "1.2.4": [
+            "Marked `CreateEdit` as deprecated. It can still be used, but it uses the same functionality as `CreateChatCompletion`. Use `CreateChatCompletion` instead."
         ]
     }
 }

--- a/src/appmixer/openai/core/createEdit/component.json
+++ b/src/appmixer/openai/core/createEdit/component.json
@@ -1,6 +1,7 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "appmixer.openai.core.createEdit",
+    "label": "CreateEdit (Deprecated)",
     "author": "Appmixer <info@appmixer.com>",
     "description": "<label><p>Creates a new edit for the provided input, instruction, and parameters.</p></label>",
     "private": false,
@@ -22,8 +23,8 @@
                         "path": "instruction"
                     },
                     "model": {
-                        "description": "ID of the model to use. You can use the `text-davinci-edit-001` or `code-davinci-edit-001` model with this endpoint.",
-                        "example": "text-davinci-edit-001",
+                        "description": "ID of the model to use. You can use the `gpt-4o` model with this endpoint.",
+                        "example": "gpt-4o",
                         "x-oaiTypeLabel": "string",
                         "type": "string",
                         "path": "model"


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2159

`CreateEdit` is deprecated alongside the recommended models for it. See https://platform.openai.com/docs/deprecations#edit-models-endpoint

- [x] mark it as legacy, recommend different models for it
- [x] make it use chat completions inside
- [x] keep the old inputs and outputs

<img width="755" alt="image" src="https://github.com/user-attachments/assets/3482f4dd-7d32-4a88-bc43-48e6fd0c097a" />
