### PR TITLE
Jira (patch) - option for multiple clouds

### DIFF
--- a/src/appmixer/jira/auth.js
+++ b/src/appmixer/jira/auth.js
@@ -20,12 +20,12 @@ module.exports = {
                 'offline_access'
             ],
 
-            pre() {
+            pre: function() {
                 return {
                     jiraCloudSite: {
                         type: 'text',
                         name: 'JIRA Cloud Site',
-                        tooltip: "If you use multiple JIRA cloud sites, enter the site name you want to connect. If you leave this empty, the first option in the select will be always used. Expected format: '<sub_domain>.atlassian.net' Note: This must be selected as the Authorize for site option during JIRA login."
+                        tooltip: "If you use multiple JIRA cloud sites, enter the site name you want to connect. If you leave this empty, the first option in the select will be always used. Expected format: <sub_domain>.atlassian.net Note: This must be selected as the Authorize for site option during JIRA login."
                     }
                 };
             },

--- a/src/appmixer/jira/auth.js
+++ b/src/appmixer/jira/auth.js
@@ -1,4 +1,4 @@
-let params;
+'use strict';
 
 module.exports = {
 
@@ -27,7 +27,7 @@ module.exports = {
                     jiraCloudSite: {
                         type: 'text',
                         name: 'JIRA Cloud Site',
-                        tooltip: "If you use multiple JIRA cloud sites, enter the site name you want to connect. If you leave this empty, the first option in the select on the next page will be always used. Expected format: <sub_domain>.atlassian.net Note: If you enter a value here, the select on next page doesnt matter, the value here will be used as your JIRA domain."
+                        tooltip: 'If you use multiple JIRA cloud sites, enter the site name you want to connect to. If you leave this empty, the first option in the select on the next page will be always used. Expected format: <sub_domain>.atlassian.net Note: If you enter a value here, the select on next page does not matter, the value here will be used as your JIRA domain.'
                     }
                 };
             },
@@ -56,6 +56,7 @@ module.exports = {
                 // Normalize the jiraCloudSite URL to ensure it's in the correct format
                 let normalizedUrl = context.jiraCloudSite;
                 if (normalizedUrl) {
+                    normalizedUrl = normalizedUrl.trim();
                     // Ensure it ends with .atlassian.net
                     if (!normalizedUrl.toLowerCase().endsWith('.atlassian.net')) {
                         normalizedUrl += '.atlassian.net';

--- a/src/appmixer/jira/auth.js
+++ b/src/appmixer/jira/auth.js
@@ -1,3 +1,5 @@
+let params;
+
 module.exports = {
 
     type: 'oauth2',
@@ -25,7 +27,7 @@ module.exports = {
                     jiraCloudSite: {
                         type: 'text',
                         name: 'JIRA Cloud Site',
-                        tooltip: "If you use multiple JIRA cloud sites, enter the site name you want to connect. If you leave this empty, the first option in the select will be always used. Expected format: <sub_domain>.atlassian.net Note: This must be selected as the Authorize for site option during JIRA login."
+                        tooltip: "If you use multiple JIRA cloud sites, enter the site name you want to connect. If you leave this empty, the first option in the select on the next page will be always used. Expected format: <sub_domain>.atlassian.net Note: If you enter a value here, the select on next page doesnt matter, the value here will be used as your JIRA domain."
                     }
                 };
             },
@@ -51,8 +53,35 @@ module.exports = {
                     }
                 });
 
-                const cloudId = context.jiraCloudSite ?? data[0].id;
-                const { name } = data[0];
+                // Normalize the jiraCloudSite URL to ensure it's in the correct format
+                let normalizedUrl = context.jiraCloudSite;
+                if (normalizedUrl) {
+                    // Ensure it ends with .atlassian.net
+                    if (!normalizedUrl.toLowerCase().endsWith('.atlassian.net')) {
+                        normalizedUrl += '.atlassian.net';
+                    }
+
+                    // Ensure it starts with https://
+                    if (!normalizedUrl.toLowerCase().startsWith('https://')) {
+                        normalizedUrl = 'https://' + normalizedUrl;
+                    }
+                }
+
+                // Find the cloudId by matching the normalized URL
+                let cloudId;
+                let name;
+                if (normalizedUrl) {
+                    const foundSite = data.find(site => site.url === normalizedUrl);
+                    if (!foundSite) {
+                        throw new Error(`JIRA Cloud Site "${context.jiraCloudSite}" not found. Available sites: ${data.map(site => site.url).join(', ')}`);
+                    }
+                    cloudId = foundSite.id;
+                    name = foundSite.name;
+                } else {
+                    cloudId = data[0].id;
+                    name = data[0].name;
+                }
+
                 return {
                     cloudId,
                     name,

--- a/src/appmixer/jira/auth.js
+++ b/src/appmixer/jira/auth.js
@@ -20,6 +20,16 @@ module.exports = {
                 'offline_access'
             ],
 
+            pre() {
+                return {
+                    jiraCloudSite: {
+                        type: 'text',
+                        name: 'JIRA Cloud Site',
+                        tooltip: "If you use multiple JIRA cloud sites, enter the site name you want to connect. If you leave this empty, the first option in the select will be always used. Expected format: '<sub_domain>.atlassian.net' Note: This must be selected as the Authorize for site option during JIRA login."
+                    }
+                };
+            },
+
             authUrl(context) {
 
                 return 'https://auth.atlassian.com/authorize?' +
@@ -41,7 +51,8 @@ module.exports = {
                     }
                 });
 
-                const { id: cloudId, name } = data[0];
+                const cloudId = context.jiraCloudSite ?? data[0].id;
+                const { name } = data[0];
                 return {
                     cloudId,
                     name,

--- a/src/appmixer/jira/bundle.json
+++ b/src/appmixer/jira/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jira",
-    "version": "1.2.3",
+    "version": "1.3.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -39,7 +39,7 @@
         "1.2.2": [
             "CreateProject, UpdateProject, AssignIssue: fixed \"Cannot read properties of undefined (reading 'includes')\" error."
         ],
-        "1.2.3": [
+        "1.3.0": [
             "Auth: when creating a new connection, there is an option to specify the JIRA Cloud Site."
         ]
     }

--- a/src/appmixer/jira/bundle.json
+++ b/src/appmixer/jira/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jira",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -38,6 +38,9 @@
         ],
         "1.2.2": [
             "CreateProject, UpdateProject, AssignIssue: fixed \"Cannot read properties of undefined (reading 'includes')\" error."
+        ],
+        "1.2.3": [
+            "Auth: when creating a new connection, there is an option to specify the JIRA Cloud Site."
         ]
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a UI input to specify a JIRA Cloud Site when creating a connection.
  * Normalizes site input URLs for more reliable site matching.
  * Provides clearer errors when a selected site isn’t found, listing available sites.
  * Keeps prior behavior by auto-selecting the first site if none is specified.

* **Chores**
  * Version bumped to 1.3.0 and changelog updated to note the new auth option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->