### PR TITLE
utils.http (patch) add backward compatibility for `Post` component

### DIFF
--- a/src/appmixer/utils/http/Post/component.json
+++ b/src/appmixer/utils/http/Post/component.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.http.Post",
-    "author": "Tomáš Waldauf <tomas@client.io>",
+    "author": "Appmixer <info@appmixer.com>",
     "description": "This component sends HTTP POST request to external services.",
     "outPorts": [
         {
@@ -52,8 +52,8 @@
                         "group": "transformation",
                         "tooltip": "Data to be send as request body.",
                         "when": {
-                            "eq": {
-                                "./bodyType": "raw"
+                            "nin": {
+                                "./bodyType": ["form-data", "binary"]
                             }
                         }
                     },

--- a/src/appmixer/utils/http/bundle.json
+++ b/src/appmixer/utils/http/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.http",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -29,6 +29,9 @@
         ],
         "1.4.4": [
             "Add response headers to the output of HTTP actions."
+        ],
+        "1.4.5": [
+            "Fixed an issue when updating the component from version 1.3.0 or earlier to 1.4.0 or later would cause the `Post` component loose its `body` input values."
         ]
     }
 }


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2234

- [x] updated `when` condition so that it also works after updating from 1.3.0 and less. Now the value of `body` is not lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where updating from earlier versions could cause the Post component to lose its body input values.
- **Other**
  - Updated author information in component metadata.
  - Adjusted visibility logic for the body input field to improve compatibility with various body types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->