### PR TITLE
hubspot (patch) Add suffix for custom properties

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -61,7 +61,7 @@
         "4.0.6": [
             "Fixed an issue when the `CreateDeal` component was showing error `resource not found`."
         ],
-        "4.1.0": [
+        "4.1.1": [
             "Added custom properties and additional properties to the following components: `CreateContact`, `CreateDeal`, `UpdateContact` and `UpdateDeal`. Custom properties are new properties that are not part of the default HubSpot properties. Additional properties default HubSpot properties but were not part of the default properties list before.",
             "Added caching of Contact and Deal properties, which can be further configured in the connector settings.",
             "Improved listing output variables for `GetContact` to make it consistent with the selected properties in the input."

--- a/src/appmixer/hubspot/commons.js
+++ b/src/appmixer/hubspot/commons.js
@@ -54,6 +54,12 @@ module.exports = {
 
             // Get all properties from HubSpot.
             const { data } = await hubspot.call('get', `crm/v3/properties/${objectType}`);
+            // Custom fields should have `[custom]` in the label
+            data.results.forEach(property => {
+                if (property.createdUserId) {
+                    property.label = `${property.label} [custom]`;
+                }
+            });
             const properties = data.results.map(property => property.name);
 
             // Save to cache both versions: triggers and actions.

--- a/src/appmixer/hubspot/config.js
+++ b/src/appmixer/hubspot/config.js
@@ -1,14 +1,6 @@
 'use strict';
-const getEnvVar = (name, defaultValue, parser) => {
 
-    let envVar = process.env[name];
-    return envVar ? (typeof parser === 'function' ? parser(envVar) : envVar) : defaultValue;
-};
-
-module.exports = context => {
-
-    return {
-        appId: context.config.appId || getEnvVar('HUBSPOT_APP_ID', null),
-        apiKey: context.config.apiKey || getEnvVar('HUBSPOT_API_KEY', null)
-    };
-};
+module.exports = ({ config }) => ({
+    appId: config.appId || process.env.HUBSPOT_APP_ID,
+    apiKey: config.apiKey || process.env.HUBSPOT_API_KEY
+});

--- a/test/hubspot/BaseSubscriptionComponent.test.js
+++ b/test/hubspot/BaseSubscriptionComponent.test.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+const testUtils = require('../utils.js');
+const Base = require('../../src/appmixer/hubspot/BaseSubscriptionComponent.js');
+
+// Simulates eg UpdatedContact component
+class TestComponent extends Base {
+
+    async getSubscriptions() {
+        return [];
+    }
+    // We don't want to call the actual API
+    subscribe() {
+        return Promise.resolve();
+    }
+    deleteSubscriptions() {
+        return Promise.resolve();
+    }
+}
+
+describe('BaseSubscriptionComponent', () => {
+
+    let context = testUtils.createMockContext();
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Set the profile info.
+        context.auth.profileInfo = {
+            token: 'CJSP5qf1KhICAQEYs-gDIIGOBii1hQIyGQAf3xBKmlwHjX7OIpuIFEavB2-qYAGQsF4',
+            user: 'test@hubspot.com',
+            hub_domain: 'demo.hubapi.com',
+            scopes: [
+                'contacts',
+                'automation',
+                'oauth'
+            ],
+            hub_id: 33,
+            app_id: 456,
+            expires_in: 21588,
+            user_id: 123,
+            token_type: 'access'
+        };
+    });
+
+    it('should register triggers', async () => {
+
+        // Register the triggers
+        const component = new TestComponent('contact.PropertyChange');
+        await component.start(context);
+
+        const addListenerArgs = context.addListener.getCall(0).args[0];
+        assert.equal(addListenerArgs, 'contact.PropertyChange:33', 'The trigger component should be registered by Appmixer.');
+    });
+
+    it('should unsubscribe', async () => {
+
+        // Unsubscribe
+        const component = new TestComponent('contact.PropertyChange');
+        await component.stop(context);
+
+        const removeListenerArgs = context.removeListener.getCall(0).args[0];
+        assert.equal(removeListenerArgs, 'contact.PropertyChange:33', 'The trigger component should be unregistered by Appmixer.');
+    });
+
+});

--- a/test/hubspot/CreateContact.test.js
+++ b/test/hubspot/CreateContact.test.js
@@ -1,0 +1,86 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('CreateContact', () => {
+
+    const CreateContact = require('../../src/appmixer/hubspot/crm/CreateContact/CreateContact.js');
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+    });
+
+    it('should create contact with custom properties', async function() {
+
+        const createData = {
+            email: 'john.doe@example.com',
+            firstname: 'John',
+            lastname: 'Doe',
+            phone: '123456789',
+            website: 'www.example.com',
+            company: 'Example',
+            address: 'Example street',
+            city: 'Example city',
+            state: 'Example state',
+            zip: '12345'
+        };
+        // This is how the inspector sends custom properties
+        createData.additionalProperties = {
+            AND: [
+                { name: 'some_custom_property', value: 'foo' },
+                { name: 'another_custom_property', value: 43 }
+            ]
+        };
+        context.messages.in.content = createData;
+
+        /** Expected data to/from HubSpot */
+        const expectedData = {
+            properties: {
+	            ...createData,
+	            some_custom_property: 'foo',
+	            another_custom_property: 43
+            }
+        };
+        delete expectedData.properties.additionalProperties;
+
+        // Mock the response of Contact creation
+        hubspotStub.resolves({
+            data: {
+                id: '38533722672',
+                properties: {
+                    createdAt: '2023-01-01T00:00:00Z',
+                    updatedAt: '2023-02-04T00:00:00Z',
+                    ...expectedData.properties
+                }
+            }
+        });
+
+        await CreateContact.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'Should make 1 call to create contact');
+        // Assert that custom properties were sent to HubSpot
+        const createContactArgs = hubspotStub.getCall(0).args;
+        assert.equal(createContactArgs[0], 'post', 'Should call post method');
+        assert.equal(createContactArgs[1], 'crm/v3/objects/contacts', 'Should call correct endpoint');
+        assert.deepEqual(createContactArgs[2], expectedData, 'Should send custom properties to HubSpot');
+
+        // Assert `context.sendJson` was called with the correct data
+        const sendJsonArgs = context.sendJson.getCall(0).args[0];
+        console.log('sendJsonArgs', sendJsonArgs);
+        assert.equal(sendJsonArgs.id, '38533722672', 'Should return contact ID');
+        assert.equal(sendJsonArgs.some_custom_property, 'foo', 'Should return custom property');
+        assert.equal(sendJsonArgs.another_custom_property, 43, 'Should return custom property');
+    });
+});

