### PR TITLE
Vercel (patch) - refactor

### DIFF
--- a/src/appmixer/vercel/auth.js
+++ b/src/appmixer/vercel/auth.js
@@ -18,8 +18,7 @@ module.exports = {
                 method: 'GET',
                 url: 'https://api.vercel.com/v2/user',
                 headers: {
-                    'Authorization': `Bearer ${context.apiToken}`,
-                    'Content-Type': 'application/json'
+                    'Authorization': `Bearer ${context.apiToken}`
                 }
             });
 
@@ -32,8 +31,7 @@ module.exports = {
                     method: 'GET',
                     url: 'https://api.vercel.com/v2/user',
                     headers: {
-                        'Authorization': `Bearer ${context.apiToken}`,
-                        'Content-Type': 'application/json'
+                        'Authorization': `Bearer ${context.apiToken}`
                     }
                 });
                 return true;

--- a/src/appmixer/vercel/bundle.json
+++ b/src/appmixer/vercel/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.vercel",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/vercel/core/CancelDeployment/CancelDeployment.js
+++ b/src/appmixer/vercel/core/CancelDeployment/CancelDeployment.js
@@ -20,8 +20,7 @@ module.exports = {
             method: 'PATCH',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             }
         });
 

--- a/src/appmixer/vercel/core/CreateProject/CreateProject.js
+++ b/src/appmixer/vercel/core/CreateProject/CreateProject.js
@@ -32,8 +32,7 @@ module.exports = {
             method: 'POST',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             },
             data: requestBody
         });

--- a/src/appmixer/vercel/core/CreateProject/component.json
+++ b/src/appmixer/vercel/core/CreateProject/component.json
@@ -86,7 +86,8 @@
                         "type": "toggle",
                         "tooltip": "Flag to define if the project source should be public.",
                         "label": "Public Source",
-                        "index": 6
+                        "index": 6,
+                        "defaultValue": false
                     },
                     "teamId": {
                         "type": "text",

--- a/src/appmixer/vercel/core/DeleteDeployment/DeleteDeployment.js
+++ b/src/appmixer/vercel/core/DeleteDeployment/DeleteDeployment.js
@@ -20,8 +20,7 @@ module.exports = {
             method: 'DELETE',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             }
         });
 

--- a/src/appmixer/vercel/core/DeleteProject/DeleteProject.js
+++ b/src/appmixer/vercel/core/DeleteProject/DeleteProject.js
@@ -22,8 +22,7 @@ module.exports = {
             method: 'DELETE',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             }
         });
 

--- a/src/appmixer/vercel/core/FindProjects/FindProjects.js
+++ b/src/appmixer/vercel/core/FindProjects/FindProjects.js
@@ -29,8 +29,7 @@ module.exports = {
             method: 'GET',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             }
         });
 

--- a/src/appmixer/vercel/core/GetDeployment/GetDeployment.js
+++ b/src/appmixer/vercel/core/GetDeployment/GetDeployment.js
@@ -21,8 +21,7 @@ module.exports = {
             method: 'GET',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             }
         });
 

--- a/src/appmixer/vercel/core/GetProject/GetProject.js
+++ b/src/appmixer/vercel/core/GetProject/GetProject.js
@@ -21,8 +21,7 @@ module.exports = {
             method: 'GET',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             }
         });
 

