### PR TITLE
Slack (major) Fix bot token usage

### DIFF
--- a/src/appmixer/slack/auth.js
+++ b/src/appmixer/slack/auth.js
@@ -34,8 +34,6 @@ module.exports = {
                 let params = new URLSearchParams([
                     ['client_id', context.clientId],
                     ['redirect_uri', context.callbackUrl],
-                    // Also add the default 'scope' param with the 'chat:write' value. Needed when sending messages as a bot.
-                    ['scope', botScopes.join(',')],
                     ['state', context.ticket]
                 ]);
                 if (Array.isArray(context.scope) && context.scope.length > 0) {
@@ -44,6 +42,11 @@ module.exports = {
                     // not in the default Oauth2 'scope' param.
                     context.scope.push('groups:history');
                     params.append('user_scope', context.scope.join(','));
+
+                    if (context.scope.includes('chat:write')) {
+                        // When sending messages, we need to add the bot scopes as well.
+                        params.append('scope', botScopes.join(','));
+                    }
                 }
                 urlObject.search = params;
                 return urlObject.toString();

--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "4.2.1",
+    "version": "5.0.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -42,9 +42,11 @@
             "Improve `botToken` handling in SendChannelMessage and SendPrivateChannelMessage components when using the default configuration.",
             "`signingSecret` existence is now checked only when not using the default configuration."
         ],
-        "4.2.1": [
-            "Added 'Thread message ID' to SendChannelMessage and SendPrivateChannelMessage components.",
-            "Fixed an issue with the `botToken` not being set correctly in the auth profile info. Requires re-authentication of the following components: SendChannelMessage, SendPrivateChannelMessage, NewChannelMessageRT."
+        "4.2.0": [
+            "Added 'Thread message ID' to SendChannelMessage and SendPrivateChannelMessage components."
+        ],
+        "5.0.0": [
+            "Fixed an issue with the `botToken` not being set correctly in the auth profile info. Requires re-authentication of the following components: SendChannelMessage, SendPrivateChannelMessage."
         ]
     }
 }


### PR DESCRIPTION
Followup to #604 

- [x] breaking version
- [x] request bot scopes only for components that do send messages - have `chat:write`
- [x] remove temporary 4.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Slack integration to version 5.0.0 with improved authentication handling.
* **Bug Fixes**
  * Resolved an issue where the bot token was not set correctly in the authentication profile, requiring re-authentication for certain components.
* **Chores**
  * Updated and reorganized changelog entries in the Slack integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->