### PR TITLE
Pinecone (patch) fix transformation tooltip

### DIFF
--- a/src/appmixer/pinecone/bundle.json
+++ b/src/appmixer/pinecone/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pinecone",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -10,6 +10,9 @@
         ],
         "1.0.2": [
             "CreateIndex: Serverless Cloud and Region fields are now trimmed upon start."
+        ],
+        "1.0.3": [
+            "QueryVectors: Fixed example for the 'Result Transformation JSONata' field."
         ]
     }
 }

--- a/src/appmixer/pinecone/database/QueryVectors/component.json
+++ b/src/appmixer/pinecone/database/QueryVectors/component.json
@@ -79,7 +79,7 @@
                         "type": "textarea",
                         "index": 8,
                         "label": "Result Transformation JSONata",
-                        "tooltip": "<a href=_blank href=\"https://jsonata.org/\">JSONata</a> transformation expression that will be used to transform the resulting array. This is a convenience feature to aggregate metadata fields across the results to, for example, feed as a context to an LLM model.<br/>For example, if the 'text' metadata field is set and the following JSONata expression is used, the result will contain a string that is the concatenation of the 'text' field of the top K results.<br/><code>$join(matches.metadata.text), \"\\n\")</code>.<br/>If your metadata contains two fields (e.g. 'text' and 'doc') that you'd like to concatenate, you can use the following expression:<br/><code>$join(matches.metadata.(doc & \";\" & text), \"\\n\")</code>."
+                        "tooltip": "<a href=_blank href=\"https://jsonata.org/\">JSONata</a> transformation expression that will be used to transform the resulting array. This is a convenience feature to aggregate metadata fields across the results to, for example, feed as a context to an LLM model.<br/>For example, if the 'text' metadata field is set and the following JSONata expression is used, the result will contain a string that is the concatenation of the 'text' field of the top K results.<br/><code>$join(matches.metadata.(text), \"\\n\")</code>.<br/>If your metadata contains two fields (e.g. 'text' and 'doc') that you'd like to concatenate, you can use the following expression:<br/><code>$join(matches.metadata.(doc & \";\" & text), \"\\n\")</code>."
                     }
                 }
             }


### PR DESCRIPTION
### Error when using example value
```
$join(matches.metadata.text), "\n")
```

![image](https://github.com/user-attachments/assets/f470b417-dcb0-4e5b-a14c-6bd071e9e881)

![image](https://github.com/user-attachments/assets/d529d1c7-f89f-4a2d-966d-63481b0d329d)

### Correct value

```
$join(matches.metadata.(text), "\n")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the example expression in the tooltip for the "Result Transformation JSONata" field within the QueryVectors feature to resolve a syntax error and improve clarity.

- **Documentation**
  - Updated the changelog to reflect the fix and incremented the version number for the related bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->