### PR TITLE
NEXL (patch) CreateTask Tooltip and Error message added

### DIFF
--- a/src/appmixer/nexl/core/CreateTask/CreateTask.js
+++ b/src/appmixer/nexl/core/CreateTask/CreateTask.js
@@ -45,8 +45,8 @@ module.exports = {
             data: { query: mutation, variables }
         });
 
-        if (data.errors) {
-            throw new context.CancelError(data.errors);
+        if (data.data.createTask.failReasons && data.data.createTask.failReasons.length > 0) {
+            throw new context.CancelError(data.data.createTask.failReasons.join(', '));
         }
 
         return context.sendJson(data.data.createTask.record, 'out');

--- a/src/appmixer/nexl/core/CreateTask/component.json
+++ b/src/appmixer/nexl/core/CreateTask/component.json
@@ -46,7 +46,7 @@
                     "assignedToUid": {
                         "type": "text",
                         "label": "Assignee Uid",
-                        "tooltip": "Assignee of the task.",
+                        "tooltip": "Assignee of the task. You can add any employee UID here. If you want to assign the task to the creator of a list, use Get List Details and map the Creator Uid to this field.",
                         "index": 2
                     }
                 }

--- a/src/appmixer/nexl/core/NewContactInList/component.json
+++ b/src/appmixer/nexl/core/NewContactInList/component.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.nexl.core.NewContactInList",
-    "label": "new Contact",
+    "label": "New Contact",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Triggers when new contacts are added in a list.",
     "private": false,

--- a/src/appmixer/nexl/core/bundle.json
+++ b/src/appmixer/nexl/core/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.nexl",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when creating a task by displaying specific failure reasons instead of generic errors.

- **Documentation**
  - Expanded the tooltip for the task assignee field to provide clearer instructions on how to assign tasks, including mapping to a list creator.
  - Updated the label for the "New Contact" component for consistent formatting.

- **Chores**
  - Bumped the version number to 1.0.1 in the manifest and changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->