### PR TITLE
Akamai (patch) ActivateList: action property removed from inspector

### DIFF
--- a/src/appmixer/akamai/bundle.json
+++ b/src/appmixer/akamai/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.akamai",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "changelog": {
       "1.0.1": [
           "Initial version"
@@ -15,6 +15,9 @@
       ],
       "1.1.0": [
         "UpsertListEntries, DeleteListEntries: added support for entering IPs in JSON format."
+      ],
+      "1.1.1": [
+        "ActivateList: removed option to select whether Activate or Deactivate the list, now always just activates."
       ]
   }
 }

--- a/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
+++ b/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
@@ -6,10 +6,10 @@ module.exports = {
     async receive(context) {
         const { hostnameUrl, accessToken, clientSecret, clientToken } =
             context.auth;
-        const { listId, action, network, comments } =
+        const { listId, network, comments } =
             context.messages.in.content;
 
-        const body = { action, network, comments };
+        const body = { action: 'ACTIVATE', network, comments };
 
         const {
             url,

--- a/src/appmixer/akamai/clientlist/ActivateList/component.json
+++ b/src/appmixer/akamai/clientlist/ActivateList/component.json
@@ -16,9 +16,6 @@
                     "listId": {
                         "type": "string"
                     },
-                    "action": {
-                        "type": "string"
-                    },
                     "network": {
                         "type": "string"
                     },
@@ -28,7 +25,6 @@
                 },
                 "required": [
                     "listId",
-                    "action",
                     "network"
                 ]
             },
@@ -47,16 +43,6 @@
                                 }
                             }
                         }
-                    },
-                    "action": {
-                        "type": "select",
-                        "label": "Action",
-                        "tooltip": "Actions you can take for the client list.",
-                        "index": 1,
-                        "options": [
-                            { "label": "Activate", "value": "ACTIVATE" },
-                            { "label": "Deactivate", "value": "DEACTIVATE" }
-                        ]
                     },
                     "network": {
                         "type": "select",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the ActivateList action to only perform activation; the option to choose between activation and deactivation has been removed.
- **Chores**
  - Incremented the version number and updated the changelog to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->