--- a/test/hubspot/CreateDeal.test.js
+++ b/test/hubspot/CreateDeal.test.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('CreateDeal', () => {
+
+    const CreateDeal = require('../../src/appmixer/hubspot/crm/CreateDeal/CreateDeal.js');
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+    });
+
+    it('should create deal with custom properties', async function() {
+
+        const createData = {
+            dealId: '38533722676',
+            dealname: 'My Deal',
+            dealstage: 'appointmentscheduled',
+            hubSpotOwnerId: 'hs9191919191',
+            amount: 1020,
+            closedate: (new Date('2022-12-31')).toISOString(),
+            pipeline: 'default'
+        };
+        // This is how the inspector sends custom properties
+        createData.additionalProperties = {
+            AND: [
+                { name: 'some_custom_property', value: 'foo' },
+                { name: 'another_custom_property', value: 43 }
+            ]
+        };
+        context.messages.in.content = createData;
+
+        /** Expected data to/from HubSpot */
+        const expectedData = {
+            dealname: createData.dealname,
+            amount: createData.amount,
+            closedate: createData.closedate,
+            pipeline: createData.pipeline,
+            dealstage: createData.dealstage,
+            hubspot_owner_id: createData.hubSpotOwnerId,
+            some_custom_property: 'foo',
+            another_custom_property: 43
+        };
+
+        // Mock the response of Deal creation
+        hubspotStub.resolves({
+            data: {
+                id: createData.dealId,
+                createdAt: '2023-01-01T00:00:00Z',
+                updatedAt: '2023-02-04T00:00:00Z',
+                properties: expectedData
+            }
+        });
+
+        await CreateDeal.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'Should make 1 call to create deal');
+        // Assert that custom properties were sent to HubSpot
+        const createDealArgs = hubspotStub.getCall(0).args;
+        assert.equal(createDealArgs[0], 'post', 'Should call post method');
+        assert.equal(createDealArgs[1], 'crm/v3/objects/deals', 'Should call correct endpoint');
+        assert.deepEqual(createDealArgs[2].properties, expectedData, 'Should send custom properties to HubSpot');
+    });
+});

--- a/test/hubspot/GetContactsProperties.test.js
+++ b/test/hubspot/GetContactsProperties.test.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('GetContactsProperties', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+
+        context.messages = { in: { content: {} } };
+    });
+
+    it('should cache outPort schema', async function() {
+
+        // The require is inside the test because we need to stub the call method
+        const GetContactsProperties = require('../../src/appmixer/hubspot/crm/GetContactsProperties/GetContactsProperties.js');
+
+        // Mock the response of the hubspot call for deal properties
+        const mockedResponse = {
+            data: {
+                results: [
+                    {
+                        name: 'firstname',
+                        label: 'First Name',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'email',
+                        label: 'Email',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    }
+                ]
+            }
+        };
+        hubspotStub.withArgs('get', 'crm/v3/properties/contacts').resolves(mockedResponse);
+
+        // 2 calls to get contact properties
+        context.properties = {};
+        await GetContactsProperties.receive(context);
+        await GetContactsProperties.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'Should make only 1 call to get contact properties');
+        // Check the outPort schema
+        const sendJsonArgs = context.sendJson.getCall(0).args;
+        assert.deepEqual(sendJsonArgs[0], mockedResponse.data.results, 'Should cache the outPort schema');
+    });
+
+    describe('custom fields', () => {
+
+        it('should return custom and HubSpot fields', async function() {
+
+            // The require is inside the test because we need to stub the call method
+            const GetContactsProperties = require('../../src/appmixer/hubspot/crm/GetContactsProperties/GetContactsProperties.js');
+
+            // Mock the response of the hubspot call for contact properties
+            const mockedResponse = [
+                {
+                    name: 'jirka_notes',
+                    label: 'Jirka Notes',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: 'What does Jirka think of this contact?',
+                    createdUserId: '71561347',
+                    displayOrder: -1,
+                    hidden: false,
+                    formField: true
+                },
+                {
+                    name: 'jirka_some_hidden_stuff',
+                    label: 'jirka some hidden stuff',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: 'This should not be in inspector',
+                    createdUserId: '71561347',
+                    displayOrder: -1,
+                    hidden: false,
+                    formField: false
+                },
+                {
+                    name: 'job_function',
+                    label: 'Job function',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: "Contact's job function. Required for the Facebook Ads Integration. Automatically synced from the Lead Ads tool.",
+                    displayOrder: -1,
+                    hidden: false,
+                    formField: true
+                },
+                {
+                    name: 'jobtitle',
+                    label: 'Job Title',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: "A contact's job title",
+                    displayOrder: 12,
+                    hidden: false,
+                    formField: true
+                }
+            ];
+            hubspotStub.withArgs('get', 'crm/v3/properties/contacts').resolves({ data: mockedResponse });
+
+            // eslint-disable-next-line max-len
+            const additionalFieldsSelectArray = await GetContactsProperties.additionalFieldsToSelectArray(mockedResponse);
+
+            assert.equal(additionalFieldsSelectArray.length, 3, 'Should return custom and HubSpot fields');
+            assert.equal(additionalFieldsSelectArray[0].label, 'Jirka Notes', 'Should return only custom fields');
+        });
+    });
+});

--- a/test/hubspot/GetDealsProperties.test.js
+++ b/test/hubspot/GetDealsProperties.test.js
@@ -1,0 +1,122 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('GetDealsProperties', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+    });
+
+    it('should cache outPort schema', async function() {
+
+        const GetDealsProperties = require('../../src/appmixer/hubspot/crm/GetDealsProperties/GetDealsProperties.js');
+
+        // Mock the response of the hubspot call for deal properties
+        const mockedResponse = {
+            data: {
+                results: [
+                    {
+                        name: 'dealname',
+                        label: 'Deal Name',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'dealinformation',
+                        options: []
+                    },
+                    {
+                        name: 'amount',
+                        label: 'Amount',
+                        type: 'number',
+                        fieldType: 'number',
+                        groupName: 'dealinformation',
+                        options: []
+                    }
+                ]
+            }
+        };
+        hubspotStub.withArgs('get', 'crm/v3/properties/deals').resolves(mockedResponse);
+
+        // 2 calls to get deal properties
+        context.properties = {};
+        await GetDealsProperties.receive(context);
+        await GetDealsProperties.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'Should make only 1 call to get deal properties');
+        // Check the outPort schema
+        const sendJsonArgs = context.sendJson.getCall(0).args;
+        assert.deepEqual(sendJsonArgs[0], mockedResponse.data.results, 'Should cache the outPort schema');
+    });
+
+    describe('custom fields', () => {
+
+        it('should return only custom fields', async function() {
+
+            const GetDealsProperties = require('../../src/appmixer/hubspot/crm/GetDealsProperties/GetDealsProperties.js');
+
+            // Mock the response of the hubspot call for deal properties
+            const mockedResponse = [
+                {
+                    name: 'jirka_notes',
+                    label: 'Jirka Notes',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: 'What does Jirka think of this deal?',
+                    createdUserId: '71561347',
+                    displayOrder: -1,
+                    hidden: false,
+                    formField: true
+                },
+                {
+                    name: 'jirka_some_hidden_stuff',
+                    label: 'jirka some hidden stuff',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: 'This should not be in inspector',
+                    createdUserId: '71561347',
+                    displayOrder: -1,
+                    hidden: false,
+                    formField: false
+                },
+                {
+                    name: 'dealname',
+                    label: 'Deal Name',
+                    type: 'string',
+                    fieldType: 'text',
+                    description: "Deal's name.",
+                    displayOrder: -1,
+                    hidden: false,
+                    formField: true
+                },
+                {
+                    name: 'amount',
+                    label: 'Amount',
+                    type: 'number',
+                    fieldType: 'number',
+                    description: "A deal's amount",
+                    displayOrder: 12,
+                    hidden: false,
+                    formField: true
+                }
+            ];
+            hubspotStub.withArgs('get', 'crm/v3/properties/deals').resolves(mockedResponse);
+
+            const customFieldsSelectArray = await GetDealsProperties.additionalFieldsToSelectArray(mockedResponse);
+
+            assert.equal(customFieldsSelectArray.length, 1, 'Should return only custom fields');
+            assert.equal(customFieldsSelectArray[0].label, 'Jirka Notes', 'Should return only custom fields');
+        });
+    });
+});

