### PR TITLE
ai.claude (patch) Fix using properties in tools

### DIFF
--- a/src/appmixer/ai/claude/bundle.json
+++ b/src/appmixer/ai/claude/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.ai.claude",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
-        "1.0.1": [
+        "1.0.2": [
             "Initial version"
         ]
     }

--- a/src/appmixer/ai/claude/lib.js
+++ b/src/appmixer/ai/claude/lib.js
@@ -105,6 +105,10 @@ module.exports = {
                     description: parameter.description
                 };
             });
+            const description = component.config.properties?.description;
+            if (!description) {
+                throw new Error(`Component ${componentId} does not have a description.`);
+            }
             const functionDeclaration = {
                 name: 'function_' + componentId,
                 description: component.config.properties.description,

--- a/src/appmixer/ai/claude/lib.js
+++ b/src/appmixer/ai/claude/lib.js
@@ -96,6 +96,10 @@ module.exports = {
                 properties: {}
             };
             parameters.forEach((parameter) => {
+                // Each parameter name must match /^[a-zA-Z0-9_-]{1,64}$/, see https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/implement-tool-use#example-of-a-good-tool-description
+                if (!/^[a-zA-Z0-9_-]{1,64}$/.test(parameter.name)) {
+                    throw new Error(`Parameter name '${parameter.name}' in component ${componentId} does not match the required pattern.`);
+                }
                 functionParameters.properties[parameter.name] = {
                     type: parameter.type,
                     description: parameter.description
@@ -106,9 +110,6 @@ module.exports = {
                 description: component.config.properties.description,
                 input_schema: functionParameters
             };
-            if (parameters.length) {
-                functionDeclaration.parameters = functionParameters;
-            }
             functionDeclarations.push(functionDeclaration);
         });
         return functionDeclarations;


### PR DESCRIPTION
Closes https://github.com/clientIO/appmixer-components/issues/2265

### Checking tool description
Must be a string. Can't be `null` or empty.

### Checking tool property name format

When the name is not [valid for Anthropic API](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/implement-tool-use#example-of-a-good-tool-description), the flow will not start

![image](https://github.com/user-attachments/assets/97b792eb-be7b-415a-9917-df3d91827207)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation to ensure parameter names follow the required format and descriptions are present, improving error handling.

- **Chores**
  - Updated bundle version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->