### PR TITLE
Airtable.CreateOrUpdateRecord, ListRecord, multiselect fixed

### DIFF
--- a/src/appmixer/airtable/bundle.json
+++ b/src/appmixer/airtable/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.airtable",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "changelog": {
         "1.0.4": [
             "Initial release"
@@ -21,6 +21,9 @@
             "(changed) CreateRecord + UpdateRecord: fields for mapping are now dynamically generated based on a Table selected.",
             "(changed) DeleteRecord -> DeleteRecords: now accepts multiple Record IDs for deletion, up to 10.",
             "(updated) ListRecords, GetRecord: output now offers dynamically generated fields for mapping based on a Table selected."
+        ],
+        "3.0.1": [
+            "Fixed issue with CreateOrUpdateRecord and ListRecords showing must be array."
         ]
     }
 }

--- a/src/appmixer/airtable/lib.js
+++ b/src/appmixer/airtable/lib.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+
+    /**
+     * Normalize multiselect input (array or string) to array format for Airtable API.
+     * @param {string|string[]} input
+     * @param {number} maxItems
+     * @param {object} context
+     * @param {string} fieldName
+     * @returns {string[]}
+     */    normalizeMultiselectInput(input, maxItems, context, fieldName) {
+
+        let normalizedInput;
+
+        if (Array.isArray(input)) {
+            normalizedInput = input;
+        } else if (typeof input === 'string') {
+            // Handle comma-separated string
+            normalizedInput = input.split(',').map(item => item.trim()).filter(item => item.length > 0);
+        } else {
+            throw new context.CancelError(`${fieldName} must be a string or an array`);
+        }
+
+        if (maxItems !== Infinity && normalizedInput.length > maxItems) {
+            throw new context.CancelError(`Cannot have more than ${maxItems} fields selected in ${fieldName}.`);
+        }
+
+        return normalizedInput;
+    }
+};

