### PR TITLE
ai/openai.AIAgent: fix 400

### DIFF
--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ai.openai",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "changelog": {
         "1.0.0": [
             "First version."
@@ -25,6 +25,9 @@
         ],
         "1.1.1": [
             "Fixed a bug which prevented the AI Agent from using MCP server tools."
+        ],
+        "1.1.2": [
+            "Fixed OpenAI API error \"tool_call_ids did not have response messages\" by ensuring all tool call IDs receive responses, even when tools timeout or fail. Added comprehensive error handling for malformed JSON arguments and improved polling logic to guarantee complete tool call coverage. Enhanced logging and reliability for AI conversations when tools experience issues."
         ]
     }
 }


### PR DESCRIPTION
Error: 
400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_wtBAwWE5ppslUKDt5UuXlWb7


complete error 

```
{
  "message": "400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_wtBAwWE5ppslUKDt5UuXlWb7",
  "status": 400,
  "headers": {
    "access-control-expose-headers": "X-Request-ID",
    "alt-svc": "h3=\":443\"; ma=86400",
    "cf-cache-status": "DYNAMIC",
    "cf-ray": "95bfa3635a888db9-HEL",
    "connection": "close",
    "content-length": "315",
    "content-type": "application/json",
    "date": "Tue, 08 Jul 2025 12:38:22 GMT",
    "openai-organization": "user-l6dyrr67j1h9w5fslksmro3a",
    "openai-processing-ms": "46",
    "openai-version": "2020-10-01",
    "server": "cloudflare",
    "set-cookie": "__cf_bm=sORCAqBEOq2rPwELpwmlzXg2XiprANdpqysL7951Wko-1751978302-1.0.1.1-Y4D6gQuAkymZOhHhxY3v1X9fJTes0lZmzb1x581nWHLePKMsV_Spn1eGHbfH1du45nPf.eg8RJzaWOwS1Bid8IFL9JFxK6Fb2FG7b8f6gRQ; path=/; expires=Tue, 08-Jul-25 13:08:22 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=lTW2TJkj2gVIS4Js1uRLaFKOJ1vPIzbDPOWU.HnFhJ4-1751978302534-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
    "x-content-type-options": "nosniff",
    "x-envoy-upstream-service-time": "50",
    "x-ratelimit-limit-requests": "500",
    "x-ratelimit-limit-tokens": "30000",
    "x-ratelimit-remaining-requests": "499",
    "x-ratelimit-remaining-tokens": "29983",
    "x-ratelimit-reset-requests": "120ms",
    "x-ratelimit-reset-tokens": "34ms",
    "x-request-id": "req_1872925396db26630c273eeae114a03c"
  },
  "request_id": "req_1872925396db26630c273eeae114a03c",
  "error": {
    "message": "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_wtBAwWE5ppslUKDt5UuXlWb7",
    "type": "invalid_request_error",
    "param": "messages",
    "code": null
  },
  "code": null,
  "param": "messages",
  "type": "invalid_request_error"
}
```

Root Causes:

Missing responses for timed-out or failed tool calls - OpenAI requires a response to every tool call ID
Incorrect polling logic that could exit prematurely
No error handling for malformed JSON arguments from OpenAI
Potential streaming tool call assembly issues

Solutions Applied:

Guaranteed response coverage - Added logic to ensure every tool call ID gets a response, even if it's an error message
Fixed polling condition - Now properly tracks collected tool calls vs pending ones
JSON error handling - Gracefully handles malformed arguments with proper error responses
Improved streaming assembly - Better handling of undefined properties during tool call accumulation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for tool call arguments, ensuring that invalid or incomplete tool calls are properly reported.
  * Ensured that all tool calls receive a response, including explicit error messages if a timeout occurs.
  * Prevented duplicate outputs for tool calls and improved tracking of completed tool calls.

* **Enhancements**
  * Improved handling of streaming responses to preserve incremental data for tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->