--- a/test/hubspot/ListPipelineStages.test.js
+++ b/test/hubspot/ListPipelineStages.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('ListPipelineStages', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call').resolves({
+            data: {
+                results: [
+                    {
+                        id: '123',
+                        label: 'Test Stage',
+                        displayOrder: 1,
+                        metadata: {
+                            probability: 0.5
+                        }
+                    }
+                ]
+            }
+        });
+    });
+
+    describe('source', () => {
+
+        it('should not throw when used as a `source`', async function() {
+
+            // The require is inside the test because we need to stub the call method
+            const ListPipelineStages = require('../../src/appmixer/hubspot/crm/ListPipelineStages/ListPipelineStages.js');
+
+            context.messages = {
+                in: {
+                    content: {
+                        // pipelineId: '123',
+                        isSource: true
+                    }
+                }
+            };
+
+            await ListPipelineStages.receive(context);
+
+            assert.equal(hubspotStub.callCount, 0, 'Should not call the hubspot API without pipelineId');
+            // Check the outPort schema
+            const sendJsonArgs = context.sendJson.getCall(0).args;
+            assert.deepEqual(sendJsonArgs[0].stages, [], 'Should not send any data');
+        });
+
+        it('should not throw when used as a `source`', async function() {
+
+            // The require is inside the test because we need to stub the call method
+            const ListPipelineStages = require('../../src/appmixer/hubspot/crm/ListPipelineStages/ListPipelineStages.js');
+
+            context.messages = {
+                in: {
+                    content: {
+                        pipelineId: '123'
+                    }
+                }
+            };
+
+            await ListPipelineStages.receive(context);
+
+            assert.equal(hubspotStub.callCount, 1, 'Should call the hubspot API with pipelineId');
+            assert.equal(hubspotStub.getCall(0).args[1], 'crm/v3/pipelines/deals/123/stages', 'Should call the correct endpoint');
+            // Check the outPort schema
+            const sendJsonArgs = context.sendJson.getCall(0).args;
+            assert.deepEqual(sendJsonArgs[0].stages[0].id, '123', 'Should send the data');
+        });
+    });
+});

--- a/test/hubspot/NewContact.test.js
+++ b/test/hubspot/NewContact.test.js
@@ -1,0 +1,171 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+const NewContact = require('../../src/appmixer/hubspot/crm/NewContact/NewContact.js');
+
+describe('NewContact', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Set the profile info.
+        context.auth.profileInfo = {
+            token: 'CJSP5qf1KhICAQEYs-gDIIGOBii1hQIyGQAf3xBKmlwHjX7OIpuIFEavB2-qYAGQsF4',
+            user: 'test@hubspot.com',
+            hub_domain: 'demo.hubapi.com',
+            scopes: [
+                'contacts',
+                'automation',
+                'oauth'
+            ],
+            hub_id: 33,
+            app_id: 456,
+            expires_in: 21588,
+            user_id: 123,
+            token_type: 'access'
+        };
+        context.messages = { webhook: { content: { data: null } } };
+        // Set the properties to output. If not empty, the component will only output these properties
+        // and will not call HubSpot API to get all properties.
+        context.properties = { properties: 'lastname,firstname,email,phone' };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(NewContact.hubspot, 'call');
+    });
+
+    // HubSpot can trigger the same create event multiple times
+    it('multiple creation of the same contact', async () => {
+
+        context.messages.webhook.content.data = {
+            '166332965081': {
+                occurredAt: 1726820335517
+            }
+        };
+
+        // Mock the response of the hubspot call
+        hubspotStub.withArgs('post', 'crm/v3/objects/contacts/batch/read').resolves({
+            data: {
+                results: [
+                    {
+                        id: '166332965081',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        firstname: 'John',
+                        lastname: 'Doe'
+                    }
+                ]
+            }
+        });
+
+        // No data in cache
+        context.staticCache.get = sinon.stub().returns(null);
+
+        await NewContact.receive(context);
+
+        // Contact ID is cached
+        assert.equal(context.staticCache.set.callCount, 1);
+
+        // The same message arrives again
+        context.messages.webhook.content.data = {
+            '166332965081': {
+                occurredAt: 1726820335517
+            }
+        };
+
+        // HubSpot sends the second event few milliseconds after the first one
+        // This simulates creating cache in the first `receive` call
+        context.staticCache.get = sinon.stub().returns('166332965081');
+        await NewContact.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1);
+        assert.equal(hubspotStub.args[0][0], 'post');
+        assert.equal(hubspotStub.args[0][1], 'crm/v3/objects/contacts/batch/read');
+
+        assert.equal(context.sendArray.callCount, 1, 'Only one message sent');
+        assert.equal(context.sendArray.args[0][0].length, 1, 'One new contact sent');
+        assert.equal(context.response.callCount, 2);
+    });
+
+    it('should cache outPort schema', async function() {
+
+        // No `properties` in the context so we need to call HubSpot API to get all properties.
+        context.properties = {};
+        // We receive 10 webhook payloads, one new contact in each payload.
+        // We should cache the outPort schema after the first payload.
+        const payloads = Array.from({ length: 10 }, (_, i) => {
+            return {
+                [`${i}`]: {
+                    occurredAt: 1726820305517 + i
+                }
+            };
+        });
+
+        // Mock the response of the hubspot call for contact properties
+        hubspotStub.withArgs('get', 'crm/v3/properties/contacts').resolves({
+            data: {
+                results: [
+                    {
+                        name: 'lastname',
+                        label: 'Last Name',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'firstname',
+                        label: 'First Name',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'email',
+                        label: 'Email',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'phone',
+                        label: 'Phone Number',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    }
+                ]
+            }
+        });
+
+        // Mock the response of the hubspot call
+        for (const payload of payloads) {
+            hubspotStub.withArgs('post', 'crm/v3/objects/contacts/batch/read').resolves({
+                data: {
+                    results: [{
+                        id: Object.keys(payload)[0],
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        lastname: 'Doe-' + Object.keys(payload)[0]
+                    }]
+                }
+            });
+        }
+
+        for (const payload of payloads) {
+            context.messages.webhook.content.data = payload;
+            await NewContact.receive(context);
+        }
+
+        assert.equal(hubspotStub.callCount, 11, 'Should make 10 calls to get contact data and 1 call to get contact properties');
+    });
+});

