### PR TITLE
Linear. ListTeams. New component added for listing teams

### DIFF
--- a/src/appmixer/linear/bundle.json
+++ b/src/appmixer/linear/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.linear",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/linear/core/ListTeams/ListTeams.js
+++ b/src/appmixer/linear/core/ListTeams/ListTeams.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const lib = require('../../lib.generated');
+
+const schema = {
+    'id': { 'type': 'string', 'title': 'Team Id' },
+    'name': { 'type': 'string', 'title': 'Team Name' },
+    'key': { 'type': 'string', 'title': 'Team Key' },
+    'description': { 'type': 'string', 'title': 'Team Description' },
+    'icon': { 'type': 'string', 'title': 'Team Icon' },
+    'color': { 'type': 'string', 'title': 'Team Color' },
+    'createdAt': { 'type': 'string', 'title': 'Team Created At' },
+    'updatedAt': { 'type': 'string', 'title': 'Team Updated At' }
+};
+
+module.exports = {
+    async receive(context) {
+
+        const { outputType } = context.messages.in.content;
+
+        if (context.properties.generateOutputPortOptions) {
+            return lib.getOutputPortOptions(context, outputType, schema, { label: 'Teams' });
+        }
+
+        // Build GraphQL query for listing teams
+        const graphqlQuery = `
+            query {
+                teams {
+                    nodes {
+                        id
+                        name
+                        key
+                        description
+                        icon
+                        color
+                        createdAt
+                        updatedAt
+                    }
+                }
+            }
+        `;
+
+        // https://linear.app/developers/graphql
+        const { data } = await context.httpRequest({
+            method: 'POST',
+            url: 'https://api.linear.app/graphql',
+            headers: {
+                'Authorization': `Bearer ${context.auth.accessToken}`
+            },
+            data: {
+                query: graphqlQuery
+            }
+        });
+
+        if (data.errors) {
+            throw new Error('GraphQL errors: ' + JSON.stringify(data.errors));
+        }
+
+        const teams = data.data.teams.nodes || [];
+
+        return lib.sendArrayOutput({ context, records: teams, outputType });
+    }
+};

