### PR TITLE
FreshDesk.ListTickets (patch)

### DIFF
--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -17,6 +17,9 @@
         "1.1.1": [
             "Added new trigger DeletedTicket.",
             "Get Ticket: fixed output port."
+        ],
+        "1.1.2": [
+            "Fixed an issue with the `ListTickets` component where it was only returning 30 tickets."
         ]
     }
 }

--- a/src/appmixer/freshdesk/tickets/ListTickets/ListTickets.js
+++ b/src/appmixer/freshdesk/tickets/ListTickets/ListTickets.js
@@ -83,6 +83,7 @@ module.exports = {
             requestObject.params.query = query;
         } else {
             requestObject.params.per_page = perPage;
+            requestObject.params.updated_since = moment().subtract(30, 'years').format('YYYY-MM-DD');
             url = `https://${auth.domain}.freshdesk.com/api/v2/tickets`;
         }
 


### PR DESCRIPTION
Fix for ListTicket component where introduced updated_since param and set to very early date to make sure all issues (including those older than 30 days) will be captured. 

<img width="708" alt="Screenshot 2025-06-26 at 11 47 43" src="https://github.com/user-attachments/assets/7b3b6b03-be2c-4015-9e7f-dfd4591e38b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the ticket listing feature only returned 30 tickets; it now retrieves a more complete list of tickets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->