--- a/test/hubspot/NewDeal.test.js
+++ b/test/hubspot/NewDeal.test.js
@@ -1,0 +1,95 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+const NewDeal = require('../../src/appmixer/hubspot/crm/NewDeal/NewDeal.js');
+
+describe('NewDeal', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Set the profile info.
+        context.auth.profileInfo = {
+            token: 'CJSP5qf1KhICAQEYs-gDIIGOBii1hQIyGQAf3xBKmlwHjX7OIpuIFEavB2-qYAGQsF4',
+            user: 'test@hubspot.com',
+            hub_domain: 'demo.hubapi.com',
+            scopes: [
+                'contacts',
+                'automation',
+                'oauth'
+            ],
+            hub_id: 33,
+            app_id: 456,
+            expires_in: 21588,
+            user_id: 123,
+            token_type: 'access'
+        };
+        context.messages = { webhook: { content: { data: null } } };
+        // Set the properties to output. If not empty, the component will only output these properties
+        // and will not call HubSpot API to get all properties.
+        context.properties = { properties: 'amount' };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(NewDeal.hubspot, 'call');
+    });
+
+    it('should cache outPort schema', async function() {
+
+        // No `properties` in the context so we need to call HubSpot API to get all properties.
+        context.properties = {};
+        // We receive 10 webhook payloads, one new deal in each payload.
+        // We should cache the outPort schema after the first payload.
+        const payloads = Array.from({ length: 10 }, (_, i) => {
+            return {
+                [`${i}`]: {
+                    occurredAt: 1726820305517 + i
+                }
+            };
+        });
+
+        // Mock the response of the hubspot call for deal properties
+        hubspotStub.withArgs('get', 'crm/v3/properties/deals').resolves({
+            data: {
+                results: [
+                    {
+                        name: 'amount',
+                        label: 'Amount',
+                        type: 'number',
+                        fieldType: 'number',
+                        readOnlyDefinition: false,
+                        hidden: false,
+                        options: []
+                    }
+                ]
+            }
+        });
+
+        // Mock the response of the hubspot call
+        for (const payload of payloads) {
+            hubspotStub.withArgs('post', 'crm/v3/objects/deals/batch/read').resolves({
+                data: {
+                    results: [{
+                        id: Object.keys(payload)[0],
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        amount: '1000' + Object.keys(payload)[0]
+                    }]
+                }
+            });
+        }
+
+        for (const payload of payloads) {
+            context.messages.webhook.content.data = payload;
+            await NewDeal.receive(context);
+        }
+
+        assert.equal(hubspotStub.callCount, 11, 'Should make 10 calls to get deal data and 1 call to get deal properties');
+    });
+});

--- a/test/hubspot/UpdateContact.test.js
+++ b/test/hubspot/UpdateContact.test.js
@@ -1,0 +1,69 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('UpdateContact', () => {
+
+    const UpdateContact = require('../../src/appmixer/hubspot/crm/UpdateContact/UpdateContact.js');
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+    });
+
+    it('should update contact with custom properties', async function() {
+
+        const updateData = {
+            email: 'john.doe@example.com',
+            firstname: 'John',
+            lastname: 'Doe'
+        };
+        // This is how the inspector sends custom properties
+        updateData.additionalProperties = {
+            AND: [
+                { name: 'some_custom_property', value: 'foo' },
+                { name: 'another_custom_property', value: 43 }
+            ]
+        };
+        context.messages.in.content = updateData;
+
+        /** Expected data to/from HubSpot */
+        const expectedData = {
+            email: updateData.email,
+            firstname: updateData.firstname,
+            lastname: updateData.lastname,
+            some_custom_property: 'foo',
+            another_custom_property: 43
+        };
+
+        // Mock the response of Contact update
+        hubspotStub.resolves({
+            data: {
+                id: '38533722672',
+                createdAt: '2023-01-01T00:00:00Z',
+                updatedAt: '2023-02-04T00:00:00Z',
+                ...expectedData
+            }
+        });
+
+        await UpdateContact.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'Should make 1 call to update contact');
+        // Assert that custom properties were sent to HubSpot
+        const updateContactArgs = hubspotStub.getCall(0).args;
+        assert.equal(updateContactArgs[0], 'patch', 'Should call patch method');
+        assert.equal(updateContactArgs[1], 'crm/v3/objects/contacts/' + encodeURIComponent(context.messages.in.content.email), 'Should call correct endpoint');
+        assert.deepEqual(updateContactArgs[2].properties, expectedData, 'Should send custom properties to HubSpot');
+    });
+});

--- a/test/hubspot/UpdateDeal.test.js
+++ b/test/hubspot/UpdateDeal.test.js
@@ -1,0 +1,74 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('UpdateDeal', () => {
+
+    const UpdateDeal = require('../../src/appmixer/hubspot/crm/UpdateDeal/UpdateDeal.js');
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+    });
+
+    it('should create and update deal with custom properties', async function() {
+
+        const updateData = {
+            dealId: '38533722672',
+            dealname: 'My Deal',
+            dealstage: 'appointmentscheduled',
+            amount: 1000,
+            closedate: (new Date('2023-12-31')).toISOString(),
+            pipeline: 'default'
+        };
+        // This is how the inspector sends custom properties
+        updateData.additionalProperties = {
+            AND: [
+                { name: 'some_custom_property', value: 'foo' },
+                { name: 'another_custom_property', value: 43 }
+            ]
+        };
+        context.messages.in.content = updateData;
+
+        /** Expected data to/from HubSpot */
+        const expectedData = {
+            dealname: updateData.dealname,
+            amount: updateData.amount,
+            closedate: updateData.closedate,
+            pipeline: updateData.pipeline,
+            dealstage: updateData.dealstage,
+            some_custom_property: 'foo',
+            another_custom_property: 43
+        };
+
+        // Mock the response of Deal creation
+        hubspotStub.resolves({
+            data: {
+                id: updateData.dealId,
+                createdAt: '2023-01-01T00:00:00Z',
+                updatedAt: '2023-02-04T00:00:00Z',
+                properties: expectedData
+            }
+        });
+
+        await UpdateDeal.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'Should make 1 call to create/update deal');
+        // Assert that custom properties were sent to HubSpot
+        const updateDealArgs = hubspotStub.getCall(0).args;
+        assert.equal(updateDealArgs[0], 'patch', 'Should call patch method');
+        assert.equal(updateDealArgs[1], 'crm/v3/objects/deals/' +  updateData.dealId, 'Should call correct endpoint');
+        assert.deepEqual(updateDealArgs[2].properties, expectedData, 'Should send custom properties to HubSpot');
+    });
+});

