### PR TITLE
Sonar ignore for `utils/chat/chat.bundle.js`

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           args: >
             -Dsonar.projectKey=clientIO_appmixer-connectors_AY7J_O6GZsPR2eThxIf0
+            -Dsonar.verbose=true
             -Dsonar.sources=src
             -Dsonar.tests=test
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,11 +30,10 @@ jobs:
         with:
           args: >
             -Dsonar.projectKey=clientIO_appmixer-connectors_AY7J_O6GZsPR2eThxIf0
-            -Dsonar.verbose=true
             -Dsonar.sources=src
             -Dsonar.tests=test
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.exclusions=test/**/*.*,src/appmixer/utils/chat/chat.bundle.js
+            -Dsonar.exclusions=test/**,src/appmixer/utils/chat/chat.bundle.js
             -Dsonar.coverage.exclusions=node_modules/**,test/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - dev
-      - sonar*
+      # - sonar*
 
 jobs:
   sonarqube:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - dev
-      # - sonar*
+      - sonar*
 
 jobs:
   sonarqube:
@@ -33,7 +33,7 @@ jobs:
             -Dsonar.sources=src
             -Dsonar.tests=test
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.exclusions=*/test/**
+            -Dsonar.exclusions=*/test/**,src/appmixer/utils/chat/chat.bundle.js
             -Dsonar.coverage.exclusions=node_modules/**,test/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,7 +33,7 @@ jobs:
             -Dsonar.sources=src
             -Dsonar.tests=test
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.exclusions=test/**,src/appmixer/utils/chat/chat.bundle.js
+            -Dsonar.exclusions=**/test/**,src/appmixer/utils/chat/chat.bundle.js
             -Dsonar.coverage.exclusions=node_modules/**,test/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,7 +33,7 @@ jobs:
             -Dsonar.sources=src
             -Dsonar.tests=test
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.exclusions=*/test/**,src/appmixer/utils/chat/chat.bundle.js
+            -Dsonar.exclusions=test/**,src/appmixer/utils/chat/chat.bundle.js
             -Dsonar.coverage.exclusions=node_modules/**,test/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,7 +33,7 @@ jobs:
             -Dsonar.sources=src
             -Dsonar.tests=test
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.exclusions=**/test/**,src/appmixer/utils/chat/chat.bundle.js
+            -Dsonar.exclusions=test/**/*.*,src/appmixer/utils/chat/chat.bundle.js
             -Dsonar.coverage.exclusions=node_modules/**,test/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.projectKey=clientIO_appmixer-connectors_AY7J_O6GZsPR2eThxIf0


### PR DESCRIPTION
In https://github.com/clientIO/appmixer-connectors/pull/672/files#diff-5821b62dcf53aac984493511bea212fa71cb234d06d3b0956b0f293b521ab790 there was a large bundled file introduced that messed up our SonarQube stats.

Lets ignore it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality scanning configuration to refine exclusion patterns, continuing to exclude test folders and additionally omitting a generated bundle from analysis for more consistent results.
  * Removed an obsolete project key from the code quality tool configuration.
  * These updates affect CI analysis only and do not change application features, builds, tests, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->