### PR TITLE
Trello (patch) trim checklist items

### DIFF
--- a/src/appmixer/trello/bundle.json
+++ b/src/appmixer/trello/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.trello",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -31,6 +31,9 @@
         ],
         "2.1.4": [
             "Fixed the issue with the CreateCard component where `idChecklists` was not being sent to the output port."
+        ],
+        "2.1.5": [
+            "Fixed an issue with AddChecklistToCard where whitespace in the checklist items was not being trimmed."
         ]
     }
 }

--- a/src/appmixer/trello/checklist/AddChecklistToCard/AddChecklistToCard.js
+++ b/src/appmixer/trello/checklist/AddChecklistToCard/AddChecklistToCard.js
@@ -21,7 +21,7 @@ module.exports = {
 
         // Add checklist items to the checklist
         if (checklistItems) {
-            const items = checklistItems.split('\n');
+            const items = checklistItems.trim().split('\n');
 
             if (items.length > 10) {
                 throw new context.CancelError('Maximum 10 checklist items are allowed');

--- a/src/appmixer/trello/list/CreateCard/CreateCard.js
+++ b/src/appmixer/trello/list/CreateCard/CreateCard.js
@@ -73,7 +73,7 @@ module.exports = {
                 const items = checklistItems.split('\n');
 
                 if (items.length > 10) {
-                    throw new context.CancelError('Maximum 5 checklist items are allowed');
+                    throw new context.CancelError('Maximum 10 checklist items are allowed');
                 }
 
                 for (let i = 0; i < items.length; i++) {

--- a/test/trello/checklist/AddChecklistToCard.test.js
+++ b/test/trello/checklist/AddChecklistToCard.test.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../../utils.js');
+const action = require('../../../src/appmixer/trello/checklist/AddChecklistToCard/AddChecklistToCard.js');
+
+describe('AddChecklistToCard', function() {
+
+    let context;
+
+    beforeEach(function() {
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        sinon.reset();
+    });
+
+    describe('receive', function() {
+
+        beforeEach(function() {
+            // Stub httpRequest
+            context.httpRequest = sinon.stub().resolves({
+                data: {
+                    id: 'foo'
+                }
+            });
+        });
+
+        describe('checklist items', function() {
+
+            it('should fail with too many checklist items due to leading newline', async function() {
+	            context.messages = {
+	                in: {
+	                    content: {
+	                        boardListCardId: 'cardId',
+	                        checklistName: 'checklist',
+	                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk'
+	                    }
+	                }
+	            };
+	            await assert.rejects(
+	                async () => {
+	                    await action.receive(context);
+	                },
+	                context.CancelError('Maximum 10 checklist items are allowed')
+	            );
+	        });
+
+            it('should make 10 API requests for 10 checklist items', async function() {
+                context.messages = {
+                    in: {
+                        content: {
+                            boardListCardId: 'cardId',
+                            checklistName: 'checklist',
+                            checklistItems: 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n'
+                        }
+                    }
+                };
+
+                await action.receive(context);
+
+                assert.strictEqual(context.httpRequest.callCount, 11);
+            });
+        });
+    });
+});

--- a/test/trello/list/createCard.test.js
+++ b/test/trello/list/createCard.test.js
@@ -63,13 +63,14 @@ describe('CreateCard', function() {
 	            context.CancelError('Card name is required')
 	        );
         });
-        it('should fail with too many checklist items due to leading newline', async function() {
+
+        it('should fail with too many checklist items', async function() {
             context.messages = {
                 in: {
                     content: {
                         name: 'card name',
                         checklistName: 'checklist',
-                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj'
+                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk'
                     }
                 }
             };
@@ -79,15 +80,12 @@ describe('CreateCard', function() {
                 },
                 context.CancelError('Maximum 10 checklist items are allowed')
             );
-        });
-
-        it('should fail with too many checklist items due to trailing newline', async function() {
             context.messages = {
                 in: {
                     content: {
                         name: 'card name',
                         checklistName: 'checklist',
-                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\n'
+                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk'
                     }
                 }
             };

--- a/test/trello/list/createCard.test.js
+++ b/test/trello/list/createCard.test.js
@@ -1,0 +1,120 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../../utils.js');
+const action = require('../../../src/appmixer/trello/list/CreateCard/CreateCard.js');
+
+describe('CreateCard', function() {
+
+    let context;
+
+    beforeEach(function() {
+
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        sinon.reset();
+    });
+
+
+    describe('receive', function() {
+
+        beforeEach(function() {
+
+            // Stub httpRequest
+            context.httpRequest = sinon.stub().resolves({
+                data: {
+                    id: 'foo'
+                }
+            });
+        });
+
+        it('should fail with no checklist name', async function() {
+
+            context.messages = {
+                in: {
+                    content: {
+                        name: 'card name',
+                        checklistItems: 'a,b,c'
+                    }
+                }
+            };
+            await assert.rejects(
+                async () => {
+                    await action.receive(context);
+                },
+                context.CancelError('Checklist name is required to add checklist items')
+            );
+        });
+
+        it('should fail with empty card name', async function() {
+
+            context.messages = { in: { content: { name: '   ' } } };
+	        await assert.rejects(
+	            async () => {
+	                await action.receive(context);
+	            },
+	            context.CancelError('Card name is required')
+	        );
+
+            context.messages = { in: { content: {} } };
+	        await assert.rejects(
+	            async () => {
+	                await action.receive(context);
+	            },
+	            context.CancelError('Card name is required')
+	        );
+        });
+        it('should fail with too many checklist items due to leading newline', async function() {
+            context.messages = {
+                in: {
+                    content: {
+                        name: 'card name',
+                        checklistName: 'checklist',
+                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj'
+                    }
+                }
+            };
+            await assert.rejects(
+                async () => {
+                    await action.receive(context);
+                },
+                context.CancelError('Maximum 10 checklist items are allowed')
+            );
+        });
+
+        it('should fail with too many checklist items due to trailing newline', async function() {
+            context.messages = {
+                in: {
+                    content: {
+                        name: 'card name',
+                        checklistName: 'checklist',
+                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\n'
+                    }
+                }
+            };
+            await assert.rejects(
+                async () => {
+                    await action.receive(context);
+                },
+                context.CancelError('Maximum 10 checklist items are allowed')
+            );
+        });
+
+        it('should make 10 API requests for 10 checklist items', async function() {
+            context.messages = {
+                in: {
+                    content: {
+                        name: 'card name',
+                        boardListId: 'boardListId',
+                        checklistName: 'checklist',
+                        // Simulating user entering checklist items with leading and trailing newlines
+                        checklistItems: '   \na\nb\nc\nd\ne\nf\ng\nh\ni\nj\n  '
+                    }
+                }
+            };
+
+            await action.receive(context);
+
+            assert.strictEqual(context.httpRequest.callCount, 12);
+        });
+    });
+});

--- a/test/trello/list/createCard.test.js
+++ b/test/trello/list/createCard.test.js
@@ -80,21 +80,6 @@ describe('CreateCard', function() {
                 },
                 context.CancelError('Maximum 10 checklist items are allowed')
             );
-            context.messages = {
-                in: {
-                    content: {
-                        name: 'card name',
-                        checklistName: 'checklist',
-                        checklistItems: '\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk'
-                    }
-                }
-            };
-            await assert.rejects(
-                async () => {
-                    await action.receive(context);
-                },
-                context.CancelError('Maximum 10 checklist items are allowed')
-            );
         });
 
         it('should make 10 API requests for 10 checklist items', async function() {


### PR DESCRIPTION
- [x] properly trim checklist items input
- [x] add tests

### Before
https://github.com/clientIO/appmixer-connectors/actions/runs/14308045256/job/40096243646

![image](https://github.com/user-attachments/assets/e764d785-a09a-4f6b-9109-f0959e84e3d8)

### After
https://github.com/clientIO/appmixer-connectors/actions/runs/14308058070/job/40096283683

![image](https://github.com/user-attachments/assets/21f06a46-53f9-4864-8ab9-9d6e1b46c3e8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with the AddChecklistToCard component by trimming unnecessary whitespace in checklist items.
	- Updated error notifications to reflect an increased limit for checklist items from 5 to 10.
- **Tests**
	- Added new unit tests to validate the AddChecklistToCard and CreateCard functionalities, ensuring proper error handling and API interactions.
- **Chores**
	- Updated the application version to 2.1.5 and refreshed the changelog accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->