### PR TITLE
Smartsheet (patch): bump version

### DIFF
--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.smartsheet",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "changelog": {
         "1.0.1": [
             "Smartsheet"
@@ -12,7 +12,7 @@
             "Breaking: Updated input field of GetFolders to have multiselect instead of single select.",
             "BugFix: Fixed GetSheet." 
         ],
-        "2.0.4": [
+        "2.0.5": [
             "Breaking change: Updated the input ports of AddRowsToSheet to fix the display of correct columns to input value in the inspector",
             "Breaking change: Bug fix in input fields of Copyfolder and MoveFolder",
             "Breaking change: Updated the input ports of UpdateRow to fix the display of correct columns to input value in the inspector",


### PR DESCRIPTION
there was a issue with casing of the GetSheet component name on master branch. I has been fixed, however we need trigger the release pipeline by changing the version, otherwise, it won't be released to production. 

issue
https://github.com/clientIO/appmixer-components/issues/2196

fix
https://github.com/clientIO/appmixer-components/pull/2216/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Application version updated to 2.0.5 with refreshed release notes.
- **Breaking Changes**
  - Modified input requirements for key operations related to sheet additions, folder handling, and row updates. These changes may require integration adjustments.
- **Bug Fixes**
  - Resolved an issue affecting the functionality of row movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->