### PR TITLE
microsoft mail: trim address in send email

### DIFF
--- a/src/appmixer/microsoft/mail/SendEmail/SendEmail.js
+++ b/src/appmixer/microsoft/mail/SendEmail/SendEmail.js
@@ -7,7 +7,7 @@ const { makeRequest } = require('../commons');
  * @param  {String} address
  * @return {{ emailAddress: { address: string }}}
  */
-const createAddress = (address) => ({ emailAddress: { address } });
+const createAddress = (address) => ({ emailAddress: { address: address?.trim() } });
 
 /**
  * Creates message JSON structured for Microsoft Mail endpoint.


### PR DESCRIPTION
* we saw clients having trouble due to the whitespaces in the email `To` list
* this ensures emails are trimmed and whitespaces removed, a better experience for users and less potential for errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email address handling by automatically removing any leading or trailing spaces before sending emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->