### PR TITLE
Airtable.NewRecord (rename from NewRecordWebhook)

### DIFF
--- a/src/appmixer/airtable/bundle.json
+++ b/src/appmixer/airtable/bundle.json
@@ -12,7 +12,7 @@
             "(breaking change) Fixed output schema for ListTables and ListBases."
         ],
         "2.1.0": [
-            "(new component) NewRecordWebhook: Trigger for watching new records in specific table."
+            "(new component) NewRecord: Webhook trigger for watching new records in specific table."
         ]
     }
 }

--- a/src/appmixer/airtable/records/NewRecordWebhook/component.json
+++ b/src/appmixer/airtable/records/NewRecordWebhook/component.json
@@ -1,7 +1,7 @@
 {
     "name": "appmixer.airtable.records.NewRecordWebhook",
     "author": "Zbynek Pelunek <zbynek.pelunek@client.io>",
-    "label": "New Record Webhook",
+    "label": "New Record",
     "description": "Watches for new records.",
     "private": false,
     "webhook": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the display name for the new record trigger from "New Record Webhook" to "New Record" to provide a clearer and more succinct user-facing label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->