### PR TITLE
Zoom (patch) - Create/Update Meeting correct start time

### DIFF
--- a/src/appmixer/zoom/bundle.json
+++ b/src/appmixer/zoom/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.zoom",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/zoom/meeting/CreateMeeting/CreateMeeting.js
+++ b/src/appmixer/zoom/meeting/CreateMeeting/CreateMeeting.js
@@ -8,7 +8,8 @@ module.exports = {
         // Build request body
         const requestBody = {
             topic,
-            start_time: startTime,
+            // start_time MUST be in format 'yyyy-MM-ddTHH:mm:ssZ'
+            start_time: startTime ? startTime.replace(/\.\d{3}Z$/, 'Z') : undefined,
             duration,
             password,
             agenda

--- a/src/appmixer/zoom/meeting/UpdateMeeting/UpdateMeeting.js
+++ b/src/appmixer/zoom/meeting/UpdateMeeting/UpdateMeeting.js
@@ -12,7 +12,8 @@ module.exports = {
         // Build request body
         const requestBody = {
             topic,
-            start_time: startTime,
+            // start_time MUST be in format 'yyyy-MM-ddTHH:mm:ssZ'
+            start_time: startTime ? startTime.replace(/\.\d{3}Z$/, 'Z') : undefined,
             duration,
             password,
             agenda


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of meeting start time for Zoom Create/Update actions to ensure a correct ISO 8601 format, preventing issues with timestamps that include milliseconds. If no start time is provided, the field is omitted.

* **Chores**
  * Bumped Zoom integration version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->