### PR TITLE
imperva (patch) add required fields

### DIFF
--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.imperva",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.2": [
             "Imperva"
         ],
         "1.1.0": [
             "Block IPs: added support for entering IPs in JSON format."
+        ],
+        "1.1.1": [
+            "Fields `siteId` and `ruleId` are now required for the `GetRule` and `DeleteRule` components."
         ]
     }
 }

--- a/src/appmixer/imperva/waf/DeleteRule/component.json
+++ b/src/appmixer/imperva/waf/DeleteRule/component.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "appmixer.imperva.waf.DeleteRule",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Delete a rule by ID.",
@@ -15,7 +15,8 @@
                 "properties": {
                     "siteId": { "type": "string" },
                     "ruleId": { "type": "string" }
-                }
+                },
+                "required": ["siteId", "ruleId"]
             },
             "inspector": {
                 "inputs": {

--- a/src/appmixer/imperva/waf/GetRule/component.json
+++ b/src/appmixer/imperva/waf/GetRule/component.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "appmixer.imperva.waf.GetRule",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Get a rule by ID.",
@@ -15,7 +15,8 @@
                 "properties": {
                     "siteId": { "type": "string" },
                     "ruleId": { "type": "string" }
-                }
+                },
+                "required": ["siteId", "ruleId"]
             },
             "inspector": {
                 "inputs": {


### PR DESCRIPTION
Fix for issue 2) from https://github.com/clientIO/appmixer-components/issues/1894#issuecomment-2801992827

Can be a patch change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The fields "siteId" and "ruleId" are now mandatory when using the GetRule and DeleteRule components in the Imperva integration.

- **Documentation**
  - Updated changelog to reflect the new mandatory input requirements for the affected components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->