### PR TITLE
google.spreadsheets (patch): encode worksheet name

### DIFF
--- a/src/appmixer/google/spreadsheets/ListColumns/ListColumns.js
+++ b/src/appmixer/google/spreadsheets/ListColumns/ListColumns.js
@@ -31,7 +31,7 @@ module.exports = {
         const sheets = google.sheets('v4');
         const listRows = Promise.promisify(sheets.spreadsheets.values.get, { context: sheets.spreadsheets.values });
         const workSheetName = context.properties.worksheetId.split('/')[1];
-        const range = `${workSheetName}!1:1`;
+        const range = `${encodeURIComponent(workSheetName)}!1:1`;
         return listRows({
             auth: commons.getOauth2Client(context.auth),
             spreadsheetId: context.properties.sheetId,

--- a/src/appmixer/google/spreadsheets/bundle.json
+++ b/src/appmixer/google/spreadsheets/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.spreadsheets",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -58,7 +58,7 @@
         "3.1.2": [
             "Bug Fix: CreateRow action throws an error when the spreadsheet is empty."
         ],
-        "3.1.3": [
+        "3.1.4": [
             "Bug Fix: CountRows, CreateRow, FindRow, GetRows, NewRow, and UpdatedRow - encode worksheet names to support sheets with special characters in the sheet name."
         ]
     }


### PR DESCRIPTION
fixes for the https://github.com/clientIO/appmixer-components/issues/2140#issuecomment-2687560331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of spreadsheet names with special characters, ensuring API requests work correctly across various actions.
- **Chores**
	- Updated the release version to 3.1.4 with corresponding changelog adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->