### PR TITLE
Dropbox.SaveURL (patch) Fix for error "The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received undefined"

### DIFF
--- a/src/appmixer/dropbox/bundle.json
+++ b/src/appmixer/dropbox/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.dropbox",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "engine": ">=5.0",
     "changelog": {
         "1.0.0": [
@@ -26,6 +26,9 @@
         ],
         "1.3.0": [
             "NewFile, NewFolder: add Path and Recursive options."
+        ],
+        "1.3.1": [
+            "SaveURL: Bug fix"
         ]
     }
 }

--- a/src/appmixer/dropbox/files/SaveURL/SaveURL.js
+++ b/src/appmixer/dropbox/files/SaveURL/SaveURL.js
@@ -24,7 +24,7 @@ function checkJobStatus(context, params, callback) {
                     checkJobStatus(context, params, callback);
                 }, 3000);
             } else {
-                callback(null, data);
+                callback(null, { data });
             }
         })
         .catch((err) => {


### PR DESCRIPTION
Was getting error "The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received undefined"

fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue affecting the URL saving functionality for a more reliable experience.
- **Chores**
	- Updated the integration package to version 1.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->