### PR TITLE
Discord (patch) - better clarity for emoji components

### DIFF
--- a/src/appmixer/discord/bundle.json
+++ b/src/appmixer/discord/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.discord",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/discord/core/ListGuildMembersWithReactionsOnMessage/component.json
+++ b/src/appmixer/discord/core/ListGuildMembersWithReactionsOnMessage/component.json
@@ -67,8 +67,8 @@
                     },
                     "emojiId": {
                         "type": "text",
-                        "tooltip": "ID of the emoji.",
-                        "label": "Emoji ID",
+                        "tooltip": "Emoji of the reaction. For example: 🥲",
+                        "label": "Emoji",
                         "index": 3
                     },
                     "outputType": {

--- a/src/appmixer/discord/core/PostReactionWithEmoji/component.json
+++ b/src/appmixer/discord/core/PostReactionWithEmoji/component.json
@@ -59,8 +59,8 @@
                     },
                     "emojiId": {
                         "type": "text",
-                        "tooltip": "Emoji to react with",
-                        "label": "Emoji ID",
+                        "tooltip": "Emoji of the reaction. For example: 🥲",
+                        "label": "Emoji",
                         "index": 2
                     }
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Improved clarity for emoji inputs in Discord components: labels now read “Emoji” (previously “Emoji ID”) and tooltips explain usage with an example (e.g., 🥲). This helps users choose the correct emoji when listing members who reacted or posting a reaction.

- Chores
  - Updated Discord bundle version to 1.0.1 and aligned changelog accordingly. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->