### PR TITLE
Akamai.UpsertListEntries - updated tooltip, Lists show types

### DIFF
--- a/src/appmixer/akamai/bundle.json
+++ b/src/appmixer/akamai/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.akamai",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "changelog": {
       "1.0.1": [
           "Initial version"
@@ -8,6 +8,10 @@
       "1.0.2": [
         "DeleteListEntries: now accepts multiple IPs separated by comma.",
         "UpserListEntries: now also activates the list after the upsert is completed."
+      ],
+      "1.0.3": [
+        "UpsertListEntries: updated tooltip for IPs as 255.255.255.255 would return an error.",
+        "Lists select now show the type of the List."
       ]
   }
 }

--- a/src/appmixer/akamai/clientlist/GetLists/GetLists.js
+++ b/src/appmixer/akamai/clientlist/GetLists/GetLists.js
@@ -58,7 +58,7 @@ module.exports = {
 
     listsToSelectArray(lists) {
         return lists.map((list) => {
-            return { label: list.name, value: list.listId };
+            return { label: `${list.name} <${list.type}>`, value: list.listId };
         });
     },
 

--- a/src/appmixer/akamai/clientlist/GetLists/component.json
+++ b/src/appmixer/akamai/clientlist/GetLists/component.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "appmixer.akamai.clientlist.GetLists",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Get Akamai client list lists.",

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "appmixer.akamai.clientlist.UpsertListEntries",
   "author": "Appmixer <info@appmixer.com>",
   "description": "Append or update client list entries and activates the list.",

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
@@ -43,7 +43,7 @@
                     "type": "text",
                     "index": 1,
                     "label": "IP or IPs",
-                    "tooltip": "Value of the entry, which is either an IP address, an Autonomous System Number (ASN), a Geolocation, a TLS fingerprint, or a file hash. Multiple values can be added at once but need to be separated by a comma. It will then use the same Description and Expiration Date. Example: <code>1.1.1.1,255.255.255.255</code>"
+                    "tooltip": "Value of the entry, which is either an IP address, an Autonomous System Number (ASN), a Geolocation, a TLS fingerprint, or a file hash. Multiple values can be added at once but need to be separated by a comma. It will then use the same Description and Expiration Date. Example: <code>1.1.1.1,192.168.1.17</code>"
                 },
                 "network": {
                     "type": "select",


### PR DESCRIPTION
I did no version change as it is only update to a tooltip and select label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced list labels now display both the list name and its type for improved clarity.
  - Refined tooltip guidance now showcases updated examples for valid input values.
- **Chores**
  - Updated application version from "1.0.2" to "1.0.3".
  - Incremented version number for the `UpsertListEntries` component from "1.0.2" to "1.0.3".
  - Incremented version number for the `GetLists` component from "1.0.0" to "1.0.1".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->