--- a/src/appmixer/linear/core/ListTeams/component.json
+++ b/src/appmixer/linear/core/ListTeams/component.json
@@ -1,0 +1,72 @@
+{
+    "name": "appmixer.linear.core.ListTeams",
+    "author": "Appmixer <info@appmixer.com>",
+    "description": "Retrieves a list of all teams in the workspace.",
+    "version": "1.0.0",
+    "auth": {
+        "service": "appmixer:linear"
+    },
+    "quota": {
+        "manager": "appmixer:linear",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outputType": {
+                        "type": "string"
+                    }
+                }
+            },
+            "inspector": {
+                "inputs": {
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 0,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            {
+                                "label": "First Item Only",
+                                "value": "first"
+                            },
+                            {
+                                "label": "All items at once",
+                                "value": "array"
+                            },
+                            {
+                                "label": "One item at a time",
+                                "value": "object"
+                            },
+                            {
+                                "label": "File",
+                                "value": "file"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/linear/core/ListTeams?outPort=out",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/outputType": "inputs/in/outputType"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiMyMjIzMjYiIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCI+CiAgPHBhdGgKICAgIGQ9Ik0xLjIyNTQxIDYxLjUyMjhjLS4yMjI1LS45NDg1LjkwNzQ4LTEuNTQ1OSAxLjU5NjM4LS44NTdMMzkuMzM0MiA5Ny4xNzgyYy42ODg5LjY4ODkuMDkxNSAxLjgxODktLjg1NyAxLjU5NjRDMjAuMDUxNSA5NC40NTIyIDUuNTQ3NzkgNzkuOTQ4NSAxLjIyNTQxIDYxLjUyMjhaTS4wMDE4OTEzNSA0Ni44ODkxYy0uMDE3NjQzNzUuMjgzMy4wODg4NzIxNS41NTk5LjI4OTU3MTY1Ljc2MDZMNTIuMzUwMyA5OS43MDg1Yy4yMDA3LjIwMDcuNDc3My4zMDc1Ljc2MDYuMjg5NiAyLjM2OTItLjE0NzYgNC42OTM4LS40NiA2Ljk2MjQtLjkyNTkuNzY0NS0uMTU3IDEuMDMwMS0xLjA5NjMuNDc4Mi0xLjY0ODFMMi41NzU5NSAzOS40NDg1Yy0uNTUxODYtLjU1MTktMS40OTExNy0uMjg2My0xLjY0ODE3NC40NzgyLS40NjU5MTUgMi4yNjg2LS43NzgzMiA0LjU5MzItLjkyNTg4NDY1IDYuOTYyNFpNNC4yMTA5MyAyOS43MDU0Yy0uMTY2NDkuMzczOC0uMDgxNjkuODEwNi4yMDc2NSAxLjFsNjQuNzc2MDIgNjQuNzc2Yy4yODk0LjI4OTQuNzI2Mi4zNzQyIDEuMS4yMDc3IDEuNzg2MS0uNzk1NiAzLjUxNzEtMS42OTI3IDUuMTg1NS0yLjY4NC41NTIxLS4zMjguNjM3My0xLjA4NjcuMTgzMi0xLjU0MDdMOC40MzU2NiAyNC4zMzY3Yy0uNDU0MDktLjQ1NDEtMS4yMTI3MS0uMzY4OS0xLjU0MDc0LjE4MzItLjk5MTMyIDEuNjY4NC0xLjg4ODQzIDMuMzk5NC0yLjY4Mzk5IDUuMTg1NVpNMTIuNjU4NyAxOC4wNzRjLS4zNzAxLS4zNzAxLS4zOTMtLjk2MzctLjA0NDMtMS4zNTQxQzIxLjc3OTUgNi40NTkzMSAzNS4xMTE0IDAgNDkuOTUxOSAwIDc3LjU5MjcgMCAxMDAgMjIuNDA3MyAxMDAgNTAuMDQ4MWMwIDE0Ljg0MDUtNi40NTkzIDI4LjE3MjQtMTYuNzE5OSAzNy4zMzc1LS4zOTAzLjM0ODctLjk4NC4zMjU4LTEuMzU0Mi0uMDQ0M0wxMi42NTg3IDE4LjA3NFoiCiAgLz4KPC9zdmc+Cg=="
+}

--- a/test/linear/ListTeams.test.js
+++ b/test/linear/ListTeams.test.js
@@ -1,0 +1,187 @@
+const assert = require('assert');
+const path = require('path');
+const dotenv = require('dotenv');
+const axios = require('axios');
+
+// Load environment variables
+dotenv.config({ path: path.join(__dirname, '../.env') });
+
+// Import the component
+const ListTeams = require('../../src/appmixer/linear/core/ListTeams/ListTeams');
+
+// Mock context
+const createMockContext = (auth, messages = {}) => {
+    return {
+        auth, 
+        messages, 
+        properties: {}, 
+        httpRequest: async (options) => {
+            const response = await axios({
+                method: options.method || 'GET', 
+                url: options.url, 
+                headers: options.headers, 
+                data: options.data
+            });
+
+            return {
+                data: response.data, 
+                status: response.status, 
+                headers: response.headers
+            };
+        }, 
+        sendJson: (data, port) => {
+            return { data, port };
+        },
+        CancelError: Error
+    };
+};
+
+describe('ListTeams Component', () => {
+
+    const accessToken = process.env.LINEAR_ACCESS_TOKEN;
+
+    if (!accessToken) {
+        console.log('Skipping tests - LINEAR_ACCESS_TOKEN not set');
+        return;
+    }
+
+    it('should list teams with array output type', async () => {
+
+        const context = createMockContext({
+            accessToken: accessToken
+        }, {
+            in: {
+                content: {
+                    outputType: 'array'
+                }
+            }
+        });
+
+        const result = await ListTeams.receive(context);
+
+        assert(result, 'Result should be defined');
+        assert.strictEqual(result.port, 'out', 'Should send to out port');
+        assert(result.data, 'Result should have data');
+        assert(result.data.result, 'Result should have teams array');
+        assert(Array.isArray(result.data.result), 'Teams should be an array');
+        assert.strictEqual(typeof result.data.count, 'number', 'Count should be a number');
+
+        if (result.data.result.length > 0) {
+            const team = result.data.result[0];
+            assert(team.id, 'Team should have id');
+            assert(team.name, 'Team should have name');
+            assert(team.key, 'Team should have key');
+            assert(typeof team.memberCount, 'number', 'Team should have memberCount');
+        }
+
+        console.log('✅ Listed teams:', result.data.count);
+    });
+
+    it('should default to array output type when not specified', async () => {
+
+        const context = createMockContext({
+            accessToken: accessToken
+        }, {
+            in: {
+                content: {}
+            }
+        });
+
+        const result = await ListTeams.receive(context);
+
+        assert(result, 'Result should be defined');
+        assert.strictEqual(result.port, 'out', 'Should send to out port');
+        assert(result.data, 'Result should have data');
+        assert(result.data.result, 'Result should have teams array');
+        assert(Array.isArray(result.data.result), 'Teams should be an array');
+    });
+
+    it('should handle object output type', async () => {
+
+        const context = createMockContext({
+            accessToken: accessToken
+        }, {
+            in: {
+                content: {
+                    outputType: 'object'
+                }
+            }
+        });
+
+        const result = await ListTeams.receive(context);
+
+        assert(result, 'Result should be defined');
+        
+        if (result.port === 'notFound') {
+            console.log('No teams found for object output type test');
+            return;
+        }
+
+        assert.strictEqual(result.port, 'out', 'Should send to out port');
+        assert(result.data, 'Result should have data');
+        assert(result.data.id, 'Team should have id');
+        assert(result.data.name, 'Team should have name');
+        assert(result.data.key, 'Team should have key');
+        assert(typeof result.data.index, 'number', 'Should have index');
+        assert(typeof result.data.count, 'number', 'Should have count');
+    });
+
+    it('should handle first output type', async () => {
+
+        const context = createMockContext({
+            accessToken: accessToken
+        }, {
+            in: {
+                content: {
+                    outputType: 'first'
+                }
+            }
+        });
+
+        const result = await ListTeams.receive(context);
+
+        assert(result, 'Result should be defined');
+        
+        if (result.port === 'notFound') {
+            console.log('No teams found for first output type test');
+            return;
+        }
+
+        assert.strictEqual(result.port, 'out', 'Should send to out port');
+        assert(result.data, 'Result should have data');
+        assert(result.data.id, 'Team should have id');
+        assert(result.data.name, 'Team should have name');
+        assert(result.data.key, 'Team should have key');
+        assert.strictEqual(result.data.index, 0, 'Should have index 0 for first item');
+        assert(typeof result.data.count, 'number', 'Should have count');
+    });
+
+    it('should handle generateOutputPortOptions', async () => {
+
+        const context = createMockContext({
+            accessToken: accessToken
+        }, {
+            in: {
+                content: {
+                    outputType: 'array'
+                }
+            }
+        });
+
+        context.properties.generateOutputPortOptions = true;
+
+        const result = await ListTeams.receive(context);
+
+        assert(result, 'Result should be defined');
+        assert.strictEqual(result.port, 'out', 'Should send to out port');
+        assert(Array.isArray(result.data), 'Result should be an array of options');
+        
+        const countOption = result.data.find(option => option.value === 'count');
+        assert(countOption, 'Should have count option');
+        assert.strictEqual(countOption.label, 'Items Count', 'Count option should have correct label');
+
+        const resultOption = result.data.find(option => option.value === 'result');
+        assert(resultOption, 'Should have result option');
+        assert.strictEqual(resultOption.label, 'Teams', 'Result option should have correct label');
+    });
+});

--- a/test/linear/ListTeams.test.js
+++ b/test/linear/ListTeams.test.js
@@ -12,23 +12,23 @@ const ListTeams = require('../../src/appmixer/linear/core/ListTeams/ListTeams');
 // Mock context
 const createMockContext = (auth, messages = {}) => {
     return {
-        auth, 
-        messages, 
-        properties: {}, 
+        auth,
+        messages,
+        properties: {},
         httpRequest: async (options) => {
             const response = await axios({
-                method: options.method || 'GET', 
-                url: options.url, 
-                headers: options.headers, 
+                method: options.method || 'GET',
+                url: options.url,
+                headers: options.headers,
                 data: options.data
             });
 
             return {
-                data: response.data, 
-                status: response.status, 
+                data: response.data,
+                status: response.status,
                 headers: response.headers
             };
-        }, 
+        },
         sendJson: (data, port) => {
             return { data, port };
         },
@@ -71,7 +71,7 @@ describe('ListTeams Component', () => {
             assert(team.id, 'Team should have id');
             assert(team.name, 'Team should have name');
             assert(team.key, 'Team should have key');
-            assert(typeof team.memberCount, 'number', 'Team should have memberCount');
+            assert.strictEqual(typeof team.memberCount, 'number', 'Team should have memberCount');
         }
 
         console.log('✅ Listed teams:', result.data.count);
@@ -111,7 +111,7 @@ describe('ListTeams Component', () => {
         const result = await ListTeams.receive(context);
 
         assert(result, 'Result should be defined');
-        
+
         if (result.port === 'notFound') {
             console.log('No teams found for object output type test');
             return;
@@ -122,8 +122,8 @@ describe('ListTeams Component', () => {
         assert(result.data.id, 'Team should have id');
         assert(result.data.name, 'Team should have name');
         assert(result.data.key, 'Team should have key');
-        assert(typeof result.data.index, 'number', 'Should have index');
-        assert(typeof result.data.count, 'number', 'Should have count');
+        assert.strictEqual(typeof result.data.index, 'number', 'Should have index');
+        assert.strictEqual(typeof result.data.count, 'number', 'Should have count');
     });
 
     it('should handle first output type', async () => {
@@ -141,7 +141,7 @@ describe('ListTeams Component', () => {
         const result = await ListTeams.receive(context);
 
         assert(result, 'Result should be defined');
-        
+
         if (result.port === 'notFound') {
             console.log('No teams found for first output type test');
             return;
@@ -153,7 +153,7 @@ describe('ListTeams Component', () => {
         assert(result.data.name, 'Team should have name');
         assert(result.data.key, 'Team should have key');
         assert.strictEqual(result.data.index, 0, 'Should have index 0 for first item');
-        assert(typeof result.data.count, 'number', 'Should have count');
+        assert.strictEqual(typeof result.data.count, 'number', 'Should have count');
     });
 
     it('should handle generateOutputPortOptions', async () => {
@@ -175,7 +175,7 @@ describe('ListTeams Component', () => {
         assert(result, 'Result should be defined');
         assert.strictEqual(result.port, 'out', 'Should send to out port');
         assert(Array.isArray(result.data), 'Result should be an array of options');
-        
+
         const countOption = result.data.find(option => option.value === 'count');
         assert(countOption, 'Should have count option');
         assert.strictEqual(countOption.label, 'Items Count', 'Count option should have correct label');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a "List Teams" component for Linear to retrieve workspace teams.
  - Supports multiple output formats: all items, first item, one-at-a-time, and file.
  - Provides output port options for easier mapping (e.g., Teams list and Items Count).

- Tests
  - Added tests covering all output types and option generation (skipped if no token).

- Chores
  - Bumped bundle version to 1.0.1 and updated changelog mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->