### PR TITLE
Resend (patch) - fix boolean/toggle inPorts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -807,6 +807,11 @@ json schema of the component.json
 }
 ```
 
+Make sure `inPorts[0].schema.properties.<input_name>.type` and `inPorts[0].inspector.inputs.<input_name>.type` match the following mapping:
+- string -> text|textarea
+- integer -> number
+- boolean -> toggle
+
 Desired order of attributes in `component.json`:
 1. `name`
 2. `description`

--- a/.github/prompts/generator-v2-fix-delete-components.prompt.md
+++ b/.github/prompts/generator-v2-fix-delete-components.prompt.md
@@ -3,10 +3,10 @@ mode: 'agent'
 description: "You are a code generator. Your task is to refactor the provided component files (component.json and a Javascript behavior file) to make it a working component."
 ---
 
-# Fix output ports for DELETE components
+# Ensure output ports for DELETE and UPDATE components
 - Applies only to components that use the DELETE method in `context.httpRequest`.
 ## Behavior javascript file
-- Ensure that components using the DELETE method in `context.httpRequest` return `context.sendJson({}, 'out');` to indicate success.
+- Ensure that components using the DELETE/PATCH/PUT method in `context.httpRequest` return `context.sendJson({}, 'out');` to indicate success.
 - Remove any unused variables caused by refactoring the output port.
 ## component.json
-- The 'out' port for these components should be defined as `{"name": "out", "options": []}`.
+- The 'out' port for these components should be defined as `["out"]`.

--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.resend",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/resend/core/UpdateContact/component.json
+++ b/src/appmixer/resend/core/UpdateContact/component.json
@@ -98,7 +98,7 @@
                         "label": "Last Name"
                     },
                     "unsubscribed": {
-                        "type": "checkbox",
+                        "type": "toggle",
                         "index": 6,
                         "tooltip": "The subscription status.",
                         "label": "Unsubscribed"

--- a/src/appmixer/resend/core/UpdateDomain/component.json
+++ b/src/appmixer/resend/core/UpdateDomain/component.json
@@ -50,13 +50,13 @@
                         "index": 1
                     },
                     "open_tracking": {
-                        "type": "checkbox",
+                        "type": "toggle",
                         "label": "Open Tracking",
                         "tooltip": "Track the open rate of each email.",
                         "index": 2
                     },
                     "click_tracking": {
-                        "type": "checkbox",
+                        "type": "toggle",
                         "label": "Click Tracking",
                         "tooltip": "Track clicks within the body of each HTML email.",
                         "index": 3


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/2353#issuecomment-3195121062

Fixed by updated prompt (gpt-5 mini)
> Check component.json files for Resend connector. Focus on inPorts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated inspector inputs to use toggles instead of checkboxes:
    * UpdateContact: unsubscribed
    * UpdateDomain: open_tracking, click_tracking

* **Documentation**
  * Added guidelines for mapping input types (string → text/textarea; integer → number; boolean → toggle).
  * Recommended attribute order for component configuration metadata.

* **Chores**
  * Bumped Resend bundle version to 1.0.1 and updated changelog accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->