### PR TITLE
utils.csv.AddRow (fix) Fix `row.split is not a function` when input is array

### DIFF
--- a/src/appmixer/utils/csv/bundle.json
+++ b/src/appmixer/utils/csv/bundle.json
@@ -1,6 +1,6 @@
 {
   "name": "appmixer.utils.csv",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "engine": ">=5.0",
   "changelog": {
     "1.0.0": [
@@ -44,6 +44,9 @@
     ],
     "2.0.4": [
       "Fixed an issue when loading a CSV file could throw 'Maximum call stack size exceeded' error."
+    ],
+    "2.0.5": [
+      "Fixed an issue with the AddRow component that could result in an error when the input row was an array."
     ]
   }
 }

--- a/test/utils/csv/AddRow.test.js
+++ b/test/utils/csv/AddRow.test.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const fs = require('fs');
+const sinon = require('sinon');
+const assert = require('assert');
+const testUtils = require('../../utils.js');
+const AddRow = require('../../../src/appmixer/utils/csv/AddRow/AddRow');
+
+const pathToCSV = path.join(__dirname, 'ID,Email,Name-3.csv');
+
+describe('AddRow', () => {
+
+    let context;
+
+    beforeEach(() => {
+
+        context = {
+            ...testUtils.createMockContext(),
+            getFileReadStream: () => fs.createReadStream(pathToCSV),
+            replaceFileStream: sinon.stub().resolves({ fileId: 'file-1', filename: 'test.csv' }),
+            properties: { withHeaders: false },
+            messages: {
+                in: {
+                    content: {
+                        fileId: 'file-1',
+                        delimiter: ',',
+                        row: 'a,b,c'
+                    }
+                }
+            },
+            config: {}
+        };
+    });
+
+    it('should call processor.addRows with string row', async () => {
+
+        await AddRow.receive(context);
+
+        assert(context.replaceFileStream.calledOnce, 'replaceFileStream should be called once');
+        const callArgs = context.replaceFileStream.getCall(0).args;
+        assert.strictEqual(callArgs[0], 'file-1', 'File ID should be file-1');
+    });
+
+    it('should call processor.addRows with array', async () => {
+
+        // Not the recommended way, but can be achieved by using eg.: SetVariable->Each->AddRow.
+        context.messages.in.content.row = ['a', 'b', 'c'];
+        await AddRow.receive(context);
+
+        assert(context.replaceFileStream.calledOnce, 'replaceFileStream should be called once');
+        const callArgs = context.replaceFileStream.getCall(0).args;
+        assert.strictEqual(callArgs[0], 'file-1', 'File ID should be file-1');
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2263#issuecomment-2915265507

In old flows the input for `AddRow` is an array. The component should handle that even though we suggest only string in the tooltip.