### PR TITLE
Google.Gmail.NewEmail (patch) Added output port option of Sender Email

### DIFF
--- a/src/appmixer/google/gmail/NewEmail/component.json
+++ b/src/appmixer/google/gmail/NewEmail/component.json
@@ -80,17 +80,6 @@
                             "subject": { "type": "string", "title": "Email Subject" },
                             "text": { "type": "string", "title": "Email Text" },
                             "html": { "type": "string", "title": "Email HTML" },
-                            "from": {
-                                "type": "array",
-                                "title": "Email Senders",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "address": { "type": "string" },
-                                        "name": { "type": "string" }
-                                    }
-                                }
-                            },
                             "to": {
                                 "type": "array",
                                 "title": "Email Recipients",
@@ -104,6 +93,16 @@
                             }
                         }
                     }
+                },
+                {
+                    "label": "Sender's Email Address",
+                    "value": "payload.from.[0].address",
+                    "schema": { "type": "string" }
+                },
+                {
+                    "label": "Sender's Name",
+                    "value": "payload.from.[0].name",
+                    "schema": { "type": "string" }
                 },
                 {
                     "label": "Attachments",

--- a/src/appmixer/google/gmail/NewEmail/component.json
+++ b/src/appmixer/google/gmail/NewEmail/component.json
@@ -80,6 +80,17 @@
                             "subject": { "type": "string", "title": "Email Subject" },
                             "text": { "type": "string", "title": "Email Text" },
                             "html": { "type": "string", "title": "Email HTML" },
+                            "from": {
+                                "type": "array",
+                                "title": "Email Senders",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "address": { "type": "string" },
+                                        "name": { "type": "string" }
+                                    }
+                                }
+                            },
                             "to": {
                                 "type": "array",
                                 "title": "Email Recipients",

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -49,6 +49,9 @@
             "Moving auth.js from googleapis to httpRequest, improving tooltips and marking fields required",
             "Adding index and total messages count in the output port options of FindEmails",
             "Renamed GetAttachment to DownloadAttachment"
+        ],
+        "2.0.7": [
+            "NewEmail Trigger - Added output port label for Sender's email address and name"
         ]
         
         


### PR DESCRIPTION
Added output port options of sender email and sender name (previously they were inside an array called Email Senders)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Gmail NewEmail trigger now provides separate output fields for the sender's email address and name, making it easier to access this information directly.

- **Chores**
  - Updated the Gmail integration version and changelog to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->