### PR TITLE
CI: trigger Marketplace update on commit to `dev`

### DIFF
--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   trigger-workflow:
+    # By default run only on the main repository. Comment out the next line to run on forks.
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Trigger appmixer-components workflow marketplace.yml

--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Trigger appmixer-components workflow marketplace.yml
         run: |
-          curl -X POST \
+          curl -f -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.PAT }}" \
           https://api.github.com/repos/clientIO/appmixer-components/actions/workflows/marketplace.yml/dispatches \

--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -1,0 +1,18 @@
+name: Trigger Workflow in appmixer-components
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  trigger-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger appmixer-components workflow marketplace.yml
+        run: |
+          curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.PAT }}" \
+          https://api.github.com/repos/clientIO/appmixer-components/actions/workflows/marketplace.yml/dispatches \
+          -d '{"ref":"dev"}'

--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -1,4 +1,4 @@
-name: Trigger Workflow in appmixer-components
+name: Trigger Marketplace QA update in appmixer-components
 
 on:
   push:


### PR DESCRIPTION
Last part of https://github.com/clientIO/appmixer-components/issues/2080

- [x] trigger GHA added in https://github.com/clientIO/appmixer-components/pull/2186 when there is a merge into `clientIO/appmixer-connectors/dev`

This usually means connector update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced an automated workflow that triggers a marketplace QA update when changes are pushed to the development branch, helping to streamline quality assurance efforts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->