### PR TITLE
Pipedrive (patch) UpdatePerson - removed custom fields

### DIFF
--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -15,6 +15,9 @@
             "FindPerson, FindDeal, FindProduct: no longer throws API error and are updated to follow our Search component standards.",
             "FindUser: out interface updated.",
             "FindProduct: validation error for 'Term to search for' updated to match the tooltip."
+        ],
+        "1.2.1": [
+            "UpdatePerson: removed custom fields."
         ]
     }
 }

--- a/src/appmixer/pipedrive/crm/UpdatePerson/UpdatePerson.js
+++ b/src/appmixer/pipedrive/crm/UpdatePerson/UpdatePerson.js
@@ -17,13 +17,6 @@ module.exports = {
         data.phone = commons.stringToContactArray(data.phone);
         data.email = commons.stringToContactArray(data.email);
 
-        const customFieldsValues = data.customFields.AND || [];
-        delete data.customFields;
-        if (customFieldsValues.length > 0) {
-            customFieldsValues.forEach(customField => {
-                data[customField.field] = customField.value;
-            });
-        }
         const response = await personsApi.updateAsync(id, data);
         if (response.success === false) {
             throw new context.CancelError(response.formattedError);

--- a/src/appmixer/pipedrive/crm/UpdatePerson/component.json
+++ b/src/appmixer/pipedrive/crm/UpdatePerson/component.json
@@ -26,8 +26,7 @@
           "phone": {
             "type": "string"
           },
-          "visible_to": {},
-          "customFields": {}
+          "visible_to": {}
         },
         "required": [
           "id"
@@ -128,39 +127,6 @@
                 "value": 3
               }
             ]
-          },
-          "customFields": {
-            "type": "expression",
-            "group": "transformation",
-            "label": "Custom Fields",
-            "tooltip": "Custom fields to update in the person.",
-            "exclusiveFields": [
-              "field"
-            ],
-            "index": 8,
-            "levels": [
-              "AND"
-            ],
-            "fields": {
-              "field": {
-                "type": "select",
-                "label": "Custom field",
-                "tooltip": "The field to append.",
-                "index": 1,
-                "source": {
-                  "url": "/component/appmixer/pipedrive/crm/ListPersonFields?outPort=out",
-                  "data": {
-                    "transform": "./transformers#fieldsToSelectArray"
-                  }
-                }
-              },
-              "value": {
-                "type": "text",
-                "label": "Value",
-                "tooltip": "The value for the custom field.",
-                "index": 2
-              }
-            }
           }
         },
         "groups": {


### PR DESCRIPTION
I have removed the custom fields because according to the documentation, those are not even supported: https://developers.pipedrive.com/docs/api/v1/Persons#updatePerson
The fields that it was using are the output ones.
Also, CreatePerson has no custom fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application version to 1.2.1 with corresponding release notes.
- **Refactor**
	- Simplified the person update functionality by removing support for custom fields, resulting in a more straightforward update process for user records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->