### PR TITLE
Twilio.MakeCall (patch) Improved output

### DIFF
--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -1,7 +1,12 @@
 {
     "name": "appmixer.twilio",
-    "version": "1.0.1",
-    "changelog": [
-        "Initial version"
-    ]
+    "version": "1.0.2",
+    "changelog": {
+        "1.0.1": [
+            "Initial version."
+        ],
+        "1.0.2": [
+            "Make Call: Added response statuses of completed, busy, failed, no-answer, canceled."
+        ]
+    }
 }

--- a/src/appmixer/twilio/calls/MakeCall/MakeCall.js
+++ b/src/appmixer/twilio/calls/MakeCall/MakeCall.js
@@ -16,8 +16,8 @@ module.exports = {
         const endpoint = context.getWebhookUrl();
         await client.calls.create({
             statusCallback: endpoint,
-            statusCallbackEvent: ["initiated", "answered"],
-            statusCallbackMethod: "POST",
+            statusCallbackEvent: ['initiated', 'answered'],
+            statusCallbackMethod: 'POST',
             url: endpoint,
             to,
             from

--- a/src/appmixer/twilio/calls/MakeCall/MakeCall.js
+++ b/src/appmixer/twilio/calls/MakeCall/MakeCall.js
@@ -1,22 +1,27 @@
 'use strict';
+
 const twilio = require('twilio');
 
 module.exports = {
-
-    receive(context) {
+    async receive(context) {
 
         if (context.messages.webhook) {
             return context.sendJson(context.messages.webhook.content.data, 'call');
         }
 
-        let { accountSID, authenticationToken } = context.auth;
-        let { from, to } = context.messages.in.content;
-        let client = twilio(accountSID, authenticationToken);
+        const { accountSID, authenticationToken } = context.auth;
+        const { from, to } = context.messages.in.content;
+        const client = twilio(accountSID, authenticationToken);
 
-        return client.calls.create({
+        await client.calls.create({
+            statusCallback: context.getWebhookUrl(),
+            statusCallbackEvent: [
+                'completed', 'busy',
+                'failed', 'no-answer', 'canceled'
+            ],
             url: context.getWebhookUrl(),
-            to: to,
-            from: from
+            to,
+            from
         });
     }
 };

--- a/src/appmixer/twilio/calls/MakeCall/MakeCall.js
+++ b/src/appmixer/twilio/calls/MakeCall/MakeCall.js
@@ -6,20 +6,19 @@ module.exports = {
     async receive(context) {
 
         if (context.messages.webhook) {
-            return context.sendJson(context.messages.webhook.content.data, 'call');
+            await context.sendJson(context.messages.webhook.content.data, 'call');
+            return context.response();
         }
 
         const { accountSID, authenticationToken } = context.auth;
         const { from, to } = context.messages.in.content;
         const client = twilio(accountSID, authenticationToken);
-
+        const endpoint = context.getWebhookUrl();
         await client.calls.create({
-            statusCallback: context.getWebhookUrl(),
-            statusCallbackEvent: [
-                'completed', 'busy',
-                'failed', 'no-answer', 'canceled'
-            ],
-            url: context.getWebhookUrl(),
+            statusCallback: endpoint,
+            statusCallbackEvent: ["initiated", "answered"],
+            statusCallbackMethod: "POST",
+            url: endpoint,
             to,
             from
         });

--- a/src/appmixer/twilio/calls/MakeCall/component.json
+++ b/src/appmixer/twilio/calls/MakeCall/component.json
@@ -8,13 +8,193 @@
     "auth": {
         "service": "appmixer:twilio"
     },
-    "outPorts": [
-        {
-            "name": "call",
-            "options": [
-            ]
-        }
-    ],
+    "outPorts": [{
+        "name": "call",
+        "options": [
+            {
+                "label": "Account Sid",
+                "value": "accountSid",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Annotation",
+                "value": "annotation",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Answered By",
+                "value": "answeredBy",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Api Version",
+                "value": "apiVersion",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Caller Name",
+                "value": "callerName",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Date Created",
+                "value": "dateCreated",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Date Updated",
+                "value": "dateUpdated",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Direction",
+                "value": "direction",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Duration",
+                "value": "duration",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "End Time",
+                "value": "endTime",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Forwarded From",
+                "value": "forwardedFrom",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "From",
+                "value": "from",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "From Formatted",
+                "value": "fromFormatted",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Group Sid",
+                "value": "groupSid",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Parent Call Sid",
+                "value": "parentCallSid",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Phone Number Sid",
+                "value": "phoneNumberSid",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Price",
+                "value": "price",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Price Unit",
+                "value": "priceUnit",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Sid",
+                "value": "sid",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Start Time",
+                "value": "startTime",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Status",
+                "value": "status",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "To",
+                "value": "to",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "To Formatted",
+                "value": "toFormatted",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Trunk Sid",
+                "value": "trunkSid",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Uri",
+                "value": "uri",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "label": "Queue Time",
+                "value": "queueTime",
+                "schema": {
+                    "type": "string"
+                }
+            }
+        ]
+    }],
     "inPorts": [
         {
             "name": "in",
@@ -51,8 +231,5 @@
                 }
             }
         }
-    ],
-    "outPorts": [
-        { "name": "call" }
     ]
 }

--- a/src/appmixer/twilio/calls/NewCall/NewCall.js
+++ b/src/appmixer/twilio/calls/NewCall/NewCall.js
@@ -21,7 +21,7 @@ module.exports = {
         } else if (context.messages.webhook) {
             // Twilio HTTP callback request.
             await context.sendJson(context.messages.webhook.content.data, 'call');
-            return context.response(); 
+            return context.response();
         }
     }
 };

--- a/src/appmixer/twilio/calls/NewCall/NewCall.js
+++ b/src/appmixer/twilio/calls/NewCall/NewCall.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 
-    receive(context) {
+    async receive(context) {
 
         if (context.properties.generateInspector) {
             // Trick to return dynamic inspector from within receive().

--- a/src/appmixer/twilio/calls/NewCall/NewCall.js
+++ b/src/appmixer/twilio/calls/NewCall/NewCall.js
@@ -20,7 +20,8 @@ module.exports = {
 
         } else if (context.messages.webhook) {
             // Twilio HTTP callback request.
-            return context.sendJson(context.messages.webhook.content.data, 'call');
+            await context.sendJson(context.messages.webhook.content.data, 'call');
+            return context.response(); 
         }
     }
 };


### PR DESCRIPTION
Added statuses of 'completed', 'busy',
                'failed', 'no-answer', 'canceled' so that we get output for all these call statuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the call functionality with detailed response statuses (completed, busy, failed, no-answer, canceled) and enriched metadata for improved tracking.
  - Improved asynchronous processing for more reliable call initiation and status handling.
- **Chores**
  - Updated the version and refined the changelog format for clearer release communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->