### PR TITLE
Imperva (fix) handle missing rule_id

### DIFF
--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.imperva",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "changelog": {
         "1.0.2": [
             "Imperva"
@@ -10,6 +10,9 @@
         ],
         "1.1.1": [
             "Fields `siteId` and `ruleId` are now required for the `GetRule` and `DeleteRule` components."
+        ],
+        "1.1.2": [
+            "Fixed an issue when the Block IPs did not fail properly when error response was received from Imperva."
         ]
     }
 }

--- a/src/appmixer/imperva/routes.js
+++ b/src/appmixer/imperva/routes.js
@@ -201,6 +201,10 @@ module.exports = (context, options) => {
             }
         });
 
+        if (!data?.rule_id) {
+            throw new Error('Imperva API did not return a rule ID when creating a new rule. Response: ' + JSON.stringify(data));
+        }
+
         processed.push(...ips.map(ip => ({ ruleId: data.rule_id, ip })));
 
         const rule = { ...data, siteId, batch: order };


### PR DESCRIPTION
- [x] ensure that when creating a rule in Imperva, it always returns `rule_id`. Fail properly if not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for the Block IPs feature to properly manage failure cases when receiving unexpected responses from Imperva.

- **Tests**
  - Added a test to verify correct behavior when the Imperva API returns a custom, non-standard response, ensuring only valid IPs are processed and errors are handled gracefully.

- **Chores**
  - Updated version and changelog to reflect the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->