### PR TITLE
HubSpot (patch) fix DeletedContact trigger start

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -50,8 +50,9 @@
         "4.0.2": [
             "(breaking change) Improve webhook handling by better event distribution using events/listeners (applies to Appmixer version 6+). Affected components: NewContact, UpdatedContact, NewDeal, UpdatedDeal."
         ],
-        "4.0.3": [
-            "Add `properties` input to triggers NewContact, UpdatedContact, NewDeal, UpdatedDeal."
+        "4.0.4": [
+            "Added `properties` input to triggers NewContact, UpdatedContact, NewDeal, UpdatedDeal.",
+            "Fixed an issue when the `DeletedContact` trigger was not starting."
         ]
     }
 }

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -16,7 +16,7 @@ module.exports = async (context) => {
 
             try {
                 const subscriptionType = eventName.split(':')[0];
-                const subscriptions = getSubscriptionsByType(subscriptionType);
+                const subscriptions = getSubscriptionsByType(subscriptionType, context);
                 const results = await getHubSpotSubscriptions(context, params);
                 const currentSubs = results.map(s => s.eventType);
 
@@ -159,7 +159,7 @@ async function triggerListenersDelayed(context, eventName, payload) {
     await context.triggerListeners({ eventName, payload });
 }
 
-function getSubscriptionsByType(subscriptionType) {
+function getSubscriptionsByType(subscriptionType, context) {
 
     let subscriptions = [];
 
@@ -180,6 +180,11 @@ function getSubscriptionsByType(subscriptionType) {
             }
         }));
     } else if (subscriptionType === 'contact.creation' || subscriptionType === 'deal.creation') {
+        subscriptions = [{
+            enabled: true,
+            subscriptionDetails: { subscriptionType }
+        }];
+    } else if (subscriptionType === 'contact.deletion') {
         subscriptions = [{
             enabled: true,
             subscriptionDetails: { subscriptionType }


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2165

- [x] pass `context` to be able to log events that we are not subscribed to
- [x] add `contact.deletion` event to trigger it properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HubSpot integration with support for contact deletion notifications.
	- Expanded trigger settings for contact and deal updates to include additional properties.

- **Bug Fixes**
	- Resolved an issue where deletion triggers failed to initiate properly.
	- Improved error handling for unsupported subscription events to ensure reliable notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->