### PR TITLE
Slack: fix Bot OAuth flow

### DIFF
--- a/src/appmixer/slack/auth.js
+++ b/src/appmixer/slack/auth.js
@@ -12,6 +12,7 @@ module.exports = {
 
         let userId = null;
         let teamName = null;
+        let botToken = null;
 
         return {
 
@@ -25,7 +26,8 @@ module.exports = {
                     // New Slack apps do not begin life with the ability to post in all public channels.
                     // For your new Slack app to gain the ability to post in all public channels, request the chat:write.public scope.
                     'chat:write.public',
-                    'chat:write'
+                    'chat:write.customize',
+                    [...context.scope || []] // Include any additional scopes requested by the component
                 ];
 
                 let urlObject = new URL('https://slack.com/oauth/v2/authorize');
@@ -70,6 +72,12 @@ module.exports = {
                     }
                     userId = response.data['authed_user']['id'];
                     teamName = response.data['team']['name'];
+
+                    // If doing OAuth2 for a bot, store the bot token.
+                    if (response.data['token_type'] === 'bot') {
+                        botToken = response.data['access_token'];
+                    }
+
                     return {
                         accessToken: response.data['authed_user']['access_token'],
                         refreshToken: null
@@ -81,7 +89,9 @@ module.exports = {
 
                 return {
                     'id': userId + (teamName ? ' - ' + teamName : '')
-                        || Math.random().toString().replace('0.', '')
+                        || Math.random().toString().replace('0.', ''),
+                    // botToken coming from the requestAccessToken method, received from Slack API when exchanging the authorization code.
+                    botToken
                 };
             },
 

--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -42,8 +42,9 @@
             "Improve `botToken` handling in SendChannelMessage and SendPrivateChannelMessage components when using the default configuration.",
             "`signingSecret` existence is now checked only when not using the default configuration."
         ],
-        "4.2.0": [
-            "Added 'Thread message ID' to SendChannelMessage and SendPrivateChannelMessage components."
+        "4.2.1": [
+            "Added 'Thread message ID' to SendChannelMessage and SendPrivateChannelMessage components.",
+            "Fixed an issue with the `botToken` not being set correctly in the auth profile info. Requires re-authentication of the following components: SendChannelMessage, SendPrivateChannelMessage, NewChannelMessageRT."
         ]
     }
 }

--- a/src/appmixer/slack/lib.js
+++ b/src/appmixer/slack/lib.js
@@ -27,7 +27,9 @@ module.exports = {
         let username;
         if (asBot === true) {
             // Make sure the bot token is used.
-            token = context.config?.botToken;
+            // Backward compatibility - 4.1.3 uses config.botToken
+            // 4.1.4+ uses context.auth.profileInfo.botToken
+            token = context.auth.profileInfo?.botToken || context.config?.botToken;
             if (!token && !context.config?.usesAuthHub) {
                 throw new context.CancelError('Bot token is required for sending messages as bot. Please provide it in the connector configuration.');
             }

--- a/test/slack/lib.test.js
+++ b/test/slack/lib.test.js
@@ -166,5 +166,15 @@ describe('lib.js', () => {
                 text: message
             });
         });
+
+        it('should prefer context.auth.profileInfo.botToken over context.config.botToken', async () => {
+            context.config.botToken = 'testBotToken';
+            context.auth.profileInfo = { botToken: 'profileBotToken' };
+            const result = await sendMessage(context, channelId, message, true);
+            // The mockWebClient is constructed with the token, so we can check which token was used
+            assert.equal(mockWebClient.token, 'profileBotToken');
+            assert.equal(mockWebClient.chat.postMessage.callCount, 1);
+            assert.deepEqual(result, { text: 'testMessage' });
+        });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2314

When connecting a Slack account it does OAuth flow properly and stores `botToken` in profile info as well. This new token is needed when this is true:
- components: `SendChannelMessage` or `SendPrivateChannelMessage`
- `Send as Bot` is toggled to true
- user is adding the bot app into a different workspace than the bot app originated from

It solves this exact use-case
> Bot tokens can also be generated using the [OAuth install flow](https://api.slack.com/legacy/oauth#bots) if you are distributing your app beyond your own workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the bot token was not correctly set in the authentication profile, improving reliability for Slack message sending as a bot.
  * Enhanced compatibility for bot token retrieval, ensuring smoother operation across different versions.

* **Chores**
  * Updated Slack integration version to 4.2.1.
  * Added a changelog entry describing recent fixes and improvements.

* **Tests**
  * Added a test to verify correct selection of the bot token when multiple sources are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->