### PR TITLE
Google Meet (patch) - End Active Conference fix

### DIFF
--- a/src/appmixer/googleMeet/bundle.json
+++ b/src/appmixer/googleMeet/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.googleMeet",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial version"
         ]
     }

--- a/src/appmixer/googleMeet/space/EndActiveConference/EndActiveConference.js
+++ b/src/appmixer/googleMeet/space/EndActiveConference/EndActiveConference.js
@@ -14,7 +14,7 @@ module.exports = {
         const spaceId = name.startsWith('spaces/') ? name.split('/')[1] : name;
 
         // https://developers.google.com/workspace/meet/api/reference/rest/v2/spaces/endActiveConference
-        const { data } = await context.httpRequest({
+        await context.httpRequest({
             method: 'POST',
             url: `https://meet.googleapis.com/v2/spaces/${spaceId}:endActiveConference`,
             headers: {
@@ -22,6 +22,6 @@ module.exports = {
             }
         });
 
-        return context.sendJson(data, 'out');
+        return context.sendJson({}, 'out');
     }
 };

--- a/src/appmixer/googleMeet/space/EndActiveConference/component.json
+++ b/src/appmixer/googleMeet/space/EndActiveConference/component.json
@@ -7,6 +7,7 @@
     "auth": {
         "service": "appmixer:googleMeet",
         "scope": [
+            "https://www.googleapis.com/auth/meetings.space.settings",
             "https://www.googleapis.com/auth/meetings.space.created"
         ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Google Meet authorization to include the Space Settings scope.
- Bug Fixes
  - End Active Conference now returns an empty response after a successful call instead of passing through the remote payload.
- Chores
  - Bumped package version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->