### PR TITLE
Imperva (fix) Use `|` in filters

### DIFF
--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -15,7 +15,7 @@
             "Fixed an issue when the Block IPs did not fail properly when error response was received from Imperva."
         ],
         "1.1.3": [
-            "Fixed an issue when filter for `ClientIP` contained '& character instead of '|' character when there were multiple IPs."
+            "Fixed an issue when filter for `ClientIP` contained '&' character instead of '|' character when there were multiple IPs."
         ]
     }
 }

--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.imperva",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "changelog": {
         "1.0.2": [
             "Imperva"
@@ -13,6 +13,9 @@
         ],
         "1.1.2": [
             "Fixed an issue when the Block IPs did not fail properly when error response was received from Imperva."
+        ],
+        "1.1.3": [
+            "Fixed an issue when filter for `ClientIP` contained '& character instead of '|' character when there were multiple IPs."
         ]
     }
 }

--- a/src/appmixer/imperva/jobs.js
+++ b/src/appmixer/imperva/jobs.js
@@ -122,7 +122,7 @@ module.exports = async (context) => {
                                 };
                                 return context.httpRequest(params);
                             } else {
-                                const filter = rule.ipsToKeepBlocking.map(ip => `ClientIP == ${ip}`).join(' & ');
+                                const filter = rule.ipsToKeepBlocking.map(ip => `ClientIP == ${ip}`).join(' | ');
                                 const params = {
                                     headers: getAuthHeader(rule.auth),
                                     url: `${baseUrl}/v2/sites/${siteId}/rules/${rule.ruleId}`,

--- a/src/appmixer/imperva/routes.js
+++ b/src/appmixer/imperva/routes.js
@@ -188,7 +188,7 @@ module.exports = (context, options) => {
 
     async function createRule(auth, siteId, ips, ruleName, order, processed = []) {
 
-        const filter = ips.map(ip => `ClientIP == ${ip}`).join(' & ');
+        const filter = ips.map(ip => `ClientIP == ${ip}`).join(' | ');
 
         const { data } = await context.httpRequest({
             headers: getAuthHeader(auth),
@@ -214,7 +214,7 @@ module.exports = (context, options) => {
 
     async function updateRule(auth, siteId, ruleId, ruleName, ips, processed = [], allNewIPs) {
 
-        const filter = ips.map(ip => `ClientIP == ${ip}`).join(' & ');
+        const filter = ips.map(ip => `ClientIP == ${ip}`).join(' | ');
 
         const { data } = await context.httpRequest({
             headers: getAuthHeader(auth),

--- a/test/imperva/routes.test.js
+++ b/test/imperva/routes.test.js
@@ -117,14 +117,14 @@ describe('POST /rules-block-ips handler', () => {
                 ...IMPERVA_RULES_RESPONSE,
                 rule_id: 13642,
                 name: IMPERVA_RULES_RESPONSE.name + '1',
-                filter: IPS.slice(0, 20).map(ip => `ClientIP == ${ip}`).join(' & ')
+                filter: IPS.slice(0, 20).map(ip => `ClientIP == ${ip}`).join(' | ')
             } });
             // Stub the 2nd API call to Imperva to create 1 rule.
             context.httpRequest.onCall(2).resolves({ data: {
                 ...IMPERVA_RULES_RESPONSE,
                 rule_id: 13643,
                 name: IMPERVA_RULES_RESPONSE.name + '2',
-                filter: IPS.slice(20).map(ip => `ClientIP == ${ip}`).join(' & ')
+                filter: IPS.slice(20).map(ip => `ClientIP == ${ip}`).join(' | ')
             } });
 
             // The payload contains 21 new IPs.
@@ -671,7 +671,7 @@ describe('POST /rules-block-ips handler', () => {
                 ...IMPERVA_RULES_RESPONSE,
                 rule_id: 43642,
                 name: IMPERVA_RULES_RESPONSE.name + '1',
-                filter: IPS.slice(0, 20).map(ip => `ClientIP == ${ip}`).join(' & ')
+                filter: IPS.slice(0, 20).map(ip => `ClientIP == ${ip}`).join(' | ')
             }
         });
         // Stub the 2nd API call to Imperva to return the custom object.

--- a/test/imperva/routes.test.js
+++ b/test/imperva/routes.test.js
@@ -216,13 +216,13 @@ describe('POST /rules-block-ips handler', () => {
                 ...IMPERVA_RULES_RESPONSE_PUT,
                 rule_id: 23642,
                 name: IMPERVA_RULES_RESPONSE_PUT.name + '1',
-                filter: EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' & ')
+                filter: EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' | ')
             } });
             context.httpRequest.onCall(2).resolves({ data: {
                 ...IMPERVA_RULES_RESPONSE_PUT,
                 rule_id: 23643,
                 name: IMPERVA_RULES_RESPONSE_PUT.name + '2',
-                filter: EXISTING_IPS.slice(19).concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' & ')
+                filter: EXISTING_IPS.slice(19).concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' | ')
             } });
 
             // The payload contains 1 new IP.
@@ -283,7 +283,7 @@ describe('POST /rules-block-ips handler', () => {
             assert.equal(httpRequest1Args.headers['x-API-Key'], AUTH.key);
             assert.match(httpRequest1Args.data.name, /Custom IP Block Rule \d+/);
             assert.equal(httpRequest1Args.data.action, 'RULE_ACTION_BLOCK');
-            assert.equal(httpRequest1Args.data.filter, EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' & '));
+            assert.equal(httpRequest1Args.data.filter, EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' | '));
             // Assert 2nd update call.
             const httpRequest2Args = context.httpRequest.getCall(2).args[0];
             assert.match(httpRequest2Args.url, /v2\/sites\/\d+\/rules\/\d+$/);
@@ -291,7 +291,7 @@ describe('POST /rules-block-ips handler', () => {
             assert.equal(httpRequest2Args.headers['x-API-Key'], AUTH.key);
             assert.match(httpRequest2Args.data.name, /Custom IP Block Rule \d+/);
             assert.equal(httpRequest2Args.data.action, 'RULE_ACTION_BLOCK');
-            assert.equal(httpRequest2Args.data.filter, EXISTING_IPS.slice(19).concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' & '));
+            assert.equal(httpRequest2Args.data.filter, EXISTING_IPS.slice(19).concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' | '));
         });
 
         it('2 blocked IPs in 1 rule, adding 1 new IP and one existing IP', async () => {
@@ -327,7 +327,7 @@ describe('POST /rules-block-ips handler', () => {
                 ...IMPERVA_RULES_RESPONSE_PUT,
                 rule_id: 82938,
                 name: IMPERVA_RULES_RESPONSE_PUT.name + '1',
-                filter: EXISTING_IPS.concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' & ')
+                filter: EXISTING_IPS.concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' | ')
             } });
 
             // The payload contains 1 new IP.