--- a/test/hubspot/UpdatedContact.test.js
+++ b/test/hubspot/UpdatedContact.test.js
@@ -1,0 +1,249 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+const UpdatedContact = require('../../src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js');
+const { version } = require('../../src/appmixer/hubspot/bundle.json');
+const { WATCHED_PROPERTIES_CONTACT } = require('../../src/appmixer/hubspot/commons.js');
+
+describe('UpdatedContact', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Set the profile info.
+        context.auth.profileInfo = {
+            token: 'CJSP5qf1KhICAQEYs-gDIIGOBii1hQIyGQAf3xBKmlwHjX7OIpuIFEavB2-qYAGQsF4',
+            user: 'test@hubspot.com',
+            hub_domain: 'demo.hubapi.com',
+            scopes: [
+                'contacts',
+                'automation',
+                'oauth'
+            ],
+            hub_id: 33,
+            app_id: 456,
+            expires_in: 21588,
+            user_id: 123,
+            token_type: 'access'
+        };
+        context.messages = { webhook: { content: { data: null } } };
+        // Set the properties to output. If not empty, the component will only output these properties
+        // and will not call HubSpot API to get all properties.
+        context.properties = { properties: 'lastname,firstname,email,phone' };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(UpdatedContact.hubspot, 'call');
+    });
+
+    it('handle CSV import of contacts to update', async () => {
+
+        context.messages.webhook.content.data = {
+            '38533722672': {
+                occurredAt: 1726820305517,
+                propertyName: 'lastname'
+            },
+            '38533722673': {
+                occurredAt: 1726820305517,
+                propertyName: 'firstname'
+            },
+            '38533722674': {
+                occurredAt: 1726820305517,
+                propertyName: 'email'
+            },
+            '38533722675': {
+                occurredAt: 1726820305517,
+                propertyName: 'phone'
+            }
+        };
+
+        // Mock the response of the hubspot call
+        hubspotStub.withArgs('post', 'crm/v3/objects/contacts/batch/read').resolves({
+            data: {
+                results: [
+                    {
+                        id: '38533722672',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-02-04T00:00:00Z'
+                    },
+                    {
+                        id: '38533722673',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-02-04T00:00:00Z'
+                    },
+                    {
+                        id: '38533722674',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-02-04T00:00:00Z'
+                    },
+                    {
+                        id: '38533722675',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-02-04T00:00:00Z'
+                    }
+                ]
+            }
+        });
+
+        await UpdatedContact.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1);
+        assert.equal(hubspotStub.args[0][0], 'post');
+        assert.equal(hubspotStub.args[0][1], 'crm/v3/objects/contacts/batch/read');
+
+        assert.equal(context.sendArray.callCount, 1);
+        assert.equal(context.sendArray.args[0][0].length, 4, '4 changes sent');
+        assert.equal(context.response.callCount, 1);
+    });
+
+    // HubSpot can trigger multiple updates of the same contact in a short period of time.
+    // 1. The first update changes firstname
+    // 2. The second update changes lastname
+    it('multiple updates of same contact', async () => {
+
+        context.messages.webhook.content.data = {
+            '38533722679': {
+                occurredAt: 1726820305517,
+                propertyName: 'firstname',
+                propertyValue: 'john'
+            }
+        };
+
+        // Mock the response of the hubspot call
+        hubspotStub.withArgs('post', 'crm/v3/objects/contacts/batch/read').resolves({
+            data: {
+                results: [
+                    {
+                        id: '38533722679',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        firstname: 'John',
+                        lastname: 'Doe'
+                    }
+                ]
+            }
+        });
+
+        // No data in cache
+        context.staticCache.get = sinon.stub().returns(null);
+
+        await UpdatedContact.receive(context);
+
+        // Contact ID is cached
+        assert.equal(context.staticCache.set.callCount, 1);
+
+        context.messages.webhook.content.data = {
+            '38533722679': {
+                occurredAt: 1726820305666,
+                propertyName: 'lastname',
+                propertyValue: 'Doe'
+            }
+        };
+
+        // HubSpot sends the second event few milliseconds after the first one
+        // This simulates creating the lock and cache in the first `receive` call
+        context.staticCache.get = sinon.stub().returns('1726820305666');
+        await UpdatedContact.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1);
+        assert.equal(hubspotStub.args[0][0], 'post');
+        assert.equal(hubspotStub.args[0][1], 'crm/v3/objects/contacts/batch/read');
+
+        assert.equal(context.sendArray.callCount, 1, 'Only one message sent');
+        assert.equal(context.sendArray.args[0][0].length, 0, 'No changes sent');
+        assert.equal(context.response.callCount, 2);
+    });
+
+    it('getSubscriptions', async () => {
+
+        if (version.startsWith('4')) {
+            const subscriptions = UpdatedContact.getSubscriptions();
+
+            assert.equal(subscriptions.length, WATCHED_PROPERTIES_CONTACT.length);
+        }
+    });
+
+    it('should cache outPort schema', async function() {
+
+        // No `properties` in the context so we need to call HubSpot API to get all properties.
+        context.properties = {};
+        // We receive 10 webhook payloads, one updated deal in each payload.
+        // We should cache the outPort schema after the first payload.
+        const payloads = Array.from({ length: 10 }, (_, i) => {
+            return {
+                [`${i}`]: {
+                    occurredAt: 1726820305517 + i,
+                    propertyName: 'lastname',
+                    propertyValue: 'Doe-' + i
+                }
+            };
+        });
+
+        // Mock the response of the hubspot call for deal properties
+        hubspotStub.withArgs('get', 'crm/v3/properties/contacts').resolves({
+            data: {
+                results: [
+                    {
+                        name: 'lastname',
+                        label: 'Last Name',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'firstname',
+                        label: 'First Name',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'email',
+                        label: 'Email',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    },
+                    {
+                        name: 'phone',
+                        label: 'Phone Number',
+                        type: 'string',
+                        fieldType: 'text',
+                        groupName: 'contactinformation',
+                        options: []
+                    }
+                ]
+            }
+        });
+        // Mock the response of the hubspot call
+        for (const payload of payloads) {
+            hubspotStub.withArgs('post', 'crm/v3/objects/contacts/batch/read').resolves({
+                data: {
+                    results: [{
+                        id: Object.keys(payload)[0],
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        lastname: 'Doe-' + Object.keys(payload)[0]
+                    }]
+                }
+            });
+        }
+
+        for (const payload of payloads) {
+            context.messages.webhook.content.data = payload;
+            await UpdatedContact.receive(context);
+        }
+
+        assert.equal(hubspotStub.callCount, 11, 'Should make 10 calls to get contact data and 1 call to get contact properties');
+    });
+
+});

