### PR TITLE
Raynet API is no longer supporting authentication using password

### DIFF
--- a/src/appmixer/raynet/auth.js
+++ b/src/appmixer/raynet/auth.js
@@ -19,10 +19,10 @@ module.exports = {
                     name: 'Email',
                     tooltip: 'Your Raynet email.'
                 },
-                password: {
+                apiKey: {
                     type: 'password',
-                    name: 'Password',
-                    tooltip: 'Password to your account.'
+                    name: 'API Key',
+                    tooltip: 'API Key for your account (associated with your email).'
                 },
                 instanceName: {
                     type: 'text',
@@ -33,7 +33,7 @@ module.exports = {
 
             validate: context => {
 
-                let authData = new Buffer(`${context.login}:${context.password}`).toString('base64');
+                let authData = new Buffer(`${context.login}:${context.apiKey}`).toString('base64');
 
                 return request({
                     method: 'GET',

--- a/src/appmixer/raynet/bundle.json
+++ b/src/appmixer/raynet/bundle.json
@@ -1,7 +1,8 @@
 {
     "name": "appmixer.raynet",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": [
-        "Initial version"
+        "Initial version",
+        "Authentication with API key instead of password"
     ]
 }

--- a/src/appmixer/raynet/bundle.json
+++ b/src/appmixer/raynet/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.raynet",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "changelog": [
         "Initial version",
         "Authentication with API key instead of password"

--- a/src/appmixer/raynet/bundle.json
+++ b/src/appmixer/raynet/bundle.json
@@ -1,8 +1,12 @@
 {
     "name": "appmixer.raynet",
     "version": "2.0.0",
-    "changelog": [
-        "Initial version",
-        "Authentication with API key instead of password"
-    ]
+    "changelog": {
+        "1.0.0": [
+            "Initial version."
+        ],
+        "2.0.0": [
+            "(Breaking change) Authentication with API key instead of password."
+        ]
+    }
 }

--- a/src/appmixer/raynet/raynet-commons.js
+++ b/src/appmixer/raynet/raynet-commons.js
@@ -47,7 +47,7 @@ const createAggregator = function(fetchFunction) {
  */
 const personsAggregator = createAggregator(args => {
 
-    const credentials = `${args.authOptions.login}:${args.authOptions.password}`;
+    const credentials = `${args.authOptions.login}:${args.authOptions.apiKey}`;
     let authData = new Buffer(credentials).toString('base64');
     let qs = {
         offset: args.offset,
@@ -94,7 +94,7 @@ module.exports = {
      */
     raynetAPI(authOptions, endpoint, method, instanceName, data, id) {
 
-        const credentials = `${authOptions.login}:${authOptions.password}`;
+        const credentials = `${authOptions.login}:${authOptions.apiKey}`;
         let authData = new Buffer(credentials).toString('base64');
 
         let options = {


### PR DESCRIPTION
According to [Raynet API doc](https://app.raynet.cz/api/doc/) the only method to authenticate (still using Basic) is using email and API key associated (generated in raynet admin section) with the account for the email. So the change drops the support for password which was no longer working anyways. 

Bumping version to 1.0.2

<img width="908" alt="Screenshot 2025-05-28 at 10 20 09" src="https://github.com/user-attachments/assets/c4f16105-9a73-4246-aa39-dbb3e9c9bc22" />

After this change I have packed/published this new version to my appmixer tenant and tested all the components from this connector.  

