### PR TITLE
Google.sheets(major): update scopes

### DIFF
--- a/src/appmixer/google/spreadsheets/CountRows/component.json
+++ b/src/appmixer/google/spreadsheets/CountRows/component.json
@@ -6,7 +6,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/CreateRow/component.json
+++ b/src/appmixer/google/spreadsheets/CreateRow/component.json
@@ -8,7 +8,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/CreateRows/component.json
+++ b/src/appmixer/google/spreadsheets/CreateRows/component.json
@@ -7,7 +7,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/DeleteRows/component.json
+++ b/src/appmixer/google/spreadsheets/DeleteRows/component.json
@@ -6,7 +6,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/FindRow/component.json
+++ b/src/appmixer/google/spreadsheets/FindRow/component.json
@@ -6,7 +6,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/GetRows/component.json
+++ b/src/appmixer/google/spreadsheets/GetRows/component.json
@@ -6,7 +6,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/ListColumns/component.json
+++ b/src/appmixer/google/spreadsheets/ListColumns/component.json
@@ -10,7 +10,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/ListColumnsWithSelectInputs/component.json
+++ b/src/appmixer/google/spreadsheets/ListColumnsWithSelectInputs/component.json
@@ -13,7 +13,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/ListRows/component.json
+++ b/src/appmixer/google/spreadsheets/ListRows/component.json
@@ -13,7 +13,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/ListSheets/component.json
+++ b/src/appmixer/google/spreadsheets/ListSheets/component.json
@@ -13,7 +13,7 @@
     "auth": {
         "service": "appmixer:google",
         "scope": [
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/ListWorksheets/component.json
+++ b/src/appmixer/google/spreadsheets/ListWorksheets/component.json
@@ -13,7 +13,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/NewRow/component.json
+++ b/src/appmixer/google/spreadsheets/NewRow/component.json
@@ -22,7 +22,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/UpdatedRow/component.json
+++ b/src/appmixer/google/spreadsheets/UpdatedRow/component.json
@@ -7,7 +7,7 @@
         "service": "appmixer:google",
         "scope": [
             "https://www.googleapis.com/auth/spreadsheets.readonly",
-            "https://www.googleapis.com/auth/drive.metadata.readonly"
+            "https://www.googleapis.com/auth/drive.readonly"
         ]
     },
     "quota": {

--- a/src/appmixer/google/spreadsheets/bundle.json
+++ b/src/appmixer/google/spreadsheets/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.spreadsheets",
-    "version": "3.1.4",
+    "version": "4.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -60,6 +60,9 @@
         ],
         "3.1.4": [
             "Bug Fix: CountRows, CreateRow, FindRow, GetRows, NewRow, and UpdatedRow - encode worksheet names to support sheets with special characters in the sheet name."
+        ],
+        "4.0.0": [
+            "Breaking Change: The `drive.metadata.readonly` scope has been changed to `drive.readonly`. Affected components: CountRows, CreateRow, DeleteRow, FindRow, GetRows, NewRow, UpdatedRow. \nMigration: you need to re-authenticate affected components mentioned above."
         ]
     }
 }


### PR DESCRIPTION
`drive.metadata.readonly` is less privileged scope, however we don't have the verification for it yet. Replacing with the `drive.readonly` will surpass  the "App is blocked" on prod env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**  
  - Enhanced spreadsheet integrations now provide more comprehensive access to Google Drive content, expanding from limited metadata views to reading file contents.  
  - The integration has been updated to version 4.0.0; users will need to re-authenticate their accounts to activate the new settings.  
  - These updates offer improved performance and consistency in data access across your spreadsheet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->