### PR TITLE
SonarQube (patch) Improve label for `ShowFileDuplications`

### DIFF
--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.sonarqube",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
-        "1.0.1": [
+        "1.0.2": [
             "Initial version"
         ]
     }

--- a/src/appmixer/sonarqube/context-sonar.md
+++ b/src/appmixer/sonarqube/context-sonar.md
@@ -213,7 +213,7 @@ key
 required
 File key
 Example value
-my_project:/src/foo/Bar.php
+my_project:src/foo/Bar.php
 
 Example response:
 ```json

--- a/src/appmixer/sonarqube/core/ShowFileDuplications/component.json
+++ b/src/appmixer/sonarqube/core/ShowFileDuplications/component.json
@@ -28,7 +28,7 @@
                 "inputs": {
                     "key": {
                         "type": "text",
-                        "tooltip": "File key (required). Example: my_project:/src/foo/Bar.php",
+                        "tooltip": "File key. Example: my_project:src/foo/Bar.php",
                         "label": "Key",
                         "index": 0
                     }

--- a/test/sonarqube/ShowFileDuplications/ShowFileDuplications.test.js
+++ b/test/sonarqube/ShowFileDuplications/ShowFileDuplications.test.js
@@ -76,7 +76,7 @@ describe('ShowFileDuplications', function() {
             context.messages = {
                 in: {
                     content: {
-                        key: 'my_project:/src/foo/Bar.php'
+                        key: 'my_project:src/foo/Bar.php'
                     }
                 }
             };
@@ -91,7 +91,7 @@ describe('ShowFileDuplications', function() {
             assert.strictEqual(requestOptions.url, 'https://sonarqube.example.com/api/duplications/show');
 
             const params = requestOptions.params;
-            assert.strictEqual(params.key, 'my_project:/src/foo/Bar.php');
+            assert.strictEqual(params.key, 'my_project:src/foo/Bar.php');
 
             // Check auth header
             const authHeader = requestOptions.headers.Authorization;


### PR DESCRIPTION
Quick fix for Issue 2 of https://github.com/clientIO/appmixer-components/issues/2312#issuecomment-3251515093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Corrected file key format in the Show File Duplications tooltip (removed leading slash in example).
- Documentation
  - Updated API docs to use the correct file key example (removed leading slash after project key).
- Chores
  - Bumped SonarQube bundle version to 1.0.2.
  - Updated changelog mapping for the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->