### PR TITLE
Slack (fix) botToken with AuthHub

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -45,7 +45,7 @@
         "4.2.0": [
             "Added 'Thread message ID' to SendChannelMessage and SendPrivateChannelMessage components."
         ],
-        "5.0.0": [
+        "5.0.1": [
             "Fixed an issue with the `botToken` not being set correctly in the auth profile info. Requires re-authentication of the following components: SendChannelMessage, SendPrivateChannelMessage."
         ]
     }

--- a/src/appmixer/slack/lib.js
+++ b/src/appmixer/slack/lib.js
@@ -54,6 +54,7 @@ module.exports = {
                     username,
                     channelId,
                     text: entities.decode(message),
+                    token,
                     ...(thread_ts ? { thread_ts } : {}),
                     ...(typeof reply_broadcast === 'boolean' ? { reply_broadcast } : {})
                 }

--- a/src/appmixer/slack/routes.js
+++ b/src/appmixer/slack/routes.js
@@ -108,7 +108,7 @@ module.exports = async context => {
             options: {
                 handler: async (req, h) => {
 
-                    const { iconUrl, username, channelId, text, thread_ts, reply_broadcast } = req.payload;
+                    const { iconUrl, username, channelId, text, thread_ts, reply_broadcast, token } = req.payload;
                     await context.log('debug', 'slack-plugin-route-auth-hub-send-message', { iconUrl, username, channelId, text, thread_ts, reply_broadcast });
                     if (!channelId || !text) {
                         context.log('error', 'slack-plugin-route-webhook-send-message-missing-params', req.payload);
@@ -116,8 +116,7 @@ module.exports = async context => {
                     }
 
                     const message = await sendBotMessageFromAuthHub(
-                        context,
-                        { iconUrl, username, channelId, text, thread_ts, reply_broadcast }
+                        { iconUrl, username, channelId, text, thread_ts, reply_broadcast, token }
                     );
                     return h.response(message).code(200);
                 }
@@ -137,11 +136,10 @@ module.exports = async context => {
 
     /** Supposed to be called from AuthHub only. */
     async function sendBotMessageFromAuthHub(
-        context,
-        { iconUrl, username, channelId, text, thread_ts, reply_broadcast }
+        { iconUrl, username, channelId, text, thread_ts, reply_broadcast, token }
     ) {
 
-        const web = new WebClient(context.config?.botToken);
+        const web = new WebClient(token);
 
         const response = await web.chat.postMessage({
             icon_url: iconUrl,


### PR DESCRIPTION
Followup to #605 

- [x] use correct `botToken` from profile info when sending messages via AuthHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the bot token was not correctly set during Slack authentication, ensuring reliable message delivery via bot integration.
  * Users of SendChannelMessage and SendPrivateChannelMessage components must re-authenticate to apply this fix.

* **Tests**
  * Updated and expanded test coverage to verify correct handling and usage of bot tokens during message sending, including scenarios with AuthHub integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->