### PR TITLE
Google Slides (patch) - Find Presentations missing searchQuery param

### DIFF
--- a/src/appmixer/googleSlides/bundle.json
+++ b/src/appmixer/googleSlides/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.googleSlides",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -8,7 +8,7 @@
         "1.0.1": [
             "Removing duplicate components."
         ],
-        "1.0.2": [
+        "1.0.3": [
             "Fixed FindPresentations 'Type is not fully qualified' error."
         ]
     }

--- a/src/appmixer/googleSlides/core/FindPresentations/FindPresentations.js
+++ b/src/appmixer/googleSlides/core/FindPresentations/FindPresentations.js
@@ -4,7 +4,7 @@ const lib = require('../../lib.generated');
 
 module.exports = {
     async receive(context) {
-        const { folderLocation, outputType } = context.messages.in.content;
+        const { searchQuery, folderLocation, outputType } = context.messages.in.content;
 
         if (context.properties.generateOutputPortOptions) {
             return lib.getOutputPortOptions(context, outputType, schema, { label: 'Presentations', value: 'result' });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved errors when searching presentations by name; queries now correctly filter results based on the provided search text.
  - Addressed a previous issue causing a “Type is not fully qualified” error in the Find Presentations action.

- Chores
  - Bumped Google Slides integration version to 1.0.3.
  - Updated changelog to reflect the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->