### PR TITLE
HubSpot (fix) Custom properties list all

### DIFF
--- a/src/appmixer/ai/gemini/GenerateEmbeddingsFromFile/GenerateEmbeddingsFromFile.js
+++ b/src/appmixer/ai/gemini/GenerateEmbeddingsFromFile/GenerateEmbeddingsFromFile.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const { Transform } = require('stream');
 const { OpenAI }  = require('openai');
-const { RecursiveCharacterTextSplitter } = require('langchain/text_splitter');
 
 // See https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-input.
 const MAX_INPUT_LENGTH = 8192 * 4; // max 8192 tokens, 1 token ~ 4 characters.
@@ -39,11 +37,11 @@ module.exports = {
 
         const partsStream = lib.splitStream(readStream, FILE_PART_SIZE);
         for await (const part of partsStream) {
-            let {embeddings, firstVector} = await this.generateEmbeddings(context, client, part.toString());
+            let { embeddings, firstVector } = await this.generateEmbeddings(context, client, part.toString());
 
-        if ((!firstVector || firstVector.length === 0) && embeddings.length > 0) {
-            firstVector = embeddings[0].vector;
-        }
+            if ((!firstVector || firstVector.length === 0) && embeddings.length > 0) {
+                firstVector = embeddings[0].vector;
+            }
             await outputFunction({ embeddings, firstVector });
         }
     },

--- a/src/appmixer/ai/gemini/lib.js
+++ b/src/appmixer/ai/gemini/lib.js
@@ -6,8 +6,6 @@ const { RecursiveCharacterTextSplitter } = require('langchain/text_splitter');
 const MAX_INPUT_LENGTH = 8192 * 4; // max 8192 tokens, 1 token ~ 4 characters.
 const MAX_BATCH_SIZE = 2048;
 
-const FILE_PART_SIZE = 1024 * 1024; // 1MB
-
 module.exports = {
 
     extractBaseModelId: function(modelName) {

--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -58,7 +58,7 @@
             "Removed webhook subscribing when using AuthHub.",
             "Fixed an issue when HubSpot webhook was not automatically created when using own API key."
         ],
-        "4.1.2": [
+        "4.1.3": [
             "Fixed an issue when the `CreateDeal` component was showing error `resource not found`.",
             "Added custom properties and additional properties to the following components: `CreateContact`, `CreateDeal`, `UpdateContact` and `UpdateDeal`. Custom properties are new properties that are not part of the default HubSpot properties. Additional properties default HubSpot properties but were not part of the default properties list before.",
             "Added caching of Contact and Deal properties, which can be further configured in the connector settings.",

--- a/src/appmixer/hubspot/crm/GetContactsProperties/GetContactsProperties.js
+++ b/src/appmixer/hubspot/crm/GetContactsProperties/GetContactsProperties.js
@@ -23,10 +23,10 @@ module.exports = {
         return context.sendJson(properties, 'out');
     },
 
-    /** Returns properties that not hardcoded into the component. Both custom and HubSpot properties. */
+    /** Returns properties that are not hardcoded into the component. Both custom and HubSpot properties. */
     additionalFieldsToSelectArray(contactsProperties) {
+
         return contactsProperties
-            .filter((property) => property.formField)
             .filter((property) => !WATCHED_PROPERTIES_CONTACT.includes(property.name))
             .map((property) => {
                 return { label: property.label, value: property.name };

--- a/src/appmixer/hubspot/crm/GetDealsProperties/GetDealsProperties.js
+++ b/src/appmixer/hubspot/crm/GetDealsProperties/GetDealsProperties.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const Hubspot = require('../../Hubspot');
 const { getObjectProperties, WATCHED_PROPERTIES_DEAL } = require('../../commons');
 
@@ -65,11 +66,10 @@ module.exports = {
         return inspector;
     },
 
-    /** Returns properties that not hardcoded into the component. Both custom and HubSpot properties. */
+    /** Returns properties that are not hardcoded into the component. Both custom and HubSpot properties. */
     additionalFieldsToSelectArray(dealsProperties) {
 
         return dealsProperties
-            .filter((property) => property.formField)
             .filter((property) => !WATCHED_PROPERTIES_DEAL.includes(property.name))
             .map((property) => {
                 return { label: property.label, value: property.name };

--- a/test/hubspot/GetContactsProperties.test.js
+++ b/test/hubspot/GetContactsProperties.test.js
@@ -88,7 +88,7 @@ describe('GetContactsProperties', () => {
                     label: 'jirka some hidden stuff',
                     type: 'string',
                     fieldType: 'text',
-                    description: 'This should not be in inspector',
+                    description: 'This is not visible in the HubSpot UI',
                     createdUserId: '71561347',
                     displayOrder: -1,
                     hidden: false,
@@ -120,7 +120,7 @@ describe('GetContactsProperties', () => {
             // eslint-disable-next-line max-len
             const additionalFieldsSelectArray = await GetContactsProperties.additionalFieldsToSelectArray(mockedResponse);
 
-            assert.equal(additionalFieldsSelectArray.length, 3, 'Should return custom and HubSpot fields');
+            assert.equal(additionalFieldsSelectArray.length, 4, 'Should return custom and HubSpot fields');
             assert.equal(additionalFieldsSelectArray[0].label, 'Jirka Notes', 'Should return only custom fields');
         });
     });

--- a/test/hubspot/GetDealsProperties.test.js
+++ b/test/hubspot/GetDealsProperties.test.js
@@ -84,7 +84,7 @@ describe('GetDealsProperties', () => {
                     label: 'jirka some hidden stuff',
                     type: 'string',
                     fieldType: 'text',
-                    description: 'This should not be in inspector',
+                    description: 'This should not be in the HubSpot UI',
                     createdUserId: '71561347',
                     displayOrder: -1,
                     hidden: false,
@@ -115,7 +115,7 @@ describe('GetDealsProperties', () => {
 
             const customFieldsSelectArray = await GetDealsProperties.additionalFieldsToSelectArray(mockedResponse);
 
-            assert.equal(customFieldsSelectArray.length, 1, 'Should return only custom fields');
+            assert.equal(customFieldsSelectArray.length, 2, 'Should return one custom fields');
             assert.equal(customFieldsSelectArray[0].label, 'Jirka Notes', 'Should return only custom fields');
         });
     });


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/1783#issuecomment-2827038044

The problem was that all Deals properties had `"formField": false`.

Additional properties are now all that are not hardcoded in the inspector - even hidden or ones that are not in HubSpot forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a "resource not found" error in the CreateDeal action for HubSpot integration.

- **New Features**
  - Added support for custom and additional properties in CreateContact, CreateDeal, UpdateContact, and UpdateDeal actions.
  - Enabled caching of Contact and Deal properties with configurable options in connector settings.
  - Improved output variables in GetContact to match selected input properties.

- **Tests**
  - Updated tests to reflect changes in visible and selectable custom fields for contacts and deals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->