### PR TITLE
ActiveCampaign.NewTask - updated tooltip

### DIFF
--- a/src/appmixer/activecampaign/tasks/NewTask/component.json
+++ b/src/appmixer/activecampaign/tasks/NewTask/component.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.activecampaign.tasks.NewTask",
-    "description": "Triggers when a new task is created.",
+    "description": "Triggers when a new task is added to a deal.",
     "author": "Camilo Manrique <camilo@client.io>",
     "webhook": true,
     "auth": {


### PR DESCRIPTION
As the event while registering new webhook hints, this trigger only triggers when a task is added to a deal. There is no webhook event purely for new tasks. Should the label of the component be also updated?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated task trigger description to clarify that the event now occurs when a new task is added to a deal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->