--- a/src/appmixer/airtable/records/CreateOrUpdateRecord/CreateOrUpdateRecord.js
+++ b/src/appmixer/airtable/records/CreateOrUpdateRecord/CreateOrUpdateRecord.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const { transformFieldstoBodyFields } = require('../../airtable-commons');
+const lib = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
+
         const {
             baseId, tableId, fieldsToMergeOn,
             returnFieldsByFieldId = false, typecast = false
@@ -13,9 +15,7 @@ module.exports = {
         const fields = context.messages.in.content;
         const { recordId } = fields;
 
-        if (fieldsToMergeOn.length > 3) {
-            throw new context.CancelError('Cannot have more than 3 fields selected in Merge Fields.');
-        }
+        const normalizedFieldsToMergeOn = lib.normalizeMultiselectInput(fieldsToMergeOn, 3, context, 'Merge Fields');
 
         const bodyFields = transformFieldstoBodyFields(fields);
 
@@ -23,7 +23,7 @@ module.exports = {
             returnFieldsByFieldId,
             typecast,
             performUpsert: {
-                fieldsToMergeOn
+                fieldsToMergeOn: normalizedFieldsToMergeOn
             },
             records: [{ fields: bodyFields, id: recordId }]
         };

--- a/src/appmixer/airtable/records/CreateOrUpdateRecord/component.json
+++ b/src/appmixer/airtable/records/CreateOrUpdateRecord/component.json
@@ -22,10 +22,7 @@
             "properties": {
                 "baseId": { "type": "string" },
                 "tableId": { "type": "string" },
-                "fieldsToMergeOn": {
-                    "type": "array",
-                    "items": { "type": "string" }
-                }
+                "fieldsToMergeOn": {}
             },
             "required": [
                 "baseId","tableId","fieldsToMergeOn"

--- a/src/appmixer/airtable/records/ListRecords/ListRecords.js
+++ b/src/appmixer/airtable/records/ListRecords/ListRecords.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { sendArrayOutput } = require('../../airtable-commons');
+const lib = require('../../lib');
 
 module.exports = {
 
@@ -21,7 +22,8 @@ module.exports = {
             cellFormat: 'json'
         };
         if (fields) {
-            queryParams.fields = fields.length > 0 ? fields : undefined;
+            const normalizedFields = lib.normalizeMultiselectInput(fields, Infinity, context, 'Fields');
+            queryParams.fields = normalizedFields.length > 0 ? normalizedFields : undefined;
         }
         if (filterByFormula) {
             queryParams.filterByFormula = filterByFormula.trim();

--- a/src/appmixer/airtable/records/ListRecords/component.json
+++ b/src/appmixer/airtable/records/ListRecords/component.json
@@ -67,7 +67,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "fields": { "type": "array", "items": { "type": "string"} },
+                    "fields": {},
                     "filterByFormula": { "type": "string" },
                     "maxRecords": { "type": "number" },
                     "sort": { "type": "string" },

--- a/test/airtable/lib.test.js
+++ b/test/airtable/lib.test.js
@@ -1,0 +1,65 @@
+const assert = require('assert');
+
+describe('lib.js', () => {
+
+    describe('normalizeMultiselectInput', () => {
+
+        const context = { CancelError: class CancelError extends Error {} };
+
+        it('should return array of fieldIds as is', () => {
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput(['field1', 'field2', 'field3'], 3, context, 'fieldsToMergeOn');
+            assert.deepStrictEqual(result, ['field1', 'field2', 'field3']);
+        });
+
+        it('should convert comma-separated string to array', () => {
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput('field1,field2,field3', 3, context, 'fieldsToMergeOn');
+            assert.deepStrictEqual(result, ['field1', 'field2', 'field3']);
+        });
+
+        it('should handle comma-separated string with spaces', () => {
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput('field1, field2 , field3', 3, context, 'fieldsToMergeOn');
+            assert.deepStrictEqual(result, ['field1', 'field2', 'field3']);
+        });
+
+        it('should filter out empty strings from comma-separated input', () => {
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput('field1,,field2,', 3, context, 'fieldsToMergeOn');
+            assert.deepStrictEqual(result, ['field1', 'field2']);
+        });
+
+        it('should throw if array exceeds maxItems', () => {
+            assert.throws(() => {
+                require('../../src/appmixer/airtable/lib').normalizeMultiselectInput(['field1', 'field2', 'field3', 'field4'], 3, context, 'fieldsToMergeOn');
+            }, context.CancelError);
+        });
+
+        it('should throw if comma-separated string exceeds maxItems', () => {
+            assert.throws(() => {
+                require('../../src/appmixer/airtable/lib').normalizeMultiselectInput('field1,field2,field3,field4', 3, context, 'fieldsToMergeOn');
+            }, context.CancelError);
+        });
+
+        it('should throw if input is not array or string', () => {
+            assert.throws(() => {
+                require('../../src/appmixer/airtable/lib').normalizeMultiselectInput(123, 3, context, 'fieldsToMergeOn');
+            }, context.CancelError);
+        });
+
+        it('should not throw when maxItems is Infinity', () => {
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput(['field1', 'field2', 'field3', 'field4', 'field5'], Infinity, context, 'fields');
+            assert.deepStrictEqual(result, ['field1', 'field2', 'field3', 'field4', 'field5']);
+        });
+
+        it('should handle large arrays when maxItems is Infinity', () => {
+            const largeArray = Array.from({ length: 100 }, (_, i) => `field${i + 1}`);
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput(largeArray, Infinity, context, 'fields');
+            assert.deepStrictEqual(result, largeArray);
+        });
+
+        it('should handle large comma-separated string when maxItems is Infinity', () => {
+            const largeString = Array.from({ length: 100 }, (_, i) => `field${i + 1}`).join(',');
+            const expectedArray = Array.from({ length: 100 }, (_, i) => `field${i + 1}`);
+            const result = require('../../src/appmixer/airtable/lib').normalizeMultiselectInput(largeString, Infinity, context, 'fields');
+            assert.deepStrictEqual(result, expectedArray);
+        });
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved errors when providing multiselect inputs in CreateOrUpdateRecord and ListRecords.
  * Inputs now accept arrays or comma-separated strings, ignore empty values, and enforce selection limits.
  * Ensures only valid, non-empty fields are sent to Airtable.

* **Tests**
  * Added comprehensive unit tests for multiselect input normalization.

* **Chores**
  * Bumped Airtable bundle version to 3.0.1 and updated changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->