### PR TITLE
Pipedrive FindLeads (patch) Label fix

### DIFF
--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -28,7 +28,7 @@
         "2.0.0": [
             "Breaking Change: Updated webhooks to v2."
         ],
-        "2.1.1": [
+        "2.1.2": [
             "Added support for leads with components: Find Leads, Create Lead, Update Lead."
         ]
     }

--- a/src/appmixer/pipedrive/crm/FindLeads/component.json
+++ b/src/appmixer/pipedrive/crm/FindLeads/component.json
@@ -42,7 +42,7 @@
                         "type": "multiselect",
                         "group": "transformation",
                         "index": 1,
-                        "label": "Title",
+                        "label": "Search From",
                         "tooltip": "The fields to perform the search from. Defaults to all of them.",
                         "options": [
                             "custom_fields",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the label for the "fields" input in the Find Leads component to "Search From" for improved clarity.
- **Chores**
  - Incremented the package version and updated the changelog to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->