### PR TITLE
canvas.CreateAssignment.fixed multiselect

### DIFF
--- a/src/appmixer/canvas/assignments/CreateAssignment/CreateAssignment.js
+++ b/src/appmixer/canvas/assignments/CreateAssignment/CreateAssignment.js
@@ -1,5 +1,6 @@
 'use strict';
 const Canvas = require('../../canvas-sdk');
+const lib = require('../../lib');
 
 module.exports = {
 
@@ -29,6 +30,10 @@ module.exports = {
             allowedAttempts
         } = context.messages.in.content;
 
+        // Normalize multiselect inputs
+        const normalizedSubmissionTypes = submissionTypes ?
+            lib.normalizeMultiselectInput(submissionTypes, 9, context, 'Submission Types') : undefined;
+
         const { auth } = context;
         const accessToken = auth.accessToken;
         const client = new Canvas(accessToken, context);
@@ -38,7 +43,7 @@ module.exports = {
             assignment_group_id: assignmentGroupId,
             description,
             position,
-            submission_types: submissionTypes,
+            submission_types: normalizedSubmissionTypes,
             due_at: dueAt,
             lock_at: lockAt,
             unlock_at: unlockAt,

--- a/src/appmixer/canvas/assignments/CreateAssignment/component.json
+++ b/src/appmixer/canvas/assignments/CreateAssignment/component.json
@@ -16,7 +16,7 @@
                     "name": { "type": "string" },
                     "description": { "type": "string" },
                     "position": { "type": "number" },
-                    "submissionTypes": { "type": "array" },
+                    "submissionTypes": {},
                     "dueAt": { "type": "string" },
                     "lockAt": { "type": "string" },
                     "unlockAt": { "type": "string" },

--- a/src/appmixer/canvas/assignments/CreateAssignment/component.json
+++ b/src/appmixer/canvas/assignments/CreateAssignment/component.json
@@ -16,7 +16,7 @@
                     "name": { "type": "string" },
                     "description": { "type": "string" },
                     "position": { "type": "number" },
-                    "submissionTypes": {},
+                    "submissionTypes": { "type": ["array", "string"] },
                     "dueAt": { "type": "string" },
                     "lockAt": { "type": "string" },
                     "unlockAt": { "type": "string" },

--- a/src/appmixer/canvas/assignments/CreateAssignment/component.json
+++ b/src/appmixer/canvas/assignments/CreateAssignment/component.json
@@ -56,8 +56,8 @@
                         "source": {
                             "url": "/component/appmixer/canvas/courses/ListAssignmentGroups?outPort=out",
                             "data": {
-                                "properties": {
-                                    "courseId": "inputs/in/courseId"
+                                "messages": {
+                                    "in/courseId": "inputs/in/courseId"
                                 },
                                 "transform": "./ListAssignmentGroups#toSelectArray"
                             }

--- a/src/appmixer/canvas/bundle.json
+++ b/src/appmixer/canvas/bundle.json
@@ -1,11 +1,15 @@
 {
     "name": "appmixer.canvas",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.0.1": ["Updated the dependencies."],
         "1.0.2": ["Updated the tooltips and component name."],
         "1.0.3": ["Added the error handler."],
-        "1.0.4": ["Added 'in' port."]
+        "1.0.4": ["Added 'in' port."],
+        "1.0.5": [
+            "Added multiselect input normalization for submissionTypes in CreateAssignment component.",
+            "Enhanced input validation and error handling for better user experience."
+        ]
     }
 }

--- a/src/appmixer/canvas/courses/ListAssignmentGroups/ListAssignmentGroups.js
+++ b/src/appmixer/canvas/courses/ListAssignmentGroups/ListAssignmentGroups.js
@@ -13,11 +13,11 @@ module.exports = {
 
         const { data } = await client.listAssignmentGroups(courseId);
 
-        return context.sendJson({ assigmentGroups: data }, 'out');
+        return context.sendJson({ assignmentGroups: data }, 'out');
     },
 
-    toSelectArray({ assigmentGroups }) {
-        return assigmentGroups.map(group => {
+    toSelectArray({ assignmentGroups }) {
+        return assignmentGroups.map(group => {
             return { label: group.name, value: group.id };
         });
     }

--- a/src/appmixer/canvas/lib.js
+++ b/src/appmixer/canvas/lib.js
@@ -1,0 +1,32 @@
+'use strict';
+
+module.exports = {
+
+    /**
+     * Normalize multiselect input (array or string) to array format for Canvas API.
+     * @param {string|string[]} input
+     * @param {number} maxItems
+     * @param {object} context
+     * @param {string} fieldName
+     * @returns {string[]}
+     */
+    normalizeMultiselectInput(input, maxItems, context, fieldName) {
+
+        let normalizedInput;
+
+        if (Array.isArray(input)) {
+            normalizedInput = input;
+        } else if (typeof input === 'string') {
+            // Handle comma-separated string
+            normalizedInput = input.split(',').map(item => item.trim()).filter(item => item.length > 0);
+        } else {
+            throw new context.CancelError(`${fieldName} must be a string or an array`);
+        }
+
+        if (maxItems !== Infinity && normalizedInput.length > maxItems) {
+            throw new context.CancelError(`Cannot have more than ${maxItems} items selected in ${fieldName}.`);
+        }
+
+        return normalizedInput;
+    }
+};

--- a/test/canvas/lib.test.js
+++ b/test/canvas/lib.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+
+describe('lib.js', () => {
+
+    describe('normalizeMultiselectInput', () => {
+
+        const context = { CancelError: class CancelError extends Error {} };
+
+        it('should return array of submission types as is', () => {
+            const result = require('../../src/appmixer/canvas/lib').normalizeMultiselectInput(['online_quiz', 'online_upload', 'online_text_entry'], 10, context, 'submissionTypes');
+            assert.deepStrictEqual(result, ['online_quiz', 'online_upload', 'online_text_entry']);
+        });
+
+        it('should convert comma-separated string to array', () => {
+            const result = require('../../src/appmixer/canvas/lib').normalizeMultiselectInput('online_quiz,online_upload,online_text_entry', 10, context, 'submissionTypes');
+            assert.deepStrictEqual(result, ['online_quiz', 'online_upload', 'online_text_entry']);
+        });
+
+        it('should handle comma-separated string with spaces', () => {
+            const result = require('../../src/appmixer/canvas/lib').normalizeMultiselectInput('online_quiz, online_upload , online_text_entry', 10, context, 'submissionTypes');
+            assert.deepStrictEqual(result, ['online_quiz', 'online_upload', 'online_text_entry']);
+        });
+
+        it('should filter out empty strings from comma-separated input', () => {
+            const result = require('../../src/appmixer/canvas/lib').normalizeMultiselectInput('online_quiz,,online_upload,', 10, context, 'submissionTypes');
+            assert.deepStrictEqual(result, ['online_quiz', 'online_upload']);
+        });
+
+        it('should throw if array exceeds maxItems', () => {
+            const largeArray = Array.from({ length: 11 }, (_, i) => `submission_type_${i + 1}`);
+            assert.throws(() => {
+                require('../../src/appmixer/canvas/lib').normalizeMultiselectInput(largeArray, 10, context, 'submissionTypes');
+            }, context.CancelError);
+        });
+
+        it('should throw if comma-separated string exceeds maxItems', () => {
+            const largeString = Array.from({ length: 11 }, (_, i) => `submission_type_${i + 1}`).join(',');
+            assert.throws(() => {
+                require('../../src/appmixer/canvas/lib').normalizeMultiselectInput(largeString, 10, context, 'submissionTypes');
+            }, context.CancelError);
+        });
+
+        it('should throw if input is not array or string', () => {
+            assert.throws(() => {
+                require('../../src/appmixer/canvas/lib').normalizeMultiselectInput(123, 10, context, 'submissionTypes');
+            }, context.CancelError);
+        });
+
+        it('should not throw when maxItems is Infinity', () => {
+            const largeArray = Array.from({ length: 50 }, (_, i) => `submission_type_${i + 1}`);
+            const result = require('../../src/appmixer/canvas/lib').normalizeMultiselectInput(largeArray, Infinity, context, 'submissionTypes');
+            assert.deepStrictEqual(result, largeArray);
+        });
+
+        it('should handle Canvas submission types', () => {
+            const canvasSubmissionTypes = ['online_quiz', 'on_paper', 'discussion_topic', 'external_tool', 'online_upload', 'online_text_entry', 'online_url', 'media_recording', 'student_annotation'];
+            const result = require('../../src/appmixer/canvas/lib').normalizeMultiselectInput(canvasSubmissionTypes, 10, context, 'submissionTypes');
+            assert.deepStrictEqual(result, canvasSubmissionTypes);
+        });
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Create Assignment accepts multiselect submission types as arrays or comma-separated strings and normalizes them for submission.
- Bug Fixes
  - Fixed misspelled assignment group field to ensure correct display and mapping.
  - Improved input validation and error handling to prevent invalid submissions.
  - Corrected inspector wiring for assignment group selection.
- Tests
  - Added tests covering multiselect input normalization and validation.
- Chores
  - Version bumped to 1.0.5 with updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->