### PR TITLE
utils.controls.Digest (patch) add quotas

### DIFF
--- a/src/appmixer/utils/controls/Digest/component.json
+++ b/src/appmixer/utils/controls/Digest/component.json
@@ -2,7 +2,12 @@
     "name": "appmixer.utils.controls.Digest",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Compile data in a single batch and send it at regular intervals or when a certain number of entries is reached.",
-    "version": "1.0.0",
+    "version": "1.0.1",
+    "quota": {
+        "manager": "appmixer:utils:controls",
+        "resources": "digest",
+        "maxWait": 10000
+    },
     "properties": {
         "schema": {
             "properties": {
@@ -149,4 +154,3 @@
     }],
     "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAGBUlEQVR4nO2dy24dRRCGSwK8gB0i3LaIrIhhAzwFCBYglgECFrBAQuKyZM9FSMAbACJSvOURkiwQsERc3gAiYhMQAgFTPmNCrDNdPV3dXdXd/y/9UuTYPv+ZrnPmm6r2HKI8Oj15f/LB5H/goj6Yj/XpqJWpIA5yhewPzGi+Qk6K4ALZH4xRfSFifYrq5snXyP5AjOpr8xqYaXdLKLiud8VVKqjnFkLB9fysuEoF9fFCKLiePxJXqaAuL4SC6/mSuEqFxPDxmxDuAatwHekMhY/x75NvsQgmAaA5oXaim0i+0jpjEUwCwIsWoToVv82HjrUJCEoA+KFFqE7FoBc61iYgKAHgWYtQnYpf4a5AEABYV+5AEABYV+5AEABYX65AUAuA2D9w3bHzfVcgqAFA7B/Ybmm+7wYEtQC4L/zsyN4PHDc3IKgFwKvCz4/sq4Hj5gYEtQCIAkgrAJYLENQCIE4Byw6dAlguQFDbAQQEbnfMJk9zEMzVAcRl4HWv2eZtDoLoANrKHATRAbSXKQhiBGwvUxDECNheZiCIEbAPmYEgANCHzEAQAOhHJiAIAPQjExDUjoDR+IlzTGOoOghqABCt3zSHWsPVQVADgBj+pHtpOFQdBDUAiPFvukPj4aogqAFAFECZAqgKghoAxCkg3aH9AdVAUNsBBASmWdofUA0Ec3QAcRkY79j9AdVAEB1Av6oCgugA+lUVEMQI2K+KgyBGwL5VHAQxAvat4iAIAPSvoiAIAPSvoiAIAPSvYiCoHQGj8ZPHUmOoGAimAiBav2W81BouBoKpAIjhTzkvDYeKgGAqAGL8W85L4+EiIJgKgCiA+gWQHQQ1AIhTQDkvnQKyg6CmAwgILOPQ/oDsIKjtAOIyMJ9j9wdkBUF0ANtTVhBEB7A9ZQNBjIDbVDYQxAi4TWUDQYyA21UWEAQAtqssIAgAbFdqEAQAti01CGpGwGj81HGoMaQGwRQAROvXxkutYRUIpgAghj923jYcUoFgCgBi/GvnbePhZBBMBUAUgK8CSAbBVADEKcDO204BySCY2gEEBNo4tD8gCQQ1HUBcBtZzzP6AJBBEB7AfrQZBdAD70moQxAi4L60GQYyA+9MqEMQIuD+tAkEAYH+KBkEAYJ+KBkEAYJ+KBkEJAL15zQct1lKrjbAjEPzUQZAUx3zUag213Ar/hJ/Azw6CpFr6sOUaankYxmtPfzsIkmrp49ZrqOVxOK+9eQitd8QlKqedQK5WbB5A6zukVSqoU4Fcrdg8gNYPS6tUUI8GcrVi8wBan5NWqaD2ArlasfwNxvqAwvk+s4tG5wO52O/bRftPzRfAMxTOxxR+q0EufsxDIdtTBrlOqvkCuJPkS9XnDXKdEzJx5lMGuU6q+QJgSdPK76jQR6YviC//fhAyedlD0UUBvEJyztcr5nkrIs9LFfOE1EUB3D75Vwrn5JH2boUsD9FmlBrKcjhn9qAuCoDFRC1l/Z42zFBKd03+MSLHOwUzrFU3BXAvye8C7K9ps1C5dffkbyIe/2D+Xi/qpgBYb5Ccl82A9mDGx+W3/ZhXPvu1jI+bQ10VAJP+VxS3EMwEb5Lu6oBpn4FPOucf+0vyt3uqqwJg3U/rdt7wuwH3CdY0i26b/ALFv+rZv0y+T/XMyqi7AmA9Ofkvil8cNhfN55NfnPwIbZo0O7P53zzY2Zu/R+rwnTRneazoM05XlwXA4oVcs0ilzB0/y4GUpG4LgHV28p9kt/j8yt8r/SSV6roAWE+QzW5cHkI9XuH5adV9AbAYDGOvDnKYad8j8G3TEAXA4suvV6nsJk1uRL1NtvsQ12qYAjjWPZPfpbiuYawP59/pqcMXq+EK4Fg8jHmZNn8EmbL1nX/m4vw7vAx2UjRsAfxffJ3/NG0GSl9M/pY2fxTxx+yf5q/x/71Hm508lruNcwoFMLhQAIMLBTC4UACDCwUwuFAAgwsFMLhQAIMLBTC4UACDCwUwuFAAg0tdAHDfNg8AowBgQ5sHgI0LoOUbHcI6H91os+VbncI6H91qt+WbHcPpvuFm263e7hxe7xtut/8vEc5nPy8dhWkAAAAASUVORK5CYII="
 }
-

--- a/src/appmixer/utils/controls/bundle.json
+++ b/src/appmixer/utils/controls/bundle.json
@@ -1,7 +1,7 @@
 {
     "name": "appmixer.utils.controls",
     "engine": ">=6.0",
-    "version": "1.9.1",
+    "version": "1.9.2",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -77,6 +77,9 @@
         ],
         "1.9.1": [
             "Digest: set * as a default for hour, dayMonth, dayWeek and 0 for minute."
+        ],
+        "1.9.2": [
+            "Digest: Set quotas to handle concurrent entries in a more robust way."
         ]
     }
 }

--- a/src/appmixer/utils/controls/quota.js
+++ b/src/appmixer/utils/controls/quota.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+
+    rules: [
+        {
+            limit: 15,
+            throttling: 'limit-concurrency',
+            queueing: 'fifo',
+            resource: 'digest'
+        }
+    ]
+};


### PR DESCRIPTION
Closes https://github.com/clientIO/appmixer-components/issues/2213

- [x] add quota to spread the load of several hundreds queued up messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced resource management with improved quota controls, ensuring more robust handling of concurrent entries.
- **Chores**
	- Updated configuration version numbers to reflect recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->