### PR TITLE
slack (patch) multiselect inputs array vs string

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -47,6 +47,9 @@
         ],
         "5.0.1": [
             "Fixed an issue with the `botToken` not being set correctly in the auth profile info. Requires re-authentication of the following components: SendChannelMessage, SendPrivateChannelMessage."
+        ],
+        "5.0.2": [
+            "Fixed an issue with invalid user selection in UploadFileToUser and SendDirectMessage components."
         ]
     }
 }

--- a/src/appmixer/slack/files/UploadFileToUser/UploadFileToUser.js
+++ b/src/appmixer/slack/files/UploadFileToUser/UploadFileToUser.js
@@ -1,16 +1,14 @@
 'use strict';
 
 const { WebClient } = require('@slack/web-api');
+const lib = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
         const { userIds, fileId, filename, altTxt, snippetType, initialComment } = context.messages.in.content;
-        if (userIds.length > 8) {
-            throw new context.CancelError('You can send a message to a maximum of 8 users at once');
-        }
-        let ids = userIds?.join(',');
+        const ids = lib.normalizeMultiselectInput(userIds, 8, context, 'userIds');
 
         const web = new WebClient(context.auth.accessToken);
         const { channel } = await web.conversations.open({ users: ids, prevent_creation: true });

--- a/src/appmixer/slack/lib.js
+++ b/src/appmixer/slack/lib.js
@@ -8,6 +8,26 @@ const { WebClient } = require('@slack/web-api');
 // const slackConnectorVersion = require('./bundle.json').version;
 
 module.exports = {
+    /**
+     * Normalize multiselect input (array or string) to comma-separated string for Slack API.
+     * @param {string|string[]} input
+     * @param {number} maxItems
+     * @param {object} context
+     * @param {string} fieldName
+     * @returns {string}
+     */
+    normalizeMultiselectInput(input, maxItems = 8, context, fieldName) {
+        if (Array.isArray(input)) {
+            if (input.length > maxItems) {
+                throw new context.CancelError(`You can send a message to a maximum of ${maxItems} users at once`);
+            }
+            return input.join(',');
+        } else if (typeof input === 'string') {
+            return input;
+        } else {
+            throw new context.CancelError(`${fieldName} must be a string or an array`);
+        }
+    },
 
     /**
      * Send slack channel message.

--- a/src/appmixer/slack/messages/SendDirectMessage/SendDirectMessage.js
+++ b/src/appmixer/slack/messages/SendDirectMessage/SendDirectMessage.js
@@ -8,10 +8,7 @@ module.exports = {
     async receive(context) {
 
         let { text, userIds } = context.messages.in.content;
-        if (userIds.length > 8) {
-            throw new context.CancelError('You can send a message to a maximum of 8 users at once');
-        }
-        let ids = userIds?.join(',');
+        const ids = lib.normalizeMultiselectInput(userIds, 8, context, 'userIds');
 
         // First, open a conversation with the user(s). It will return the channel ID.
         const web = new WebClient(context.auth.accessToken);
@@ -28,4 +25,3 @@ module.exports = {
         return context.sendJson(message, 'out');
     }
 };
-

--- a/test/slack/lib.test.js
+++ b/test/slack/lib.test.js
@@ -27,6 +27,31 @@ require.cache[require.resolve('@slack/web-api')].exports = {
 const { sendMessage } = require('../../src/appmixer/slack/lib.js');
 
 describe('lib.js', () => {
+    describe('normalizeMultiselectInput', () => {
+        const context = { CancelError: class CancelError extends Error {} };
+
+        it('should join array of userIds', () => {
+            const result = require('../../src/appmixer/slack/lib').normalizeMultiselectInput(['U1', 'U2', 'U3'], 8, context, 'userIds');
+            assert.strictEqual(result, 'U1,U2,U3');
+        });
+
+        it('should return string userId as is', () => {
+            const result = require('../../src/appmixer/slack/lib').normalizeMultiselectInput('U1', 8, context, 'userIds');
+            assert.strictEqual(result, 'U1');
+        });
+
+        it('should throw if array exceeds maxItems', () => {
+            assert.throws(() => {
+                require('../../src/appmixer/slack/lib').normalizeMultiselectInput(['U1','U2','U3','U4','U5','U6','U7','U8','U9'], 8, context, 'userIds');
+            }, context.CancelError);
+        });
+
+        it('should throw if input is not array or string', () => {
+            assert.throws(() => {
+                require('../../src/appmixer/slack/lib').normalizeMultiselectInput(123, 8, context, 'userIds');
+            }, context.CancelError);
+        });
+    });
 
     describe('sendMessage - asBot', () => {
 


### PR DESCRIPTION
Fixes https://github.com/clientIO/appmixer-components/issues/2359

- [x] add new function to normalize input for users
- [x] use it where user multiselect exists
- [x] tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed invalid user selection when sending direct messages or uploading files to users.
  - Improved validation for selecting up to 8 recipients, with clearer error messages.
  - Increased reliability when opening conversations and delivering messages/files to selected users.

- Chores
  - Bumped Slack bundle to version 5.0.2 and updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->