--- a/test/hubspot/UpdatedDeal.test.js
+++ b/test/hubspot/UpdatedDeal.test.js
@@ -1,0 +1,222 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+const UpdatedDeal = require('../../src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js');
+const { WATCHED_PROPERTIES_DEAL } = require('../../src/appmixer/hubspot/commons.js');
+
+describe('UpdatedDeal', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        // Set the profile info.
+        context.auth.profileInfo = {
+            token: 'CJSP5qf1KhICAQEYs-gDIIGOBii1hQIyGQAf3xBKmlwHjX7OIpuIFEavB2-qYAGQsF4',
+            user: 'test@hubspot.com',
+            hub_domain: 'demo.hubapi.com',
+            scopes: [
+                'contacts',
+                'automation',
+                'oauth'
+            ],
+            hub_id: 33,
+            app_id: 456,
+            expires_in: 21588,
+            user_id: 123,
+            token_type: 'access'
+        };
+        context.messages = { webhook: { content: { data: null } } };
+        // Set the properties to output. If not empty, the component will only output these properties
+        // and will not call HubSpot API to get all properties.
+        context.properties = { properties: 'lastname,firstname,email,phone' };
+        context.componentId = 'testComponentId';
+
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        hubspotStub = sinon.stub(UpdatedDeal.hubspot, 'call');
+    });
+
+    it('created and updated at the same time', async () => {
+
+        context.messages.webhook.content.data = {
+            '38533722672': {
+                occurredAt: 1726820305517,
+                propertyName: 'amount',
+                propertyValue: '1000'
+            }
+        };
+
+        // Mock the response of the hubspot call
+        hubspotStub.withArgs('post', 'crm/v3/objects/deals/batch/read').resolves({
+            data: {
+                results: [
+                    {
+                        id: '38533722672',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        amount: '1000'
+                    }
+                ]
+            }
+        });
+
+        await UpdatedDeal.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1);
+        assert.equal(hubspotStub.args[0][0], 'post');
+        assert.equal(hubspotStub.args[0][1], 'crm/v3/objects/deals/batch/read');
+
+        assert.equal(context.sendArray.callCount, 1);
+        assert.equal(context.sendArray.args[0][0].length, 0, 'No changes sent');
+        assert.equal(context.response.callCount, 1);
+    });
+
+    it('update of ignored property only', async () => {
+
+        context.messages.webhook.content.data = {
+            '38533722673': {
+                occurredAt: 1726820305517,
+                propertyName: 'lastmodifieddate',
+                propertyValue: '2023-01-01T00:00:00Z'
+            }
+        };
+
+        // Mock the response of the hubspot call
+        hubspotStub.withArgs('post', 'crm/v3/objects/deals/batch/read').resolves({
+            data: {
+                results: []
+            }
+        });
+
+        await UpdatedDeal.receive(context);
+
+        assert.equal(hubspotStub.callCount, 0, 'No call to hubspot');
+        assert.equal(context.sendArray.callCount, 0);
+        assert.equal(context.response.callCount, 1);
+    });
+
+    // HubSpot can trigger multiple updates of the same deal in a short period of time.
+    // 1. The first update changes amount
+    // 2. The second update changes name
+    it('multiple updates of same deal', async () => {
+
+        context.messages.webhook.content.data = {
+            '38533722672': {
+                occurredAt: 1726820305517,
+                propertyName: 'amount',
+                propertyValue: '1001'
+            }
+        };
+
+        // Mock the response of the hubspot call
+        hubspotStub.withArgs('post', 'crm/v3/objects/deals/batch/read').resolves({
+            data: {
+                results: [
+                    {
+                        id: '38533722672',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        amount: '1001',
+                        name: 'New Deal Name'
+                    }
+                ]
+            }
+        });
+
+        // No data in cache
+        context.staticCache.get = sinon.stub().returns(null);
+
+        await UpdatedDeal.receive(context);
+
+        // Deal ID is cached
+        assert.equal(context.staticCache.set.callCount, 1);
+
+        context.messages.webhook.content.data = {
+            '38533722672': {
+                occurredAt: 1726820305517,
+                propertyName: 'dealname',
+                propertyValue: 'New Deal Name'
+            }
+        };
+
+        // HubSpot sends the second event few milliseconds after the first one
+        // This simulates creating the lock and cache in the first `receive` call
+        context.staticCache.get = sinon.stub().returns('1726820305517');
+        await UpdatedDeal.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1);
+        assert.equal(hubspotStub.args[0][0], 'post');
+        assert.equal(hubspotStub.args[0][1], 'crm/v3/objects/deals/batch/read');
+
+        assert.equal(context.sendArray.callCount, 1, 'Only one message sent');
+        assert.equal(context.sendArray.args[0][0].length, 0, 'No changes sent');
+        assert.equal(context.response.callCount, 2);
+    });
+
+    it('getSubscriptions', async () => {
+
+        // Common for both versions
+        const subscriptions = UpdatedDeal.getSubscriptions();
+        assert.equal(subscriptions.length, WATCHED_PROPERTIES_DEAL.length);
+    });
+
+    it('should cache outPort schema', async function() {
+
+        // No `properties` in the context so we need to call HubSpot API to get all properties.
+        context.properties = {};
+        // We receive 10 webhook payloads, one updated deal in each payload.
+        // We should cache the outPort schema after the first payload.
+        const payloads = Array.from({ length: 10 }, (_, i) => {
+            return {
+                [`${i}`]: {
+                    occurredAt: 1726820305517 + i,
+                    propertyName: 'amount',
+                    propertyValue: '1000'
+                }
+            };
+        });
+
+        // Mock the response of the hubspot call for deal properties
+        hubspotStub.withArgs('get', 'crm/v3/properties/deals').resolves({
+            data: {
+                results: [
+                    {
+                        name: 'amount',
+                        label: 'Amount',
+                        type: 'number',
+                        fieldType: 'number',
+                        readOnlyDefinition: false,
+                        hidden: false,
+                        options: []
+                    }
+                ]
+            }
+        });
+        // Mock the response of the hubspot call
+        for (const payload of payloads) {
+            hubspotStub.withArgs('post', 'crm/v3/objects/deals/batch/read').resolves({
+                data: {
+                    results: [{
+                        id: Object.keys(payload)[0],
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-01-01T00:00:00Z',
+                        amount: '1000' + Object.keys(payload)[0]
+                    }]
+                }
+            });
+        }
+
+        for (const payload of payloads) {
+            context.messages.webhook.content.data = payload;
+            await UpdatedDeal.receive(context);
+        }
+
+        assert.equal(hubspotStub.callCount, 11, 'Should make 10 calls to get deal data and 1 call to get deal properties');
+    });
+});

--- a/test/hubspot/commons.test.js
+++ b/test/hubspot/commons.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+let HubSpot = require('../../src/appmixer/hubspot/Hubspot.js');
+
+describe('commons.js', () => {
+
+    let context = testUtils.createMockContext();
+    let hubspotStub;
+
+    beforeEach(async () => {
+
+        // Reset the context.
+        context = testUtils.createMockContext();
+        context.messages = { in: { content: {} } };
+        context.config = {
+            objectPropertiesCacheTTL: 1
+        };
+        // Reset hubspot stub if it was called before
+        if (hubspotStub) {
+            hubspotStub.restore();
+        }
+        // Stub the hubspot methods
+        hubspotStub = sinon.stub(HubSpot.prototype, 'call');
+    });
+
+    it('should mark custom properties with a suffix', async () => {
+
+        const { getObjectProperties } = require('../../src/appmixer/hubspot/commons');
+        // Mock the response of the hubspot call for contact properties
+        const mockedResponse = [
+            {
+                name: 'jirka_notes',
+                label: 'Jirka Notes',
+                type: 'string',
+                fieldType: 'text',
+                description: 'What does Jirka think of this contact?',
+                createdUserId: '71561347',
+                displayOrder: -1,
+                hidden: false,
+                formField: true
+            },
+            {
+                name: 'jobtitle',
+                label: 'Job Title',
+                type: 'string',
+                fieldType: 'text',
+                description: "A contact's job title",
+                displayOrder: 12,
+                hidden: false,
+                formField: true
+            }
+        ];
+        hubspotStub.withArgs('get', 'crm/v3/properties/contacts').resolves({ data: { results: mockedResponse } });
+
+        const properties = await getObjectProperties(context, { call: hubspotStub }, 'contacts');
+        assert(properties.length > 0);
+        assert.equal(properties[0].label, 'Jirka Notes [custom]', 'Custom field should have [custom] suffix');
+        assert.equal(properties[1].label, 'Job Title', 'Non custom field should not have [custom] suffix');
+    });
+});

