### PR TITLE
AIAgents (fix) ignore empty parameters from `ai.agenttools.ToolStart`

### DIFF
--- a/src/appmixer/ai/claude/AIAgent/AIAgent.js
+++ b/src/appmixer/ai/claude/AIAgent/AIAgent.js
@@ -12,7 +12,7 @@ module.exports = {
         try {
             const tools = lib.getConnectedToolStartComponents(context.componentId, context.flowDescriptor);
             const functionDeclarations = lib.getFunctionDeclarations(tools);
-            context.log({ step: 'start 1', functionDeclarations, tools });
+
             return context.stateSet('functionDeclarations', functionDeclarations);
         } catch (error) {
             throw new context.CancelError(error);

--- a/src/appmixer/ai/claude/bundle.json
+++ b/src/appmixer/ai/claude/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.ai.claude",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.2": [
             "Initial version"
+        ],
+        "1.0.3": [
+            "Fixed an error `JSON schema is invalid` that occurred when the AiAgent used a tool with an empty parameters object."
         ]
     }
 }

--- a/src/appmixer/ai/claude/lib.js
+++ b/src/appmixer/ai/claude/lib.js
@@ -100,6 +100,10 @@ module.exports = {
                 if (!/^[a-zA-Z0-9_-]{1,64}$/.test(parameter.name)) {
                     throw new Error(`Parameter name '${parameter.name}' in component ${componentId} does not match the required pattern.`);
                 }
+                // Skip empty objects
+                if (Object.keys(parameter).length === 0) {
+                    return;
+                }
                 functionParameters.properties[parameter.name] = {
                     type: parameter.type,
                     description: parameter.description

--- a/src/appmixer/ai/gemini/GenerateEmbeddings/component.json
+++ b/src/appmixer/ai/gemini/GenerateEmbeddings/component.json
@@ -14,7 +14,8 @@
                 "model": { "type": "string" },
                 "chunkSize": { "type": "integer" },
                 "chunkOverlap": { "type": "integer" }
-            }
+            },
+            "required": ["text"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/ai/gemini/GenerateEmbeddingsFromFile/component.json
+++ b/src/appmixer/ai/gemini/GenerateEmbeddingsFromFile/component.json
@@ -15,7 +15,8 @@
                 "chunkSize": { "type": "integer" },
                 "chunkOverlap": { "type": "integer" },
                 "embeddingTemplate": { "type": "string" }
-            }
+            },
+            "required": ["fileId"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/ai/gemini/TransformTextToJSON/component.json
+++ b/src/appmixer/ai/gemini/TransformTextToJSON/component.json
@@ -22,7 +22,7 @@
                     "label": "Text",
                     "type": "textarea",
                     "index": 1,
-                    "tooltip": "The text from which to extract structured JSON data. Example: <code>John is 25 years old.</code>."
+                    "tooltip": "The text from which to extract structured JSON data. Example: <code>John is 25 years old.</code>"
                 },
                 "jsonSchema": {
                     "label": "Output JSON Schema",

--- a/src/appmixer/ai/gemini/bundle.json
+++ b/src/appmixer/ai/gemini/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.ai.gemini",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
         "1.0.0": [
             "First version."
         ],
         "1.0.1": [
             "TransformTextToJSON: improved error handling for invalid JSON schema input."
+        ],
+        "1.0.2": [
+            "Fixed an error `JSON schema is invalid` that occurred when the AiAgent used a tool with an empty parameters object."
         ]
     }
 }