--- a/src/appmixer/vercel/core/UpdateProject/UpdateProject.js
+++ b/src/appmixer/vercel/core/UpdateProject/UpdateProject.js
@@ -27,16 +27,15 @@ module.exports = {
         const url = `https://api.vercel.com/v9/projects/${encodeURIComponent(id)}${params.toString() ? '?' + params.toString() : ''}`;
 
         // https://vercel.com/docs/rest-api/reference/projects#update-project
-        const { data } = await context.httpRequest({
+        await context.httpRequest({
             method: 'PATCH',
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.apiToken}`,
-                'Content-Type': 'application/json'
+                'Authorization': `Bearer ${context.auth.apiToken}`
             },
             data: requestBody
         });
 
-        return context.sendJson(data, 'out');
+        return context.sendJson({}, 'out');
     }
 };

--- a/src/appmixer/vercel/core/UpdateProject/component.json
+++ b/src/appmixer/vercel/core/UpdateProject/component.json
@@ -78,7 +78,8 @@
                         "type": "toggle",
                         "tooltip": "Updated public access flag.",
                         "label": "Public Source",
-                        "index": 5
+                        "index": 5,
+                        "defaultValue": false
                     },
                     "teamId": {
                         "type": "text",

--- a/src/appmixer/vercel/core/UpdateProject/component.json
+++ b/src/appmixer/vercel/core/UpdateProject/component.json
@@ -91,68 +91,6 @@
             }
         }
     ],
-    "outPorts": [
-        {
-            "name": "out",
-            "options": [
-                {
-                    "label": "Id",
-                    "value": "id",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Name",
-                    "value": "name",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Framework",
-                    "value": "framework",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Dev Command",
-                    "value": "devCommand",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Build Command",
-                    "value": "buildCommand",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Output Directory",
-                    "value": "outputDirectory",
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "label": "Public Source",
-                    "value": "publicSource",
-                    "schema": {
-                        "type": "boolean"
-                    }
-                },
-                {
-                    "label": "Updated At",
-                    "value": "updatedAt",
-                    "schema": {
-                        "type": "number"
-                    }
-                }
-            ]
-        }
-    ],
+    "outPorts": ["out"],
     "icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMjAwMTA5MDQvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvVFIvMjAwMS9SRUMtU1ZHLTIwMDEwOTA0L0RURC9zdmcxMC5kdGQiPgo8c3ZnIHZlcnNpb249IjEuMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNTEyLjAwMDAwMHB0IiBoZWlnaHQ9IjUxMi4wMDAwMDBwdCIgdmlld0JveD0iMCAwIDUxMi4wMDAwMDAgNTEyLjAwMDAwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgbWVldCI+Cgo8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCw1MTIuMDAwMDAwKSBzY2FsZSgwLjEwMDAwMCwtMC4xMDAwMDApIiBmaWxsPSIjMDAwMDAwIiBzdHJva2U9Im5vbmUiPgo8cGF0aCBkPSJNMjMxMCA1MTA5IGMtNTAyIC01NSAtOTc0IC0yNDkgLTEzNTUgLTU1NiAtMTI5IC0xMDQgLTM0MCAtMzIxIC00MzMgLTQ0NSAtMjY1IC0zNTQgLTQzNCAtNzU4IC00OTggLTExOTMgLTIyIC0xNDcgLTI5IC00MjggLTE1IC01NzUgNDIgLTQzMyAxODAgLTgzMyA0MDUgLTExNzQgNDE0IC02MjkgMTA0NyAtMTAzMiAxNzkxIC0xMTQyIDE0NyAtMjIgNDI4IC0yOSA1NzUgLTE1IDQzMyA0MiA4MzMgMTgwIDExNzQgNDA1IDYyOSA0MTQgMTAzMiAxMDQ3IDExNDIgMTc5MSAyMiAxNDcgMjkgNDI4IDE1IDU3NSAtNTEgNTI0IC0yMzggOTg4IC01NTggMTM4NSAtMTA0IDEyOSAtMzIxIDM0MCAtNDQ1IDQzMyAtMzU0IDI2NSAtNzU1IDQzMiAtMTE5MyA0OTggLTEyMSAxOCAtNDg3IDI2IC02MDUgMTN6IG05MDkgLTIzNDggYzM0NyAtNjA3IDYzMSAtMTEwNSA2MzEgLTExMDcgMCAtMiAtNTY5IC00IC0xMjY1IC00IC02OTYgMCAtMTI2NSAyIC0xMjY1IDUgMCA4IDEyNjMgMjIxNiAxMjY2IDIyMTIgMSAtMSAyODcgLTQ5OSA2MzMgLTExMDZ6Ii8+CjwvZz4KPC9zdmc+"
 }

--- a/test/vercel/CreateProject.test.js
+++ b/test/vercel/CreateProject.test.js
@@ -38,7 +38,6 @@ describe('CreateProject', () => {
                 assert.strictEqual(options.data.name, projectName);
                 assert.strictEqual(options.data.framework, 'nextjs');
                 assert(options.headers['Authorization'].includes('Bearer'));
-                assert.strictEqual(options.headers['Content-Type'], 'application/json');
 
                 // Return mock response
                 return { data: mockResponse };

--- a/test/vercel/UpdateProject.test.js
+++ b/test/vercel/UpdateProject.test.js
@@ -39,16 +39,12 @@ describe('UpdateProject', () => {
                 assert.strictEqual(options.data.name, newName);
                 assert.strictEqual(options.data.devCommand, 'npm run dev-updated');
                 assert(options.headers['Authorization'].includes('Bearer'));
-                assert.strictEqual(options.headers['Content-Type'], 'application/json');
 
                 return { data: mockUpdatedProject };
             },
             sendJson: (data, port) => {
                 assert.strictEqual(port, 'out');
-                assert(data);
-                assert.strictEqual(data.id, projectId);
-                assert.strictEqual(data.name, newName);
-                assert.strictEqual(data.devCommand, 'npm run dev-updated');
+                assert.deepStrictEqual(data, {});
                 return Promise.resolve();
             }
         };
@@ -114,9 +110,7 @@ describe('UpdateProject', () => {
             },
             sendJson: (data, port) => {
                 assert.strictEqual(port, 'out');
-                assert(data);
-                assert.strictEqual(data.id, projectId);
-                assert.strictEqual(data.name, 'new-name');
+                assert.deepStrictEqual(data, {});
                 return Promise.resolve();
             }
         };
@@ -155,9 +149,7 @@ describe('UpdateProject', () => {
             },
             sendJson: (data, port) => {
                 assert.strictEqual(port, 'out');
-                assert(data);
-                assert.strictEqual(data.id, projectId);
-                assert.strictEqual(data.publicSource, false);
+                assert.deepStrictEqual(data, {});
                 return Promise.resolve();
             }
         };


### PR DESCRIPTION
No bug fixes. Refactoring to our standards
- `context.httpRequest` call
- empty `outPorts` for update actions

Based on :copilot: Copilot agent work from https://github.com/jirihofman/appmixer-connectors/pull/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Default “Public Source” toggle is now off by default in Create Project and Update Project.

- Refactor
  - Update Project output simplified: emits a single “out” port without detailed fields.
  - Update Project now returns an empty response body after update.

- Chores
  - Version bumped to 1.0.1.

- Tests
  - Adjusted tests to reflect the simplified Update Project output and default toggle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->