### PR TITLE
Pipedrive.ListPeople (patch) Renamed List People to List Persons. Label Change only. (second)

### DIFF
--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -31,7 +31,7 @@
         "2.1.2": [
             "Added support for leads with components: Find Leads, Create Lead, Update Lead."
         ],
-        "2.1.3": [
+        "2.1.4": [
             "Updated List People label to List Persons."
         ]
     }

--- a/src/appmixer/pipedrive/crm/ListPeople/component.json
+++ b/src/appmixer/pipedrive/crm/ListPeople/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.pipedrive.crm.ListPeople",
     "author": "Tomáš Waldauf <tomas@client.io>",
     "description": "When triggered, returns a list of people.",
-    "label": "List People",
+    "label": "List Persons",
     "version": "1.0.1",
     "private": true,
     "inPorts": [ "in" ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No functional changes; UI text updated only.
- Style
  - Renamed the Pipedrive CRM ListPeople action from “List People” to “List Persons” across the UI (component picker, workflow nodes) for clearer, consistent terminology.
- Chores
  - Bumped integration version to 2.1.4 and updated release notes/changelog to reflect the label change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->