### PR TITLE
OpenAI (patch) update model labels for `CreateEdit`

### DIFF
--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.openai",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "changelog": {
         "1.1.0": [
             "OpenAI API"
@@ -17,6 +17,9 @@
         ],
         "1.2.5": [
             "UploadFile: now correctly works with all 4 purpose options. Beware that not all options work for each file."
+        ],
+        "1.2.6": [
+            "Updated labels for models in the `CreateEdit` component."
         ]
     }
 }

--- a/src/appmixer/openai/core/createEdit/component.json
+++ b/src/appmixer/openai/core/createEdit/component.json
@@ -81,7 +81,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "Model",
-                        "tooltip": "<p>ID of the model to use. You can use the <code>text-davinci-edit-001</code> or <code>code-davinci-edit-001</code> model with this endpoint. Example: text-davinci-edit-001</p>"
+                        "tooltip": "<p>ID of the model to use. You can use the <code>gpt-4o</code> model with this endpoint.</p>"
                     },
                     "input": {
                         "type": "text",


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2159#issuecomment-2690575263



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package to version 1.2.6.

- **New Features**
  - Refined the model selection interface: Labels have been updated.
  - Revised the tooltip for the model selection field to clearly indicate the new available GPT-4o model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->