### PR TITLE
Jira ListField users now display users without email

### DIFF
--- a/src/appmixer/jira/issues/ListField/ListField.js
+++ b/src/appmixer/jira/issues/ListField/ListField.js
@@ -43,13 +43,7 @@ module.exports = {
                 });
             }
 
-            const filtered = response.filter(res => {
-                if (res.emailAddress) {
-                    return res;
-                }
-            });
-
-            return filtered.map(res => {
+            return response.map(res => {
 
                 return {
                     label: res.displayName,


### PR DESCRIPTION
For some reason, the users without an email were filtered out from Assignee and Reported options. However on Jira, you could select these users for the issue.
This change make it so you can select the same users as assignee/reporter on appmixer as you would on Jira.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for populating list selection fields to include all available entries instead of filtering by a specific attribute. This change ensures users now see a complete set of options when interacting with list fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->