### PR TITLE
SonarQube (patch) - add validation

### DIFF
--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.sonarqube",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/sonarqube/core/FindMeasureHistory/FindMeasureHistory.js
+++ b/src/appmixer/sonarqube/core/FindMeasureHistory/FindMeasureHistory.js
@@ -2,8 +2,17 @@
 
 module.exports = {
     async receive(context) {
+
         const { component, metrics, branch, from, to } = context.messages.in.content;
         const serverUrl = context.auth.serverUrl.replace(/\/$/, '');
+
+        if (!component) {
+            throw new context.CancelError('Component is required');
+        }
+
+        if (!metrics) {
+            throw new context.CancelError('Metrics is required');
+        }
 
         // https://sonar.appmixer.cloud/web_api/api/measures/search_history
         const { data } = await context.httpRequest({

--- a/src/appmixer/sonarqube/core/FindMeasures/FindMeasures.js
+++ b/src/appmixer/sonarqube/core/FindMeasures/FindMeasures.js
@@ -2,8 +2,17 @@
 
 module.exports = {
     async receive(context) {
+
         const { metricKeys, projectKeys } = context.messages.in.content;
         const serverUrl = context.auth.serverUrl.replace(/\/$/, '');
+
+        if (!metricKeys) {
+            throw new context.CancelError('Metric Keys is required');
+        }
+
+        if (!projectKeys) {
+            throw new context.CancelError('Project Keys is required');
+        }
 
         // https://sonar.appmixer.cloud/web_api/api/measures/search
         const { data } = await context.httpRequest({

--- a/src/appmixer/sonarqube/core/FindProjectQualityGateStatus/FindProjectQualityGateStatus.js
+++ b/src/appmixer/sonarqube/core/FindProjectQualityGateStatus/FindProjectQualityGateStatus.js
@@ -6,6 +6,10 @@ module.exports = {
         const { analysisId, branch, projectId, projectKey, pullRequest } = context.messages.in.content;
         const serverUrl = context.auth.serverUrl.replace(/\/$/, '');
 
+        if (!analysisId && !projectId && !projectKey) {
+            throw new context.CancelError('At least one of Analysis Id, Project Id, or Project Key is required');
+        }
+
         // SonarQube API endpoint: /api/qualitygates/project_status
         const { data } = await context.httpRequest({
             method: 'GET',

--- a/src/appmixer/sonarqube/core/ShowFileDuplications/ShowFileDuplications.js
+++ b/src/appmixer/sonarqube/core/ShowFileDuplications/ShowFileDuplications.js
@@ -2,8 +2,13 @@
 
 module.exports = {
     async receive(context) {
+
         const { key } = context.messages.in.content;
         const serverUrl = context.auth.serverUrl.replace(/\/$/, '');
+
+        if (!key) {
+            throw new context.CancelError('Key is required');
+        }
 
         // https://sonar.appmixer.cloud/web_api/api/duplications/show
         const { data } = await context.httpRequest({


### PR DESCRIPTION
When is this needed?

When variable is used and its value is `null`/`undefined`/`""`

Reproducible with using a modifier like this
<img width="496" height="328" alt="image" src="https://github.com/user-attachments/assets/a9b5ad91-b560-4712-8ec5-0731c6a47571" />

Based on https://github.com/jirihofman/appmixer-connectors/pull/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Added required-field validation across SonarQube actions:
    - Measure History: requires component and metrics.
    - Measures Search: requires metric keys and project keys.
    - Project Quality Gate Status: requires at least one of analysis ID, project ID, or project key.
    - File Duplications: requires key.
  - Clear early error messages prevent unnecessary API calls.

- Chores
  - Bumped SonarQube integration version to 1.0.1 and updated changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->