### PR TITLE
AI Bedrock (patch) - CreateBatchInferenceJob

### DIFF
--- a/src/appmixer/ai/bedrock/CreateBatchInferenceJob/component.json
+++ b/src/appmixer/ai/bedrock/CreateBatchInferenceJob/component.json
@@ -5,6 +5,7 @@
     "auth": {
         "service": "appmixer:ai:bedrock"
     },
+    "version": "1.0.1",
     "inPorts": [{
         "name": "in",
         "schema": {
@@ -19,7 +20,7 @@
                 "region": { "type": "string" },
                 "model": { "type": "string" }
             },
-            "required": ["region", "model"]
+            "required": ["region", "model",  "roleArn", "jobName", "s3OutputObjectBucket", "s3OutputObjectKey", "s3InputObjectBucket", "s3InputObjectKey"]
         },
         "inspector": {
             "inputs": {

--- a/src/appmixer/ai/bedrock/bundle.json
+++ b/src/appmixer/ai/bedrock/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.ai.bedrock",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
         "1.0.1": [
             "First version."
+        ],
+        "1.0.2": [
+            "Fixed required fields for `CreateBatchInferenceJob`."
         ]
     }
 }


### PR DESCRIPTION
# What
Make the required inputs in AWS also required in the inspector.

Closes UI issues in https://github.com/clientIO/appmixer-components/issues/2291

### No output config
![image](https://github.com/user-attachments/assets/694eb4eb-6ca6-47e0-b784-535d96c239b4)

### No job name
![image](https://github.com/user-attachments/assets/1e295315-9413-405c-b17f-91a316a6ea66)

### No input config
No screenshot, same problem