--- a/test/hubspot/routes-advanced.test.js
+++ b/test/hubspot/routes-advanced.test.js
@@ -1,0 +1,183 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+const routes = require('../../src/appmixer/hubspot/routes.js');
+
+// Single scenario:
+// New Deal is created in HubSpot with a specific amount and deal name and stage and close date.
+// HubSpot triggers the following event:
+// 1. Deal creation
+// 2. Deal property amount changed
+// 3. Deal property dealstage changed
+// 4. Deal property dealname changed
+// 5. Deal property pipeline changed
+// 6. Deal property closedate changed
+// These events are sent to Appmixer in several batches, in this example we will simulate the following:
+// Events 2 and 3 are sent in the first batch (updates only)
+// Events 1, 4, 5 and 6 are sent in the second batch (creation and updates)
+// Expected result: Appmixer should trigger only for New Deal creation event if the event is sent "soon" after the property changes.
+// What is "soon"? We will define it as 2 seconds.
+describe('POST /events handler advanced', () => {
+
+    let context = testUtils.createMockContext();
+    let handler;
+
+    beforeEach(async () => {
+
+        // Reset the context
+        context = {
+            ...testUtils.createMockContext(),
+            // Routes/plugins specific stubs
+            http: {
+                router: {
+                    register: sinon.stub()
+                }
+            }
+        };
+
+        // Register the routes the same way Appmixer does.
+        await routes(context);
+        // Get the right handler for the POST /events route - our HubSpot triggers.
+        handler = context.http.router.register.getCall(0).args[0].options.handler;
+        // Stubs common to all tests. v4
+        context.triggerComponent.resolves();
+    });
+
+    it('ignore update events fired with create event', async function() {
+
+        // Fixtures
+        const req1 = {
+            payload: [
+                {
+                    eventId: 3313558930,
+                    subscriptionId: 3117550,
+                    portalId: 154661564,
+                    appId: 3220555,
+                    occurredAt: 1737447084866,
+                    subscriptionType: 'deal.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 108008343753,
+                    propertyName: 'amount',
+                    propertyValue: '666',
+                    changeSource: 'INTEGRATION',
+                    sourceId: '3220555'
+                },
+                {
+                    eventId: 623346684,
+                    subscriptionId: 3117546,
+                    portalId: 154661564,
+                    appId: 3220555,
+                    occurredAt: 1737447084866,
+                    subscriptionType: 'deal.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 108008343753,
+                    propertyName: 'dealstage',
+                    propertyValue: 'appointmentscheduled',
+                    changeSource: 'INTEGRATION',
+                    sourceId: '3220555'
+                }
+            ]
+        };
+
+        const req2 = {
+            payload: [
+                {
+                    eventId: 2298890858,
+                    subscriptionId: 3117545,
+                    portalId: 154661564,
+                    appId: 3220555,
+                    occurredAt: 1737447084866,
+                    subscriptionType: 'deal.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 108008343753,
+                    propertyName: 'dealname',
+                    propertyValue: 'New deal 1737447084',
+                    changeSource: 'INTEGRATION',
+                    sourceId: '3220555'
+                },
+                {
+                    eventId: 2801075737,
+                    subscriptionId: 3117544,
+                    portalId: 154661564,
+                    appId: 3220555,
+                    occurredAt: 1737447084866,
+                    subscriptionType: 'deal.creation',
+                    attemptNumber: 0,
+                    objectId: 108008343753,
+                    changeFlag: 'CREATED',
+                    changeSource: 'INTEGRATION',
+                    sourceId: '3220555'
+                },
+                {
+                    eventId: 2745776837,
+                    subscriptionId: 3117547,
+                    portalId: 154661564,
+                    appId: 3220555,
+                    occurredAt: 1737447084866,
+                    subscriptionType: 'deal.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 108008343753,
+                    propertyName: 'pipeline',
+                    propertyValue: 'default',
+                    changeSource: 'INTEGRATION',
+                    sourceId: '3220555'
+                },
+                {
+                    eventId: 1098120383,
+                    subscriptionId: 3117549,
+                    portalId: 154661564,
+                    appId: 3220555,
+                    occurredAt: 1737447084866,
+                    subscriptionType: 'deal.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 108008343753,
+                    propertyName: 'closedate',
+                    propertyValue: '2033935200000',
+                    changeSource: 'INTEGRATION',
+                    sourceId: '3220555'
+                }
+            ]
+        };
+
+        const clock = sinon.useFakeTimers();
+        // Call the handlers at the same time
+        await handler(req1);
+        await handler(req2);
+
+        // Expecting no calls yet to triggerListeners, this is the time when the events are received.
+        assert.equal(context.triggerListeners.callCount, 0, 'triggerListeners should not be called yet');
+
+        // Jump 6 seconds into the future to trigger delayed events
+        await clock.tickAsync(6000);
+        console.log('Jumped 6 seconds into the future');
+
+        // Assertions
+        // Expecting 1 call to triggerListeners, only for the deal creation event.
+        assert.equal(context.triggerListeners.callCount, 1, 'triggerListeners should be called once');
+        const triggerListenersArgsExpected = {
+            eventName: 'deal.creation:154661564',
+            payload: { '108008343753': req2.payload[1] }
+        };
+
+        assert(
+            context.triggerListeners.calledWith(triggerListenersArgsExpected),
+            'triggerListeners should be called with the correct arguments'
+        );
+
+        // Some records should be cached in MongoDB
+        assert.equal(Object.keys(global.serviceState).length, 1, 'Some records should be cached in MongoDB');
+        // Assert the value of the first key
+        const key = Object.keys(global.serviceState)[0];
+        assert.equal(global.serviceState[key], 1737447084866, 'The first key should have the correct value');
+
+        // Jump another 6 seconds into the future to make sure the records are not cached in MongoDB
+        await clock.tickAsync(6000);
+        console.log('Jumped another 6 seconds into the future');
+
+        // Still expecting 1 call to triggerListeners, only for the deal creation event.
+        assert.equal(context.triggerListeners.callCount, 1, 'triggerListeners should be called once');
+
+        // No records should be cached in MongoDB
+        assert.equal(Object.keys(global.serviceState).length, 0, 'No records should be cached in MongoDB');
+    });
+});

