### PR TITLE
Utils.Files.DownloadFile - fix typo

### DIFF
--- a/src/appmixer/utils/files/DownloadFile/component.json
+++ b/src/appmixer/utils/files/DownloadFile/component.json
@@ -32,7 +32,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "File link",
-                        "tooltip": "Downloadble file link."
+                        "tooltip": "Downloadable file link."
                     },
                     "customFileName": {
                         "type": "text",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed a typographical error in the tooltip text for the file download link to ensure accurate and clear information for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->