### PR TITLE
Stripe.MakeAPICall.(Patch).Adding Response in Output Port and Logging

### DIFF
--- a/src/appmixer/stripe/bundle.json
+++ b/src/appmixer/stripe/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.stripe",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
-        "1.0.2": [
+        "1.0.3": [
             "Initial version"
         ]
     }

--- a/src/appmixer/stripe/core/MakeAPICall/MakeAPICall.js
+++ b/src/appmixer/stripe/core/MakeAPICall/MakeAPICall.js
@@ -30,6 +30,8 @@ module.exports = {
             }
         });
 
-        return context.sendJson(data, 'out');
+        await context.log({ step: 'http-request-success', response: data });
+
+        return context.sendJson({ response: data }, 'out');
     }
 };

--- a/src/appmixer/stripe/core/MakeAPICall/component.json
+++ b/src/appmixer/stripe/core/MakeAPICall/component.json
@@ -61,15 +61,8 @@
             "name": "out",
             "options": [
                 {
-                    "label": "Message",
-                    "value": "message",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Data",
-                    "value": "data",
+                    "label": "Response",
+                    "value": "response",
                     "schema": {
                         "type": "object",
                         "properties": {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified the Make API Call output to a single “Response” object, replacing separate “Message” and “Data” outputs.
  - Standardized the returned payload to { response: ... } for consistency.
  - Existing flows expecting previous outputs may require updates.

- Chores
  - Bumped Stripe bundle version to 1.0.3 and updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->