--- a/test/hubspot/routes.test.js
+++ b/test/hubspot/routes.test.js
@@ -1,0 +1,359 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../utils.js');
+const routes = require('../../src/appmixer/hubspot/routes');
+const { version } = require('../../src/appmixer/hubspot/bundle.json');
+
+describe('POST /events handler', () => {
+
+    let context = testUtils.createMockContext();
+    let handler;
+
+    // Fixtures
+    // A single OAuth app has 3 users (HubSpot accounts): Airbus, Boeing and Cessna.
+    const PORTAL_ID_AIRBUS = 33;
+
+    beforeEach(async () => {
+
+        // Reset the context
+        context = {
+            ...testUtils.createMockContext(),
+            // Routes/plugins specific stubs
+            http: {
+                router: {
+                    register: sinon.stub()
+                }
+            }
+            // v3
+        };
+
+        // Register the routes the same way Appmixer does.
+        await routes(context);
+        // Get the right handler for the POST /events route - our HubSpot triggers.
+        handler = context.http.router.register.getCall(version.startsWith('4') ? 0 : 2).args[0].options.handler;
+        // Stubs common to all tests. v4
+        context.triggerComponent.resolves();
+    });
+
+    if (version.startsWith('4')) {
+        it('call to context.onListenerAdded should register the trigger in HubSpot', async () => {
+
+            // Stub the HTTP requests to HubSpot.
+            // First is to get all webhook subscriptions
+            context.httpRequest.onCall(0).resolves({
+                statusCode: 200,
+                data: {
+                    results: []
+                }
+            });
+            // Second is to create a new webhook subscriptions
+            context.httpRequest.onCall(1).resolves({
+                statusCode: 200
+            });
+
+            const handler = context.onListenerAdded.getCall(0).args[0];
+            await handler(
+                {
+                    eventName: 'contact.creation:33',
+                    url: 'https://api.foo.appmixer.cloud/flows/2fe6d046-aaaa-4375-94f0-7f06c3e22536/components/9929ac7b-aaaa-433a-b654-cba6cec3293a',
+                    params: {
+                        apiKey: 'eu1-aaaa-bbbb-4e82-dddd-22e0d0dd09b6',
+                        appId: '1234585'
+                    }
+                }
+            );
+            assert.equal(context.httpRequest.callCount, 2, 'httpRequest should be called twice');
+        });
+    }
+
+    it('no call to triggerComponent', async () => {
+
+        // The payload contains 2 events for the same user Airbus:
+        // Both events are of type contact.propertyChange that we are not interested in.
+        const req = {
+            payload: [
+                {
+                    eventId: 841732359,
+                    subscriptionId: 2921817,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    propertyName: 'hubspot_owner_id',
+                    propertyValue: '1246609022',
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                },
+                {
+                    eventId: 3114348649,
+                    subscriptionId: 2921816,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    propertyName: 'hubspot_owner_assigneddate',
+                    propertyValue: '1726820305522',
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                }
+            ]
+        };
+
+        // Call the handler with the payload.
+        await handler(req);
+
+        // Assertions
+        // Expecting no calls to triggerListeners.
+        assert.equal(context.triggerListeners.callCount, 0, 'triggerListeners should not be called');
+    });
+
+    it('multiple changes of the same contact in a single event', async () => {
+
+        // Fixtures
+        const PORTAL_ID_AIRBUS = 33;
+        const req = {
+            payload: [
+                // 2x changes that we are not interested in.
+                {
+                    eventId: 841732359,
+                    subscriptionId: 2921817,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    propertyName: 'hubspot_owner_id',
+                    propertyValue: '1246609022',
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                },
+                {
+                    eventId: 3114348649,
+                    subscriptionId: 2921816,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    propertyName: 'hubspot_owner_assigneddate',
+                    propertyValue: '1726820305522',
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                },
+                // 1x change that we are interested in.
+                {
+                    eventId: 3114348649,
+                    subscriptionId: 2921816,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    propertyName: 'firstname',
+                    propertyValue: 'Andrew',
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                },
+                {
+                    eventId: 3114348649,
+                    subscriptionId: 2921816,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.propertyChange',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    propertyName: 'hubspot_owner_assigneddate',
+                    propertyValue: '1726820305522',
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                }
+            ]
+        };
+
+        // Stubs v3
+        context.service.stateGet.onCall(0).returns([
+            { flowId: 'flowA', componentId: 'updated-contact-2' }
+        ]);
+
+        const clock = sinon.useFakeTimers();
+        // Call the handler with the payload.
+        await handler(req);
+
+        // Jump 6 seconds into the future to trigger delayed events
+        await clock.tickAsync(6000);
+
+        // Assertions
+        // Expecting 1 call to triggerListeners, only for the user Airbus.
+        if (version.startsWith('4')) {
+            assert.equal(context.triggerListeners.callCount, 1, 'triggerListeners should be called once');
+        } else {
+            assert.equal(context.triggerComponent.callCount, 1, 'triggerComponent should be called once');
+        }
+
+        // Expecting the call to triggerListeners to be with the correct arguments.
+        if (version.startsWith('4')) {
+            const triggerListenersArgsExpected = [
+                [
+                    {
+                        eventName: `contact.propertyChange:${PORTAL_ID_AIRBUS}`,
+                        payload: { '38533722672': req.payload[2] }
+                    }
+                ]
+            ];
+            assert(
+                context.triggerListeners.calledWith(...triggerListenersArgsExpected[0]),
+                'triggerListeners should be called with the correct arguments'
+            );
+        } else {
+            const triggerComponentArgsExpected = [
+                // flowid, componentid, payload
+                'flowA',
+                'updated-contact-2',
+                {
+                    '38533722672': req.payload[2]
+                }
+            ];
+
+            // Assert flowId
+            assert.equal(
+                context.triggerComponent.getCall(0).args[0],
+                triggerComponentArgsExpected[0],
+                'should be called with correct flowId'
+            );
+            // Assert componentId
+            assert.equal(
+                context.triggerComponent.getCall(0).args[1],
+                triggerComponentArgsExpected[1],
+                'should be called with correct componentId'
+            );
+            // Assert payload
+            assert.deepEqual(
+                context.triggerComponent.getCall(0).args[2],
+                triggerComponentArgsExpected[2],
+                'should be called with correct payload'
+            );
+        }
+    });
+
+    it('CSV import of multiple contacts', async () => {
+
+        // Fixtures
+        const req = {
+            payload: [
+                // 3x new contact
+                {
+                    eventId: 841732359,
+                    subscriptionId: 2921817,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.creation',
+                    attemptNumber: 0,
+                    objectId: 38533722672,
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                },
+                {
+                    eventId: 3114348649,
+                    subscriptionId: 2921816,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.creation',
+                    attemptNumber: 0,
+                    objectId: 38533722673,
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                },
+                {
+                    eventId: 3114348649,
+                    subscriptionId: 2921816,
+                    portalId: PORTAL_ID_AIRBUS,
+                    appId: 2036647,
+                    occurredAt: 1726820305517,
+                    subscriptionType: 'contact.creation',
+                    attemptNumber: 0,
+                    objectId: 38533722674,
+                    changeSource: 'CRM_UI',
+                    sourceId: 'test-unit'
+                }
+            ]
+        };
+
+        // Stubs v3
+        context.service.stateGet.onCall(0).returns([
+            { flowId: 'flowA', componentId: 'updated-contact-2' }
+        ]);
+
+        const clock = sinon.useFakeTimers();
+        // Call the handler with the payload.
+        await handler(req);
+
+        // Jump 6 seconds into the future to trigger delayed events
+        await clock.tickAsync(6000);
+
+        // Assertions
+        if (version.startsWith('4')) {
+            // Expecting 1 call to triggerListeners with 3 new contacts.
+            assert.equal(context.triggerListeners.callCount, 1, 'triggerListeners should be called once');
+            // Expecting the call to triggerListeners to be with the correct arguments.
+            const triggerListenersArgsExpected = [
+                [
+                    {
+                        eventName: `contact.creation:${PORTAL_ID_AIRBUS}`,
+                        payload: {
+                            '38533722672': req.payload[0],
+                            '38533722673': req.payload[1],
+                            '38533722674': req.payload[2]
+                        }
+                    }
+                ]
+            ];
+            assert(
+                context.triggerListeners.calledWith(...triggerListenersArgsExpected[0]),
+                'triggerListeners should be called with the correct arguments'
+            );
+        } else {
+            // Expecting 1 call to triggerComponent with 3 new contacts.
+            assert.equal(context.triggerComponent.callCount, 1, 'triggerComponent should be called 3 times');
+            // Expecting the call to triggerComponent to be with the correct arguments.
+            const triggerComponentArgsExpected = [
+                // flowid, componentid, payload
+                'flowA',
+                'updated-contact-2',
+                {
+                    '38533722672': req.payload[0],
+                    '38533722673': req.payload[1],
+                    '38533722674': req.payload[2]
+                }
+            ];
+            // Assert flowId
+            assert.equal(
+                context.triggerComponent.getCall(0).args[0],
+                triggerComponentArgsExpected[0],
+                'should be called with correct flowId'
+            );
+            // Assert componentId
+            assert.equal(
+                context.triggerComponent.getCall(0).args[1],
+                triggerComponentArgsExpected[1],
+                'should be called with correct componentId'
+            );
+            // Assert payload
+            assert.deepEqual(
+                context.triggerComponent.getCall(0).args[2],
+                triggerComponentArgsExpected[2],
+                'should be called with correct payload'
+            );
+        }
+    });
+});
+


### PR DESCRIPTION
- [x] add suffix when selecting a field in the inspector
- [x] move existing HubSpot tests here

![image](https://github.com/user-attachments/assets/3c76f6cd-7fa1-4c25-8363-9e6712934763)

![image](https://github.com/user-attachments/assets/9575f12a-4e37-41f2-9002-942721ac5f87)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom and additional properties in contact and deal creation and update components.
  - Introduced configurable caching for contact and deal properties.
  - Improved output variables for contact retrieval to match selected input properties.

- **Bug Fixes**
  - Custom property labels are now clearly marked in property lists.

- **Tests**
  - Added comprehensive tests covering new features, caching behavior, event handling, and webhook processing for HubSpot integration.

- **Chores**
  - Updated version and changelog to reflect recent changes.
  - Simplified configuration logic for environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->