### PR TITLE
Slack (patch) check `signingSecret` only when not using AuthHub

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "4.1.4",
+    "version": "4.1.5",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -38,8 +38,9 @@
             "Added options to SendChannelMessage and SendPrivateChannelMessage to send messages as a bot user.",
             "Fixed and issue when NewChannelMessageRT trigger did not register messages containing some special UTF characters."
         ],
-        "4.1.4": [
-            "Improve `botToken` handling in SendChannelMessage and SendPrivateChannelMessage components when using the default configuration."
+        "4.1.5": [
+            "Improve `botToken` handling in SendChannelMessage and SendPrivateChannelMessage components when using the default configuration.",
+            "`signingSecret` existence is now checked only when not using the default configuration."
         ]
     }
 }

--- a/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
+++ b/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
@@ -6,11 +6,11 @@ module.exports = {
 
         const componentName = context.flowDescriptor[context.componentId].label || 'New Channel Message';
 
-        if (!context.config?.authToken && !context.config.usesAuthHub) {
+        if (!context.config?.authToken && !context.config?.usesAuthHub) {
             throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "authToken" with a valid Slack App token.`);
         }
 
-        if (!context.config.signingSecret && !context.config.usesAuthHub) {
+        if (!context.config?.signingSecret && !context.config?.usesAuthHub) {
             throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "signingSecret" with a valid Slack App signing secret.`);
         }
 

--- a/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
+++ b/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
@@ -6,11 +6,11 @@ module.exports = {
 
         const componentName = context.flowDescriptor[context.componentId].label || 'New Channel Message';
 
-        if (!context.config?.authToken) {
+        if (!context.config?.authToken && !context.config.usesAuthHub) {
             throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "authToken" with a valid Slack App token.`);
         }
 
-        if (!context.config.signingSecret) {
+        if (!context.config.signingSecret && !context.config.usesAuthHub) {
             throw new Error(`Missing Slack configuration for component: ${componentName}. Please configure the "signingSecret" with a valid Slack App signing secret.`);
         }
 

--- a/test/slack/NewChannelMessageRT.test.js
+++ b/test/slack/NewChannelMessageRT.test.js
@@ -24,16 +24,56 @@ describe('NewChannelMessageRT', () => {
             channelId: 'slack_channel_id'
         };
         context.messages = { webhook: { content: { data: null } } };
+        context.flowDescriptor = {
+            'componentId-1': {
+                label: 'New Channel Message'
+            }
+        };
     });
 
-    it('start', async () => {
+    describe('start', async () => {
 
-        await NewChannelMessageRT.start(context);
+        it('ok', async () => {
 
-        // Assert the listener was added.
-        assert.equal(context.addListener.callCount, 1);
-        const addListenerCall = context.addListener.getCall(0);
-        assert.equal(addListenerCall.args[0], context.properties.channelId);
+            await NewChannelMessageRT.start(context);
+
+            // Assert the listener was added.
+            assert.equal(context.addListener.callCount, 1);
+            const addListenerCall = context.addListener.getCall(0);
+            assert.equal(addListenerCall.args[0], context.properties.channelId);
+        });
+        it('start - missing authToken', async () => {
+
+            context.config.authToken = null;
+
+            try {
+                await NewChannelMessageRT.start(context);
+            } catch (error) {
+                assert.equal(error.message, 'Missing Slack configuration for component: New Channel Message. Please configure the "authToken" with a valid Slack App token.');
+            }
+        });
+        it('start - missing signingSecret', async () => {
+
+            context.config.signingSecret = null;
+
+            try {
+                await NewChannelMessageRT.start(context);
+            } catch (error) {
+                assert.equal(error.message, 'Missing Slack configuration for component: New Channel Message. Please configure the "signingSecret" with a valid Slack App signing secret.');
+            }
+        });
+        it('start - missing signingSecret - AuthHub', async () => {
+
+            context.config.signingSecret = null;
+            context.config.usesAuthHub = true;
+
+            await NewChannelMessageRT.start(context);
+
+            // Assert the listener was added.
+            assert.equal(context.addListener.callCount, 1);
+            const addListenerCall = context.addListener.getCall(0);
+            assert.equal(addListenerCall.args[0], context.properties.channelId);
+        });
     });
 
     it('stop', async () => {

--- a/test/slack/NewChannelMessageRT.test.js
+++ b/test/slack/NewChannelMessageRT.test.js
@@ -52,6 +52,17 @@ describe('NewChannelMessageRT', () => {
                 assert.equal(error.message, 'Missing Slack configuration for component: New Channel Message. Please configure the "authToken" with a valid Slack App token.');
             }
         });
+        it('start - missing authToken - AuthHub', async () => {
+            context.config.authToken = null;
+            context.config.usesAuthHub = true;
+
+            await NewChannelMessageRT.start(context);
+
+            // Assert the listener was added.
+            assert.equal(context.addListener.callCount, 1);
+            const addListenerCall = context.addListener.getCall(0);
+            assert.equal(addListenerCall.args[0], context.properties.channelId);
+        });
         it('start - missing signingSecret', async () => {
 
             context.config.signingSecret = null;


### PR DESCRIPTION
This shouldn't happen when using AuthHub

![image](https://github.com/user-attachments/assets/9a2417c5-bcd3-4a3e-8034-89e1cf8d7e58)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Slack integration bundle version with refined authentication validation rules.
- **Tests**
	- Expanded test coverage for Slack channel message triggers, including scenarios with different authentication configurations and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->