### PR TITLE
AWS S3 (patch) Bucket can be entered as string

### DIFF
--- a/src/appmixer/aws/auth.js
+++ b/src/appmixer/aws/auth.js
@@ -32,7 +32,20 @@ module.exports = {
             });
 
             const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
-            return s3.listBuckets().promise();
+            try {
+                await s3.listBuckets().promise();
+            } catch (err) {
+                // If the error is:
+                //  User is not authorized to perform: s3:ListAllMyBuckets because no identity-based policy allows the s3:ListAllMyBuckets action
+                // we can continue, as the user may not have permissions to list buckets.
+                // This permission is not required for most operations.
+                if (err.code === 'AccessDenied' && err.message.includes('s3:ListAllMyBuckets')) {
+                    return;
+                }
+
+                // Otherwise, throw the error.
+                throw err;
+            }
         }
     }
 };

--- a/src/appmixer/aws/s3/DeleteBucket/component.json
+++ b/src/appmixer/aws/s3/DeleteBucket/component.json
@@ -20,7 +20,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/DeleteObject/component.json
+++ b/src/appmixer/aws/s3/DeleteObject/component.json
@@ -22,7 +22,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/DeletedObject/component.json
+++ b/src/appmixer/aws/s3/DeletedObject/component.json
@@ -32,7 +32,7 @@
                     }
                 },
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 2,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/GetFileObject/component.json
+++ b/src/appmixer/aws/s3/GetFileObject/component.json
@@ -22,7 +22,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/GetObject/component.json
+++ b/src/appmixer/aws/s3/GetObject/component.json
@@ -22,7 +22,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/GetSignedUrl/component.json
+++ b/src/appmixer/aws/s3/GetSignedUrl/component.json
@@ -24,7 +24,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/ListBuckets/ListBuckets.js
+++ b/src/appmixer/aws/s3/ListBuckets/ListBuckets.js
@@ -12,16 +12,24 @@ module.exports = {
         const { sendWholeArray } = context.properties;
 
         const { s3 } = commons.init(context);
-        const { Buckets } = await s3.listBuckets().promise();
+        try {
+            const { Buckets } = await s3.listBuckets().promise();
 
-        if (sendWholeArray) {
-            return context.sendJson(Buckets, 'bucket');
-        } else {
-            const promises = [];
-            Buckets.forEach(bucket => {
-                promises.push(context.sendJson(bucket, 'bucket'));
-            });
-            return Promise.all(promises);
+            if (sendWholeArray) {
+                return context.sendJson(Buckets, 'bucket');
+            } else {
+                const promises = [];
+                Buckets.forEach(bucket => {
+                    promises.push(context.sendJson(bucket, 'bucket'));
+                });
+                return Promise.all(promises);
+            }
+        } catch (err) {
+            if (sendWholeArray) {
+                // When used as a source, return an empty array on error or insufficient permissions.
+                return context.sendJson([], 'bucket');
+            }
+            throw err;
         }
     },
 

--- a/src/appmixer/aws/s3/ListBuckets/component.json
+++ b/src/appmixer/aws/s3/ListBuckets/component.json
@@ -1,6 +1,7 @@
 {
     "name": "appmixer.aws.s3.ListBuckets",
-    "author": "Jimoh Damilola <jimoh@client.io>",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "1.0.1",
     "description": "Return list of buckets created on AWS S3.",
     "private": false,
     "auth": {

--- a/src/appmixer/aws/s3/NewObject/component.json
+++ b/src/appmixer/aws/s3/NewObject/component.json
@@ -32,7 +32,7 @@
                     }
                 },
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 2,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/PutContent/component.json
+++ b/src/appmixer/aws/s3/PutContent/component.json
@@ -32,7 +32,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/PutObject/component.json
+++ b/src/appmixer/aws/s3/PutObject/component.json
@@ -33,7 +33,7 @@
         "inspector": {
             "inputs": {
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 1,
                     "tooltip": "Your AWS S3 Bucket",

--- a/src/appmixer/aws/s3/UpdatedObject/component.json
+++ b/src/appmixer/aws/s3/UpdatedObject/component.json
@@ -32,7 +32,7 @@
                     }
                 },
                 "bucket": {
-                    "type": "select",
+                    "type": "text",
                     "label": "Bucket",
                     "index": 2,
                     "tooltip": "Your AWS S3 Bucket.",

--- a/src/appmixer/aws/s3/bundle.json
+++ b/src/appmixer/aws/s3/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.aws.s3",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -11,6 +11,10 @@
         "1.0.3": [
             "Fixed a bug with initializing the SNS and S3 clients for triggers.",
             "Fixed S3.NewObject, S3.DeletedObject and S3.UpdatedObject for non-versioned buckets and also object keys with spaces."
+        ],
+        "1.0.4": [
+            "Connecting to S3 no longer requires the `s3:ListAllMyBuckets` permission.",
+            "Bucket name in all components can now be specified as a string. The previous behavior remains: If the account has s3:ListAllMyBuckets permission, the bucket name can also be selected from a list of buckets."
         ]
     }
 }


### PR DESCRIPTION
- [x] `s3:ListAllMyBuckets` is no longer required
- [x] return empty array when s3.listBuckets() fails with missing permissions when used as a source
- [x] change the bucket selection to text in every component