@@ -374,7 +374,7 @@ describe('POST /rules-block-ips handler', () => {
             assert.equal(httpRequestArgs.headers['x-API-Key'], AUTH.key);
             assert.match(httpRequestArgs.data.name, /Custom IP Block Rule \d+/);
             assert.equal(httpRequestArgs.data.action, 'RULE_ACTION_BLOCK');
-            assert.equal(httpRequestArgs.data.filter, EXISTING_IPS.concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' & '));
+            assert.equal(httpRequestArgs.data.filter, EXISTING_IPS.concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' | '));
         });
 
         it('1000 new IPs, 100 existing rules with 19 IPs each', async () => {
@@ -409,7 +409,7 @@ describe('POST /rules-block-ips handler', () => {
                     ...IMPERVA_RULES_RESPONSE_PUT,
                     rule_id: 23642 + i,
                     name: IMPERVA_RULES_RESPONSE_PUT.name + (i + 1),
-                    filter: EXISTING_IPS.slice(i * 19, (i + 1) * 19).concat(NEW_IPS.slice(i, i + 1)).map(ip => `ClientIP == ${ip}`).join(' & ')
+                    filter: EXISTING_IPS.slice(i * 19, (i + 1) * 19).concat(NEW_IPS.slice(i, i + 1)).map(ip => `ClientIP == ${ip}`).join(' | ')
                 } });
             }
             // Stub 50 API calls to Imperva to create 50 rules. 50x20 = 1000 new IPs.
