### PR TITLE
Stripe. MakeApiCall. (patch) Bug Fix for parameters

### DIFF
--- a/src/appmixer/stripe/bundle.json
+++ b/src/appmixer/stripe/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.stripe",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
-        "1.0.1": [
+        "1.0.2": [
             "Initial version"
         ]
     }

--- a/src/appmixer/stripe/core/MakeAPICall/MakeAPICall.js
+++ b/src/appmixer/stripe/core/MakeAPICall/MakeAPICall.js
@@ -1,10 +1,21 @@
-
 'use strict';
 
 module.exports = {
     async receive(context) {
 
         const { customEndpoint, method, parameters } = context.messages.in.content;
+
+        // Parse parameters if it's a JSON string
+        let parsedParameters = {};
+        if (parameters) {
+            if (typeof parameters === 'string') {
+                try {
+                    parsedParameters = JSON.parse(parameters);
+                } catch (error) {
+                    throw new context.CancelError('Invalid JSON format in parameters');
+                }
+            }
+        }
 
         // https://stripe.com/docs/api
         const { data } = await context.httpRequest({
@@ -15,7 +26,7 @@ module.exports = {
                 'Content-Type': 'application/x-www-form-urlencoded'
             },
             data: {
-                ...parameters
+                ...parsedParameters
             }
         });
 

--- a/src/appmixer/stripe/core/MakeAPICall/component.json
+++ b/src/appmixer/stripe/core/MakeAPICall/component.json
@@ -24,7 +24,7 @@
                         "type": "string"
                     },
                     "parameters": {
-                        "type": "object"
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/src/appmixer/stripe/core/MakeAPICall/component.json
+++ b/src/appmixer/stripe/core/MakeAPICall/component.json
@@ -47,7 +47,7 @@
                         "index": 1
                     },
                     "parameters": {
-                        "type": "text",
+                        "type": "textarea",
                         "tooltip": "Key-value object containing parameters for the API call.",
                         "label": "Parameters",
                         "index": 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MakeAPICall now accepts parameters as a JSON string, validates input, and reports a clear error for invalid JSON.
  * Parameters input in the component inspector updated to a multiline textarea.

* **Refactor**
  * Request payload construction updated to use the parsed JSON parameters.

* **Chores**
  * Bumped Stripe bundle version to 1.0.2 and updated the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->