### PR TITLE
Google Analytics (minor).Generate Report - multiselect fix

### DIFF
--- a/src/appmixer/google/analytics/GenerateReport/GenerateReport.js
+++ b/src/appmixer/google/analytics/GenerateReport/GenerateReport.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const lib = require('../lib');
+
 /**
  * Component which generates report from Google Analytics 4
  * @extends {Component}
@@ -10,6 +12,25 @@ module.exports = {
 
         const { dateRanges, dimensions, metrics, customDateRanges, limit, keepEmptyRows } = context.messages.in.content;
         const { propertyId } = context.properties;
+
+        if (!propertyId) {
+            throw new context.CancelError('Property ID is required!');
+        }
+        if (!dimensions) {
+            throw new context.CancelError('Dimensions are required!');
+        }
+        if (!metrics) {
+            throw new context.CancelError('Metrics are required!');
+        }
+        if (Boolean(keepEmptyRows) === undefined) {
+            throw new context.CancelError('Keep Empty Rows flag is required!');
+        }
+
+        // Normalize multiselect inputs
+        const normalizedDimensions = dimensions ?
+            lib.normalizeMultiselectInput(dimensions, context, 'Dimensions') : [];
+        const normalizedMetrics = metrics ?
+            lib.normalizeMultiselectInput(metrics, context, 'Metrics') : [];
 
         let dateRangesArr = [];
 
@@ -50,11 +71,11 @@ module.exports = {
                     endDate: 'yesterday'
                 });
         }
-        const dimensionsArr = dimensions.map(d => {
+        const dimensionsArr = normalizedDimensions.map(d => {
             return { name: d };
         });
 
-        const metricsArr = metrics.map(m => {
+        const metricsArr = normalizedMetrics.map(m => {
             return { name: m };
         });
 

--- a/src/appmixer/google/analytics/GenerateReport/GenerateReport.js
+++ b/src/appmixer/google/analytics/GenerateReport/GenerateReport.js
@@ -22,15 +22,20 @@ module.exports = {
         if (!metrics) {
             throw new context.CancelError('Metrics are required!');
         }
-        if (Boolean(keepEmptyRows) === undefined) {
+        if (keepEmptyRows === undefined) {
             throw new context.CancelError('Keep Empty Rows flag is required!');
         }
 
         // Normalize multiselect inputs
-        const normalizedDimensions = dimensions ?
-            lib.normalizeMultiselectInput(dimensions, context, 'Dimensions') : [];
-        const normalizedMetrics = metrics ?
-            lib.normalizeMultiselectInput(metrics, context, 'Metrics') : [];
+        const normalizedDimensions = lib.normalizeMultiselectInput(dimensions, context, 'Dimensions');
+        const normalizedMetrics = lib.normalizeMultiselectInput(metrics, context, 'Metrics');
+
+        if (normalizedDimensions.length === 0) {
+            throw new context.CancelError('At least one dimension is required!');
+        }
+        if (normalizedMetrics.length === 0) {
+            throw new context.CancelError('At least one metric is required!');
+        }
 
         let dateRangesArr = [];
 

--- a/src/appmixer/google/analytics/GenerateReport/component.json
+++ b/src/appmixer/google/analytics/GenerateReport/component.json
@@ -61,16 +61,10 @@
                         }
                     },
                     "dimensions": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": ["array", "string"]
                     },
                     "metrics": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": ["array", "string"]
                     },
                     "limit": {
                         "type": "number",

--- a/src/appmixer/google/analytics/bundle.json
+++ b/src/appmixer/google/analytics/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.analytics",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -10,6 +10,9 @@
         ],
         "2.0.0": [
             "Upgrade to Google Analytics 4"
+        ],
+        "2.1.0": [
+            "Implemented multiselect input normalization for dimensions and metrics fields in GenerateReport component."
         ]
     }
 }

--- a/src/appmixer/google/analytics/lib.js
+++ b/src/appmixer/google/analytics/lib.js
@@ -1,0 +1,22 @@
+module.exports = {
+
+    /**
+     * Normalize multiselect input (array or string) to array format.
+     * Strings are treated as single values or comma-separated lists.
+     * @param {string|string[]} input
+     * @param {object} context
+     * @param {string} fieldName
+     * @returns {string[]}
+     */
+    normalizeMultiselectInput(input, context, fieldName) {
+
+        if (Array.isArray(input)) {
+            return input;
+        } else if (typeof input === 'string') {
+            // Handle single string value or comma-separated string
+            return input.split(',').map(item => item.trim()).filter(item => item.length > 0);
+        } else {
+            throw new context.CancelError(`${fieldName} must be a string or an array`);
+        }
+    }
+};