@@ -418,7 +418,7 @@ describe('POST /rules-block-ips handler', () => {
                     ...IMPERVA_RULES_RESPONSE_PUT,
                     rule_id: 23642 + i,
                     name: IMPERVA_RULES_RESPONSE_PUT.name + (i + 1),
-                    filter: NEW_IPS.slice(i * 20, (i + 1) * 20).map(ip => `ClientIP == ${ip}`).join(' & ')
+                    filter: NEW_IPS.slice(i * 20, (i + 1) * 20).map(ip => `ClientIP == ${ip}`).join(' | ')
                 } });
             }
 
@@ -464,7 +464,7 @@ describe('POST /rules-block-ips handler', () => {
                     ...IMPERVA_RULES_RESPONSE,
                     rule_id: 43642,
                     name: IMPERVA_RULES_RESPONSE.name + '1',
-                    filter: IPS.slice(0, 20).map(ip => `ClientIP == ${ip}`).join(' & ')
+                    filter: IPS.slice(0, 20).map(ip => `ClientIP == ${ip}`).join(' | ')
                 }
             });
             // Stub the 2nd API call to Imperva to return an error.
@@ -557,7 +557,7 @@ describe('POST /rules-block-ips handler', () => {
                     ...IMPERVA_RULES_RESPONSE_PUT,
                     rule_id: 43642,
                     name: IMPERVA_RULES_RESPONSE_PUT.name + '1',
-                    filter: EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' & ')
+                    filter: EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' | ')
                 }
             });
             // Stub the 2nd API call to Imperva to return an error.
@@ -606,7 +606,7 @@ describe('POST /rules-block-ips handler', () => {
             assert.equal(httpRequest1Args.headers['x-API-Key'], AUTH.key);
             assert.match(httpRequest1Args.data.name, /Custom IP Block Rule \d+/);
             assert.equal(httpRequest1Args.data.action, 'RULE_ACTION_BLOCK');
-            assert.equal(httpRequest1Args.data.filter, EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' & '));
+            assert.equal(httpRequest1Args.data.filter, EXISTING_IPS.slice(0, 19).concat(NEW_IPS.slice(0, 1)).map(ip => `ClientIP == ${ip}`).join(' | '));
             // Assert 2nd update call.
             const httpRequest2Args = context.httpRequest.getCall(2).args[0];
             assert.match(httpRequest2Args.url, /v2\/sites\/\d+\/rules\/\d+$/);
@@ -614,7 +614,7 @@ describe('POST /rules-block-ips handler', () => {
             assert.equal(httpRequest2Args.headers['x-API-Key'], AUTH.key);
             assert.match(httpRequest2Args.data.name, /Custom IP Block Rule \d+/);
             assert.equal(httpRequest2Args.data.action, 'RULE_ACTION_BLOCK');
-            assert.equal(httpRequest2Args.data.filter, EXISTING_IPS.slice(19).concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' & '));
+            assert.equal(httpRequest2Args.data.filter, EXISTING_IPS.slice(19).concat(NEW_IPS.slice(1)).map(ip => `ClientIP == ${ip}`).join(' | '));
         });
     });
 

--- a/test/imperva/routes.test.js
+++ b/test/imperva/routes.test.js
@@ -738,7 +738,7 @@ describe('POST /rules-block-ips handler', () => {
         assert.equal(httpRequestArgs1.headers['x-API-Key'], AUTH.key);
         assert.match(httpRequestArgs1.data.name, /Custom IP Block Rule \d+ 1/);
         assert.equal(httpRequestArgs1.data.action, 'RULE_ACTION_BLOCK');
-        assert.match(httpRequestArgs1.data.filter, /ClientIP == 1\.1\.1\.1/);
+        assert.match(httpRequestArgs1.data.filter, /ClientIP == 1\.1\.1\.1 \| ClientIP == 1.1\.1\.2/);
         assert.match(httpRequestArgs1.data.filter, /ClientIP == 1\.1\.1\.20/);
         // Second call
         const httpRequestArgs2 = context.httpRequest.getCall(2).args[0];


### PR DESCRIPTION
In order for the custom rule to work properly with multiply IPs, the IP conditions needs to be connected by `|` (or) not `&` (and). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where filtering by multiple IP addresses used an incorrect logical operator, ensuring that multiple IPs are now combined with "OR" instead of "AND" in rule filters.
- **Tests**
  - Updated test cases to validate the correct use of the "OR" operator when handling multiple IP addresses in filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->