### PR TITLE
GoogleSheets.CountRows (patch) Bug fix if no rows in sheet

### DIFF
--- a/src/appmixer/google/spreadsheets/CountRows/CountRows.js
+++ b/src/appmixer/google/spreadsheets/CountRows/CountRows.js
@@ -18,7 +18,7 @@ module.exports = {
             majorDimension: 'ROWS'
         }).then(res => {
             const row = {
-                count: res['values'].length
+                count: res.values ? res.values.length : 0
             };
             return context.sendJson(row, 'rowCount');
         });

--- a/src/appmixer/google/spreadsheets/bundle.json
+++ b/src/appmixer/google/spreadsheets/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.spreadsheets",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -66,6 +66,9 @@
         ],
         "4.0.1": [
             "Create Row, Create Rows, Delete Rows: Added `spreadsheets.readonly` scope, as it is necessary for obtaining dynamic input values for the 'Worksheet' field."
+        ],
+        "4.0.2": [
+            "Handled the case in Count Rows if there are no rows in the spreadsheet."
         ]
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Count Rows now gracefully handles empty or missing data in spreadsheets, returning 0 instead of failing. This prevents errors and improves reliability when sheets have no rows or unavailable values.

- Chores
  - Bumped version to 4.0.2.
  - Updated changelog to reflect improved handling of empty spreadsheets in Count Rows.

No user action required; existing setups benefit from increased stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->