### PR TITLE
Pipedrive.ListPeople (patch) Renamed List People to List Person. Label Change only.

### DIFF
--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -30,6 +30,9 @@
         ],
         "2.1.2": [
             "Added support for leads with components: Find Leads, Create Lead, Update Lead."
+        ],
+        "2.1.3": [
+            "Updated List People label to List Persons."
         ]
     }
 }

--- a/src/appmixer/pipedrive/crm/ListPeople/component.json
+++ b/src/appmixer/pipedrive/crm/ListPeople/component.json
@@ -2,6 +2,8 @@
     "name": "appmixer.pipedrive.crm.ListPeople",
     "author": "Tomáš Waldauf <tomas@client.io>",
     "description": "When triggered, returns a list of people.",
+    "label": "List People",
+    "version": "1.0.1",
     "private": true,
     "inPorts": [ "in" ],
     "outPorts": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the display label from “List People” to “List Persons” in the relevant action.

- Chores
  - Bumped integration package version to 2.1.3.
  - Added a changelog entry for version 2.1.3 noting the label update.
  - Incremented the component version to 1.0.1.

- Notes
  - No functional behavior changes; users will only notice the updated label in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->