### PR TITLE
Slack (patch) improve tooltip for sending messages to private channels "as_bot"

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -33,7 +33,7 @@
         "3.2.0": [
             "NewChannelMessageRT: added more output variables such as: channel, channel_type, team, event_ts, blocks, bot_profile."
         ],
-        "4.1.2": [
+        "4.1.3": [
             "(breaking change) Added payload authentication for triggers. Will require setting `signingSecret` in the connector configuration.",
             "Added options to SendChannelMessage and SendPrivateChannelMessage to send messages as a bot user.",
             "Fixed and issue when NewChannelMessageRT trigger did not register messages containing some special UTF characters."

--- a/src/appmixer/slack/list/SendPrivateChannelMessage/component.json
+++ b/src/appmixer/slack/list/SendPrivateChannelMessage/component.json
@@ -76,6 +76,7 @@
                     "asBot": {
                         "type": "toggle",
                         "label": "Send as bot",
+                        "tooltip": "Send the message as a bot user. Make sure the bot is member of the <a href='https://api.slack.com/methods/chat.postMessage#private' target='_blank'>private channel</a>.",
                         "defaultValue": false,
                         "index": 3
                     },

--- a/src/appmixer/slack/list/SendPrivateChannelMessage/component.json
+++ b/src/appmixer/slack/list/SendPrivateChannelMessage/component.json
@@ -76,7 +76,7 @@
                     "asBot": {
                         "type": "toggle",
                         "label": "Send as bot",
-                        "tooltip": "Send the message as a bot user. Make sure the bot is member of the <a href='https://api.slack.com/methods/chat.postMessage#private' target='_blank'>private channel</a>.",
+                        "tooltip": "Send the message as a bot user. Make sure the bot is a member of the <a href='https://api.slack.com/methods/chat.postMessage#private' target='_blank'>private channel</a>. Ask your Slack admin if unsure which bot app to add.",
                         "defaultValue": false,
                         "index": 3
                     },


### PR DESCRIPTION
### new tooltip
The tooltip links to official Slack docs for sending messages into private channels.

<img width="391" alt="image" src="https://github.com/user-attachments/assets/fc9cc693-d0af-445d-a55c-3e3219d81870" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the integration version to 4.1.3 with corresponding release details.
- **Bug Fixes**
  - Resolved an issue impacting the handling of special characters in messages.
- **New Features**
  - Enhanced the messaging interface by adding a tooltip that provides guidance for sending messages as a bot, clarifying channel membership requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->