### PR TITLE
microsoft.mail.DownloadAttachment (patch) fix downloading JSON files

### DIFF
--- a/src/appmixer/microsoft/mail/DownloadAttachment/DownloadAttachment.js
+++ b/src/appmixer/microsoft/mail/DownloadAttachment/DownloadAttachment.js
@@ -10,9 +10,13 @@ module.exports = {
         const attachmentUrl = `/me/messages/${messageId}/attachments/${attachmentId}`;
         const attachmentResponse = await makeRequest(context, { path: attachmentUrl, method: 'GET' });
 
-        const contentUrl = `/me/messages/${messageId}/attachments/${attachmentId}/$value`;
-        const attachmentContentResponse = await makeRequest(context, {
-            path: contentUrl,
+        const contentUrl = `https://graph.microsoft.com/v1.0/me/messages/${messageId}/attachments/${attachmentId}/$value`;
+        const attachmentContentResponse = await context.httpRequest({
+            url: contentUrl,
+            // Not sending accept header to get the raw data
+            headers: {
+                Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`
+            },
             method: 'GET',
             responseType: 'arraybuffer'
         });

--- a/src/appmixer/microsoft/mail/bundle.json
+++ b/src/appmixer/microsoft/mail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.mail",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -22,6 +22,9 @@
         ],
         "1.3.1": [
             "Fix for possible connection with empty label."
+        ],
+        "1.3.2": [
+            "Fixed an issue where downloading attachments would fail for JSON files."
         ]
     }
 }


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2128
- special case when the attachment was a json file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue that prevented JSON file attachments from downloading correctly.
	- Enhanced the overall attachment download process for improved reliability and security.
- **Chores**
	- Updated the application version to 1.3.2 and refreshed the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->