--- a/test/google/analytics/GenerateReport.test.js
+++ b/test/google/analytics/GenerateReport.test.js
@@ -1,0 +1,167 @@
+const assert = require('assert');
+const GenerateReport = require('../../../src/appmixer/google/analytics/GenerateReport/GenerateReport');
+
+// Mock context for testing
+const mockContext = {
+    CancelError: class extends Error {
+        constructor(message) {
+            super(message);
+            this.name = 'CancelError';
+        }
+    },
+    messages: {
+        in: {
+            content: {}
+        }
+    },
+    properties: {
+        propertyId: '123456789'
+    },
+    auth: {
+        accessToken: 'mock-token'
+    },
+    httpRequest: async () => ({
+        data: {
+            dimensionHeaders: [],
+            metricHeaders: [],
+            rows: []
+        }
+    }),
+    sendJson: (data) => data
+};
+
+describe('Google Analytics GenerateReport', () => {
+
+    describe('multiselect normalization', () => {
+
+        it('should normalize dimensions string input to array', async () => {
+            mockContext.messages.in.content = {
+                dimensions: 'country,city,browser',
+                metrics: ['sessions', 'users'],
+                keepEmptyRows: false
+            };
+
+            // Mock httpRequest to capture the request data
+            mockContext.httpRequest = async (config) => {
+                const body = config.data;
+
+                // Verify that dimensions were normalized to array format
+                assert(Array.isArray(body.dimensions));
+                assert.strictEqual(body.dimensions.length, 3);
+                assert.deepStrictEqual(body.dimensions, [
+                    { name: 'country' },
+                    { name: 'city' },
+                    { name: 'browser' }
+                ]);
+
+                return {
+                    data: {
+                        dimensionHeaders: [],
+                        metricHeaders: [],
+                        rows: []
+                    }
+                };
+            };
+
+            await GenerateReport.receive(mockContext);
+        });
+
+        it('should normalize metrics string input to array', async () => {
+            mockContext.messages.in.content = {
+                dimensions: ['country', 'city'],
+                metrics: 'sessions,users,pageviews',
+                keepEmptyRows: false
+            };
+
+            // Mock httpRequest to capture the request data
+            mockContext.httpRequest = async (config) => {
+                const body = config.data;
+
+                // Verify that metrics were normalized to array format
+                assert(Array.isArray(body.metrics));
+                assert.strictEqual(body.metrics.length, 3);
+                assert.deepStrictEqual(body.metrics, [
+                    { name: 'sessions' },
+                    { name: 'users' },
+                    { name: 'pageviews' }
+                ]);
+
+                return {
+                    data: {
+                        dimensionHeaders: [],
+                        metricHeaders: [],
+                        rows: []
+                    }
+                };
+            };
+
+            await GenerateReport.receive(mockContext);
+        });
+
+        it('should handle both dimensions and metrics as strings', async () => {
+            mockContext.messages.in.content = {
+                dimensions: 'country, city',
+                metrics: 'sessions, users',
+                keepEmptyRows: false
+            };
+
+            // Mock httpRequest to capture the request data
+            mockContext.httpRequest = async (config) => {
+                const body = config.data;
+
+                // Verify that both were normalized correctly
+                assert.deepStrictEqual(body.dimensions, [
+                    { name: 'country' },
+                    { name: 'city' }
+                ]);
+                assert.deepStrictEqual(body.metrics, [
+                    { name: 'sessions' },
+                    { name: 'users' }
+                ]);
+
+                return {
+                    data: {
+                        dimensionHeaders: [],
+                        metricHeaders: [],
+                        rows: []
+                    }
+                };
+            };
+
+            await GenerateReport.receive(mockContext);
+        });
+
+        it('should handle array inputs unchanged', async () => {
+            mockContext.messages.in.content = {
+                dimensions: ['country', 'city'],
+                metrics: ['sessions', 'users'],
+                keepEmptyRows: false
+            };
+
+            // Mock httpRequest to capture the request data
+            mockContext.httpRequest = async (config) => {
+                const body = config.data;
+
+                // Verify that arrays were preserved
+                assert.deepStrictEqual(body.dimensions, [
+                    { name: 'country' },
+                    { name: 'city' }
+                ]);
+                assert.deepStrictEqual(body.metrics, [
+                    { name: 'sessions' },
+                    { name: 'users' }
+                ]);
+
+                return {
+                    data: {
+                        dimensionHeaders: [],
+                        metricHeaders: [],
+                        rows: []
+                    }
+                };
+            };
+
+            await GenerateReport.receive(mockContext);
+        });
+    });
+});

