### PR TITLE
GoogleTasks (patch) Silencing 400 errors if TaskList not present

### DIFF
--- a/src/appmixer/googleTasks/bundle.json
+++ b/src/appmixer/googleTasks/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.googleTasks",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/googleTasks/core/DeleteTask/component.json
+++ b/src/appmixer/googleTasks/core/DeleteTask/component.json
@@ -45,18 +45,9 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Select the task or insert the task ID to delete task.",
+                        "tooltip": "Insert the task ID to delete task. The task should exist in the selected task list.",
                         "label": "Task ID",
-                        "index": 0,
-                        "source": {
-                            "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
-                            "data": {
-                                "transform": "./ListTasks#tasksToSelectArray",
-                                "messages": {
-                                    "in/tasklist": "inputs/in/tasklist"
-                                }
-                            }
-                        }
+                        "index": 0
                     }
                 }
             }

--- a/src/appmixer/googleTasks/core/DeleteTask/component.json
+++ b/src/appmixer/googleTasks/core/DeleteTask/component.json
@@ -47,7 +47,7 @@
                         "type": "text",
                         "tooltip": "Select the task or insert the task ID to delete task. The task should already exist in the specified task list.",
                         "label": "Task ID",
-                        "index": 0,
+                        "index": 1,
                         "source": {
                             "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
                             "data": {

--- a/src/appmixer/googleTasks/core/DeleteTask/component.json
+++ b/src/appmixer/googleTasks/core/DeleteTask/component.json
@@ -45,9 +45,18 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Insert the task ID to delete task. The task should exist in the selected task list.",
+                        "tooltip": "Select the task or insert the task ID to delete task.",
                         "label": "Task ID",
-                        "index": 0
+                        "index": 0,
+                        "source": {
+                            "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
+                            "data": {
+                                "transform": "./ListTasks#tasksToSelectArray",
+                                "messages": {
+                                    "in/tasklist": "inputs/in/tasklist"
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/appmixer/googleTasks/core/DeleteTask/component.json
+++ b/src/appmixer/googleTasks/core/DeleteTask/component.json
@@ -45,7 +45,7 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Select the task or insert the task ID to delete task.",
+                        "tooltip": "Select the task or insert the task ID to delete task. The task should already exist in the specified task list.",
                         "label": "Task ID",
                         "index": 0,
                         "source": {

--- a/src/appmixer/googleTasks/core/GetTask/component.json
+++ b/src/appmixer/googleTasks/core/GetTask/component.json
@@ -45,7 +45,7 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Select the task or insert the task ID to fetch task.",
+                        "tooltip": "Select the task or insert the task ID to fetch task. The task should already exist in the specified task list.",
                         "label": "Task ID",
                         "index": 1,
                         "source": {

--- a/src/appmixer/googleTasks/core/GetTask/component.json
+++ b/src/appmixer/googleTasks/core/GetTask/component.json
@@ -45,18 +45,9 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Select the task or insert the task ID to fetch task.",
+                        "tooltip": "Insert the task ID to fetch task. The task should exist in the selected task list.",
                         "label": "Task ID",
-                        "index": 1,
-                        "source": {
-                            "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
-                            "data": {
-                                "transform": "./ListTasks#tasksToSelectArray",
-                                "messages": {
-                                    "in/tasklist": "inputs/in/tasklist"
-                                }
-                            }
-                        }
+                        "index": 1
                     }
                 }
             }

--- a/src/appmixer/googleTasks/core/GetTask/component.json
+++ b/src/appmixer/googleTasks/core/GetTask/component.json
@@ -45,9 +45,18 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Insert the task ID to fetch task. The task should exist in the selected task list.",
+                        "tooltip": "Select the task or insert the task ID to fetch task.",
                         "label": "Task ID",
-                        "index": 1
+                        "index": 1,
+                        "source": {
+                            "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
+                            "data": {
+                                "transform": "./ListTasks#tasksToSelectArray",
+                                "messages": {
+                                    "in/tasklist": "inputs/in/tasklist"
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/appmixer/googleTasks/core/ListTasks/ListTasks.js
+++ b/src/appmixer/googleTasks/core/ListTasks/ListTasks.js
@@ -7,14 +7,23 @@ module.exports = {
 
         // https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/list
 
-        const { data } = await context.httpRequest({
-            method: 'GET',
-            url: `https://tasks.googleapis.com/tasks/v1/lists/${tasklist}/tasks`,
-            headers: {
-                'Authorization': `Bearer ${context.auth.accessToken}`
+        try {
+            const { data } = await context.httpRequest({
+                method: 'GET',
+                url: `https://tasks.googleapis.com/tasks/v1/lists/${tasklist}/tasks`,
+                headers: {
+                    'Authorization': `Bearer ${context.auth.accessToken}`
+                }
+            });
+            return context.sendJson(data.items || [], 'out');
+        } catch (error) {
+            // Silence 400-level errors (like 400 Bad Request when tasklist is not available)
+            if (error.response && error.response.status >= 400 && error.response.status < 500) {
+                return context.sendJson([], 'out');
             }
-        });
-        return context.sendJson(data.items || [], 'out');
+            // Re-throw other errors
+            throw error;
+        }
     },
 
     tasksToSelectArray(tasks) {

--- a/src/appmixer/googleTasks/core/UpdateTask/component.json
+++ b/src/appmixer/googleTasks/core/UpdateTask/component.json
@@ -89,7 +89,7 @@
                         "index": 4
                     },
                     "status": {
-                        "type": "text",
+                        "type": "select",
                         "tooltip": "Updated status for the task.",
                         "label": "Status",
                         "options": [

--- a/src/appmixer/googleTasks/core/UpdateTask/component.json
+++ b/src/appmixer/googleTasks/core/UpdateTask/component.json
@@ -57,9 +57,18 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Insert the task ID to update task. The task should exist in the selected task list.",
+                        "tooltip": "Select the task or insert the task ID to update task.",
                         "label": "Task ID",
-                        "index": 1
+                        "index": 1,
+                        "source": {
+                            "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
+                            "data": {
+                                "transform": "./ListTasks#tasksToSelectArray",
+                                "messages": {
+                                    "in/tasklist": "inputs/in/tasklist"
+                                }
+                            }
+                        }
                     },
                     "title": {
                         "type": "text",
@@ -80,7 +89,7 @@
                         "index": 4
                     },
                     "status": {
-                        "type": "select",
+                        "type": "text",
                         "tooltip": "Updated status for the task.",
                         "label": "Status",
                         "options": [

--- a/src/appmixer/googleTasks/core/UpdateTask/component.json
+++ b/src/appmixer/googleTasks/core/UpdateTask/component.json
@@ -57,18 +57,9 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Select the task or insert the task ID to update task.",
+                        "tooltip": "Insert the task ID to update task. The task should exist in the selected task list.",
                         "label": "Task ID",
-                        "index": 1,
-                        "source": {
-                            "url": "/component/appmixer/googleTasks/core/ListTasks?outPort=out",
-                            "data": {
-                                "transform": "./ListTasks#tasksToSelectArray",
-                                "messages": {
-                                    "in/tasklist": "inputs/in/tasklist"
-                                }
-                            }
-                        }
+                        "index": 1
                     },
                     "title": {
                         "type": "text",
@@ -89,7 +80,7 @@
                         "index": 4
                     },
                     "status": {
-                        "type": "text",
+                        "type": "select",
                         "tooltip": "Updated status for the task.",
                         "label": "Status",
                         "options": [

--- a/src/appmixer/googleTasks/core/UpdateTask/component.json
+++ b/src/appmixer/googleTasks/core/UpdateTask/component.json
@@ -57,7 +57,7 @@
                     },
                     "task": {
                         "type": "text",
-                        "tooltip": "Select the task or insert the task ID to update task.",
+                        "tooltip": "Select the task or insert the task ID to update task. The task should already exist in the specified task list.",
                         "label": "Task ID",
                         "index": 1,
                         "source": {


### PR DESCRIPTION
For fetching a list of tasks, for dynamic input, we are required to have a List ID present. If the list ID is selected from a tag in a flow and not the list dropdown itself, then there is an error on the task endpoint. I have silenced the 400 something error in this case so we can run the flow with input tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "status" field when updating a task is now a dropdown with predefined options ("Needs Action" and "Completed") for easier selection.

* **Bug Fixes**
  * Improved error handling when listing tasks: client-side errors now return an empty list instead of causing failures.

* **Documentation**
  * Tooltips for task selection fields have been updated to clarify that the task must already exist in the specified task list.

* **Chores**
  * Updated the package version number and changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->