### PR TITLE
controls.onError: fix uncaught exception

### DIFF
--- a/src/appmixer/utils/controls/OnError/OnError.js
+++ b/src/appmixer/utils/controls/OnError/OnError.js
@@ -44,7 +44,7 @@ function addLabels(context, errors) {
     return errors.map(err => ({
         ...err,
         flowName: context.flowInfo.flowName,
-        componentLabel: err.componentId ? (context.flowDescriptor[err.componentId]?.label || err.componentType.split('.')[3]) : undefined
+        componentLabel: err.componentId ? (context.flowDescriptor[err.componentId]?.label || err.componentType?.split('.')[3]) : undefined
     }));
 }
 

--- a/src/appmixer/utils/controls/bundle.json
+++ b/src/appmixer/utils/controls/bundle.json
@@ -1,7 +1,7 @@
 {
     "name": "appmixer.utils.controls",
     "engine": ">=6.0",
-    "version": "1.9.3",
+    "version": "1.9.4",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -83,6 +83,9 @@
         ],
         "1.9.3": [
             "Digest: Tuned to handle higher number of concurrent entries."
+        ],
+        "1.9.4": [
+            "OnError: fixing 'TypeError: Cannot read properties of undefined (reading 'split')'."
         ]
     }
 }


### PR DESCRIPTION
https://appmixer.freshdesk.com/a/tickets/9100

reproduce: 
```js
err = {componentId: "324234234324"};
err.componentId ? (context.flowDescriptor[err.componentId]?.label || err.componentType.split('.')[3]) : undefined
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the OnError component that could cause a runtime error under certain conditions.

* **Chores**
  * Updated version number and changelog to reflect the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->