--- a/test/google/analytics/lib.test.js
+++ b/test/google/analytics/lib.test.js
@@ -1,0 +1,119 @@
+const assert = require('assert');
+const { normalizeMultiselectInput } = require('../../../src/appmixer/google/analytics/lib');
+
+// Mock context for testing
+const mockContext = {
+    CancelError: class extends Error {
+        constructor(message) {
+            super(message);
+            this.name = 'CancelError';
+        }
+    }
+};
+
+describe('Google Analytics lib', () => {
+
+    describe('normalizeMultiselectInput', () => {
+
+        it('should return array as-is when input is already an array', () => {
+            const input = ['value1', 'value2'];
+            const result = normalizeMultiselectInput(input, mockContext, 'dimensions');
+            assert.deepStrictEqual(result, ['value1', 'value2']);
+            assert.strictEqual(result, input); // Should be the same reference
+        });
+
+        it('should handle single string value or comma-separated string', () => {
+            // Single value without commas
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('single', mockContext, 'dimensions'),
+                ['single']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput(' single ', mockContext, 'dimensions'),
+                ['single']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:dimension1', mockContext, 'dimensions'),
+                ['ga:dimension1']
+            );
+
+            // Comma-separated values
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:dimension1,ga:dimension2', mockContext, 'dimensions'),
+                ['ga:dimension1', 'ga:dimension2']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:metric1, ga:metric2, ga:metric3', mockContext, 'metrics'),
+                ['ga:metric1', 'ga:metric2', 'ga:metric3']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput(' ga:dimension1 , ga:dimension2 , ga:dimension3 ', mockContext, 'dimensions'),
+                ['ga:dimension1', 'ga:dimension2', 'ga:dimension3']
+            );
+        });
+
+        it('should filter out empty strings after splitting', () => {
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:dimension1,,ga:dimension2', mockContext, 'dimensions'),
+                ['ga:dimension1', 'ga:dimension2']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:metric1, , ga:metric2', mockContext, 'metrics'),
+                ['ga:metric1', 'ga:metric2']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput(',', mockContext, 'dimensions'),
+                []
+            );
+        });
+
+        it('should throw error for invalid input types', () => {
+            assert.throws(() => {
+                normalizeMultiselectInput(123, mockContext, 'dimensions');
+            }, /dimensions must be a string or an array/);
+
+            assert.throws(() => {
+                normalizeMultiselectInput(true, mockContext, 'metrics');
+            }, /metrics must be a string or an array/);
+
+            assert.throws(() => {
+                normalizeMultiselectInput(null, mockContext, 'dimensions');
+            }, /dimensions must be a string or an array/);
+        });
+
+        it('should handle edge cases', () => {
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('   ', mockContext, 'dimensions'),
+                []
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:dimension1,', mockContext, 'dimensions'),
+                ['ga:dimension1']
+            );
+            assert.deepStrictEqual(
+                normalizeMultiselectInput(',ga:dimension1', mockContext, 'dimensions'),
+                ['ga:dimension1']
+            );
+        });
+
+        it('should handle Google Analytics specific dimension and metric formats', () => {
+            // GA4 style dimensions
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('country,city,browser', mockContext, 'dimensions'),
+                ['country', 'city', 'browser']
+            );
+
+            // GA4 style metrics
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('sessions,users,pageviews', mockContext, 'metrics'),
+                ['sessions', 'users', 'pageviews']
+            );
+
+            // Mixed formats
+            assert.deepStrictEqual(
+                normalizeMultiselectInput('ga:country, city, pageTitle', mockContext, 'dimensions'),
+                ['ga:country', 'city', 'pageTitle']
+            );
+        });
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GenerateReport accepts dimensions and metrics as arrays or comma-separated strings.
  - Inputs are normalized (trimmed, empty items removed) and validated with clearer error messages.

- **Tests**
  - Added tests covering multiselect normalization and resulting request payload shapes.

- **Chores**
  - Package version bumped to 2.1.0 with changelog entry for multiselect normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->