### PR TITLE
PDFCO (patch) Minor: Adding dependency for FormData

### DIFF
--- a/src/appmixer/pdfco/bundle.json
+++ b/src/appmixer/pdfco/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.pdfco",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/pdfco/package.json
+++ b/src/appmixer/pdfco/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pdfco",
+  "version": "1.0.0",
+  "description": "Appmixer connector for Pdf Co API integration.",
+  "dependencies": {
+    "form-data": "^4.0.4"
+  }
+}

--- a/src/appmixer/pdfco/package.json
+++ b/src/appmixer/pdfco/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "description": "Appmixer connector for Pdf Co API integration.",
   "dependencies": {
-    "form-data": "^4.0.4"
+    "form-data": "4.0.4"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Pdf.co connector version from 1.0.0 to 1.0.1.
  * Added package manifest for the Pdf.co connector with metadata and a dependency on form-data 4.0.4 to support installation and builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->