--- a/src/appmixer/ai/gemini/lib.js
+++ b/src/appmixer/ai/gemini/lib.js
@@ -227,6 +227,10 @@ module.exports = {
                 properties: {}
             };
             parameters.forEach((parameter) => {
+                // Skip empty objects
+                if (Object.keys(parameter).length === 0) {
+                    return;
+                }
                 functionParameters.properties[parameter.name] = {
                     type: parameter.type,
                     description: parameter.description

--- a/src/appmixer/ai/openai/AIAgent/AIAgent.js
+++ b/src/appmixer/ai/openai/AIAgent/AIAgent.js
@@ -77,6 +77,10 @@ module.exports = {
                 properties: {}
             };
             parameters.forEach((parameter) => {
+                // Skip empty objects
+                if (Object.keys(parameter).length === 0) {
+                    return;
+                }
                 toolParameters.properties[parameter.name] = {
                     type: parameter.type,
                     description: parameter.description

--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ai.openai",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.0": [
             "First version."
@@ -10,6 +10,9 @@
         ],
         "1.0.2": [
             "TransformTextToJSON: improved error handling for invalid JSON schema input."
+        ],
+        "1.0.3": [
+            "Fixed an error `JSON schema is invalid` that occurred when the AiAgent used a tool with an empty parameters object."
         ]
     }
 }

--- a/test/ai/claude/lib.test.js
+++ b/test/ai/claude/lib.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const claudeLib = require('../../../src/appmixer/ai/claude/lib');
+
+describe('ai.claude getFunctionDeclarations', () => {
+
+    it('should handle parameters.ADD with empty object', () => {
+        const tools = {
+            comp1: {
+                config: {
+                    properties: {
+                        description: 'desc',
+                        parameters: {
+                            ADD: [
+                                { name: 'foo', type: 'string', description: 'desc' },
+                                {} // empty object
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+        // Should not throw, should skip empty param
+        const result = claudeLib.getFunctionDeclarations(tools);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].name, 'function_comp1');
+        assert.strictEqual(result[0].description, 'desc');
+        assert.deepStrictEqual(result[0].input_schema.properties.foo, { type: 'string', description: 'desc' });
+        // Should not include empty property
+        assert.strictEqual(Object.keys(result[0].input_schema.properties).length, 1);
+    });
+});

--- a/test/ai/gemini/lib.test.js
+++ b/test/ai/gemini/lib.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const geminiLib = require('../../../src/appmixer/ai/gemini/lib');
+
+describe('ai.gemini getFunctionDeclarations', () => {
+
+    it('should handle parameters.ADD with empty object', () => {
+        const tools = {
+            comp1: {
+                config: {
+                    properties: {
+                        description: 'desc',
+                        parameters: {
+                            ADD: [
+                                { name: 'foo', type: 'string', description: 'desc' },
+                                {} // empty object
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+        // Should not throw, should skip empty param
+        const result = geminiLib.getFunctionDeclarations(tools);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].name, 'function_comp1');
+        assert.strictEqual(result[0].description, 'desc');
+        assert.deepStrictEqual(result[0].parameters.properties.foo, { type: 'string', description: 'desc' });
+        // Should not include empty property
+        assert.strictEqual(Object.keys(result[0].parameters.properties).length, 1);
+    });
+});

--- a/test/ai/openai/AiAgent.test.js
+++ b/test/ai/openai/AiAgent.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const { getToolsDefinition } = require('../../../src/appmixer/ai/openai/AIAgent/AIAgent');
+
+describe('ai.openai AIAgent', () => {
+
+    it('should handle parameters.ADD with empty object', () => {
+        const tools = {
+            comp1: {
+                config: {
+                    properties: {
+                        description: 'desc',
+                        parameters: {
+                            ADD: [
+                                { name: 'foo', type: 'string', description: 'desc' },
+                                {} // empty object
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+        // Should not throw, should skip empty param
+        const result = getToolsDefinition(tools);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].function.name, 'comp1');
+        assert.strictEqual(result[0].function.description, 'desc');
+        assert.deepStrictEqual(result[0].function.parameters.properties.foo, { type: 'string', description: 'desc' });
+        // Should not include empty property
+        assert.strictEqual(Object.keys(result[0].function.parameters.properties).length, 1);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2265#issuecomment-2933703787



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where using tools with empty parameter objects could trigger invalid JSON schema errors in AI agents for Claude, Gemini, and OpenAI integrations.
  - Enforced required fields in input schemas for Gemini components to improve data validation.

- **Tests**
  - Added new test cases to ensure tools with empty parameter objects are handled correctly and do not cause errors.

- **Chores**
  - Updated version numbers and changelogs for affected AI bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->