### PR TITLE
HubSpot (patch) remove webhook subscribing for AuthHub

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -53,6 +53,9 @@
         "4.0.4": [
             "Added `properties` input to triggers NewContact, UpdatedContact, NewDeal, UpdatedDeal.",
             "Fixed an issue when the `DeletedContact` trigger was not starting."
+        ],
+        "4.0.5": [
+            "Removed webhook subscribing when using AuthHub."
         ]
     }
 }

--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -55,7 +55,8 @@
             "Fixed an issue when the `DeletedContact` trigger was not starting."
         ],
         "4.0.5": [
-            "Removed webhook subscribing when using AuthHub."
+            "Removed webhook subscribing when using AuthHub.",
+            "Fixed an issue when HubSpot webhook was not automatically created when using own API key."
         ]
     }
 }

--- a/src/appmixer/hubspot/plugin.js
+++ b/src/appmixer/hubspot/plugin.js
@@ -1,13 +1,33 @@
 'use strict';
+const Hubspot = require('./Hubspot');
 
 module.exports = async context => {
 
     const config = require('./config')(context);
+    const { appId, apiKey } = config;
+    const { clientId, clientSecret } = context.config;
 
-    const isAuthHub = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
-    if (!(config.appId && config.apiKey) && !isAuthHub) {
-        context.log('error', 'Hubspot module not configured properly, missing appId or apiKey.');
+    /** Is this AuthHub or Engine pod? */
+    const isAuthHubPod = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
+
+    // When using AuthHub, the configuration is not needed in the Engine.
+    // How do we know if we are using AuthHub? We have `clientId` but not `clientSecret` and no `appId` or `apiKey`.
+    const isAuthHubInUse = !appId && !apiKey && !!clientId && !clientSecret;
+    if (!(appId && apiKey) && !isAuthHubInUse && !isAuthHubPod) {
+        context.log('error', 'HubSpot module not configured properly, missing appId or apiKey.');
         return {};
+    }
+
+    // Register webhook only in Engine pod and if not using AuthHub.
+    if (!isAuthHubPod && !isAuthHubInUse) {
+        const baseUrl = context.appmixerApiUrl;
+        const eventsUrl = context.http.router.getPluginEndpoint('/events');
+        const url = baseUrl.concat(eventsUrl);
+        const hs = new Hubspot('', config);
+        await hs.registerWebhook(url);
+        context.hubspot = hs;
+    } else {
+        context.log('info', 'Auth hub detected, no need to register HubSpot webhook.');
     }
 
     require('./routes')(context);

--- a/src/appmixer/hubspot/plugin.js
+++ b/src/appmixer/hubspot/plugin.js
@@ -4,7 +4,8 @@ module.exports = async context => {
 
     const config = require('./config')(context);
 
-    if (!(config.appId && config.apiKey)) {
+    const isAuthHub = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
+    if (!(config.appId && config.apiKey) && !isAuthHub) {
         context.log('error', 'Hubspot module not configured properly, missing appId or apiKey.');
         return {};
     }

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -9,6 +9,12 @@ module.exports = async (context) => {
     // This will create a subscription in HubSpot for the given subscriptionType if it does not exist.
     context.onListenerAdded(async (listener) => {
 
+        const isAuthHub = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
+        if (isAuthHub) {
+            // This is AuthHub, we don't need to create subscriptions here.
+            return;
+        }
+
         const { eventName, params } = listener;
 
         try {

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -9,8 +9,9 @@ module.exports = async (context) => {
     // This will create a subscription in HubSpot for the given subscriptionType if it does not exist.
     context.onListenerAdded(async (listener) => {
 
-        const isAuthHub = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
-        if (isAuthHub) {
+        /** Is this AuthHub or Engine pod? */
+        const isAuthHubPod = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
+        if (isAuthHubPod) {
             // This is AuthHub, we don't need to create subscriptions here.
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2193

☝️ This PR limits when HubSpot webhook is configured and when it subscribes to HubSpot events.

## AuthHub config vs AuthHub/Engine pod
In this PR we check two important environment details:
- **are we in Engine or AuthHub pod?**
    - don't run any API calls for HubSpot webhooks in AutHub pod
    - it is only for processing incoming webhook payloads
- **is AuthHub config in use?**
    - if the config for HubSpot is taken from AuthHub, don't run any API calls for HubSpot webhooks

## When to run the original code?
The original code that creates HubSpot webhook (`targetUrl` and `maxConcurrentRequests`) should run only when
- in Engine pod
- not using AuthHub config
- has `appId` and `apiKey`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated product version from 4.0.4 to 4.0.5 with an updated changelog entry.

- **New Features**
  - Enhanced integration logic to conditionally register webhooks based on the operating environment, ensuring registration occurs only when appropriate.
  - Strengthened configuration validation and error logging to boost system stability.
  - Optimized overall integration handling to deliver a more reliable and efficient user experience.
  - Removed webhook subscribing when using AuthHub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->