### PR TITLE
microsoft.mail.SendEmail: (patch) trim email address 

### DIFF
--- a/src/appmixer/microsoft/mail/SendEmail/SendEmail.js
+++ b/src/appmixer/microsoft/mail/SendEmail/SendEmail.js
@@ -7,8 +7,11 @@ const { makeRequest } = require('../commons');
  * @param  {String} address
  * @return {{ emailAddress: { address: string }}}
  */
-const createAddress = (address) => ({ emailAddress: { address } });
-
+const createAddress = (address) => ({
+    emailAddress: {
+        address: address && typeof address === 'string' ? address.trim() : address
+    }
+});
 /**
  * Creates message JSON structured for Microsoft Mail endpoint.
  * @param  {Object} json - Input message JSON.

--- a/src/appmixer/microsoft/mail/bundle.json
+++ b/src/appmixer/microsoft/mail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.mail",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -31,7 +31,9 @@
         ],
         "1.3.4": [
             "Fixed a bug in trigger DeletedEmail."
+        ],
+        "1.3.5": [
+            "SendEmail: trim email address before sending."
         ]
-
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trim whitespace from email addresses before sending, improving handling of comma-separated recipients and preventing errors caused by accidental spaces.

* **Chores**
  * Bumped Microsoft Mail bundle to version 1.3.5.
  * Updated changelog to reflect the email address trimming improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->