### PR TITLE
Smartsheet (minor) - multiselect

### DIFF
--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -1,10 +1,7 @@
 {
     "name": "appmixer.smartsheet",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "changelog": {
-        "2.0.6": [
-            "Implemented multiselect input normalization for include and skipRemap fields in CopyFolder, CopySheet, GetFolder, GetWorkspace, and MoveRows components."
-        ],
         "1.0.1": [
             "Smartsheet"
         ],
@@ -20,6 +17,9 @@
             "Breaking change: Bug fix in input fields of Copyfolder and MoveFolder",
             "Breaking change: Updated the input ports of UpdateRow to fix the display of correct columns to input value in the inspector",
             "Bug fix: Fixed the MoveRow component"
+        ],
+        "2.1.0": [
+            "Implemented multiselect input normalization for include and skipRemap fields in CopyFolder, CopySheet, GetFolder, GetWorkspace, and MoveRows components."
         ]
     }
 }

--- a/src/appmixer/smartsheet/bundle.json
+++ b/src/appmixer/smartsheet/bundle.json
@@ -1,7 +1,10 @@
 {
     "name": "appmixer.smartsheet",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "changelog": {
+        "2.0.6": [
+            "Implemented multiselect input normalization for include and skipRemap fields in CopyFolder, CopySheet, GetFolder, GetWorkspace, and MoveRows components."
+        ],
         "1.0.1": [
             "Smartsheet"
         ],

--- a/src/appmixer/smartsheet/core/CopyFolder/CopyFolder.js
+++ b/src/appmixer/smartsheet/core/CopyFolder/CopyFolder.js
@@ -29,9 +29,9 @@ module.exports = {
         let requestBody = {};
         lib.setProperties(requestBody, inputMapping);
 
-        const queryParameters = { 'include': input['include'],
+        const queryParameters = { 'include': input['include'] ? lib.normalizeMultiselectInput(input['include'], context, 'Include') : undefined,
             'exclude': input['exclude'],
-            'skipRemap': input['skipRemap'] };
+            'skipRemap': input['skipRemap'] ? lib.normalizeMultiselectInput(input['skipRemap'], context, 'Skip Remap') : undefined };
 
         Object.keys(queryParameters).forEach(parameter => {
             if (queryParameters[parameter]) {

--- a/src/appmixer/smartsheet/core/CopyFolder/component.json
+++ b/src/appmixer/smartsheet/core/CopyFolder/component.json
@@ -18,7 +18,7 @@
                         "type": "number"
                     },
                     "include": {
-                        "type": "array"
+                        "type": ["array", "string"]
                     },
                     "exclude": {
                         "type": "string",
@@ -27,7 +27,7 @@
                         ]
                     },
                     "skipRemap": {
-                        "type": "array"
+                        "type": ["array", "string"]
                     },
                     "destinationFolderId": {
                         "type": "number"

--- a/src/appmixer/smartsheet/core/CopySheet/CopySheet.js
+++ b/src/appmixer/smartsheet/core/CopySheet/CopySheet.js
@@ -19,6 +19,7 @@ module.exports = {
         let url = lib.getBaseUrl(context) + `/sheets/${input['sheetId']}/copy`;
 
         const headers = {};
+        const query = new URLSearchParams;
 
         const inputMapping = {
             'destinationId': input['destinationType'] === 'home' ? null : input['destinationFolderId'] || input['destinationWorkspaceId'],
@@ -28,6 +29,15 @@ module.exports = {
         let requestBody = {};
         lib.setProperties(requestBody, inputMapping);
 
+        const queryParameters = { 'include': input['include'] ? lib.normalizeMultiselectInput(input['include'], context, 'Include') : undefined,
+            'exclude': input['exclude'] };
+
+        Object.keys(queryParameters).forEach(parameter => {
+            if (queryParameters[parameter]) {
+                query.append(parameter, queryParameters[parameter]);
+            }
+        });
+
         headers['Authorization'] = 'Bearer ' + context.auth.accessToken;
 
         const req = {
@@ -36,6 +46,11 @@ module.exports = {
             data: requestBody,
             headers: headers
         };
+
+        const queryString = query.toString();
+        if (queryString) {
+            req.url += '?' + queryString;
+        }
 
         try {
             const response = await context.httpRequest(req);

--- a/src/appmixer/smartsheet/core/CopySheet/component.json
+++ b/src/appmixer/smartsheet/core/CopySheet/component.json
@@ -20,7 +20,7 @@
                     
                     
                     "include": {
-                        "type": "array"
+                        "type": ["array", "string"]
                     },
                     "exclude": {
                         "type": "string",

--- a/src/appmixer/smartsheet/core/GetFolder/GetFolder.js
+++ b/src/appmixer/smartsheet/core/GetFolder/GetFolder.js
@@ -21,7 +21,7 @@ module.exports = {
         const headers = {};
         const query = new URLSearchParams;
 
-        const queryParameters = { 'include': input['include'] };
+        const queryParameters = { 'include': input['include'] ? lib.normalizeMultiselectInput(input['include'], context, 'Include') : undefined };
 
         Object.keys(queryParameters).forEach(parameter => {
             if (queryParameters[parameter]) {

--- a/src/appmixer/smartsheet/core/GetFolder/component.json
+++ b/src/appmixer/smartsheet/core/GetFolder/component.json
@@ -19,7 +19,7 @@
                         "type": "number"
                     },
                     "include": {
-                        "type": "array"
+                        "type": ["array", "string"]
                     }
                 }
             },

--- a/src/appmixer/smartsheet/core/GetWorkspace/GetWorkspace.js
+++ b/src/appmixer/smartsheet/core/GetWorkspace/GetWorkspace.js
@@ -22,7 +22,7 @@ module.exports = {
         const query = new URLSearchParams;
 
         const queryParameters = { 'accessApiLevel': input['accessApiLevel'],
-            'include': input['include'],
+            'include': input['include'] ? lib.normalizeMultiselectInput(input['include'], context, 'Include') : undefined,
             'loadAll': input['loadAll'] };
 
         Object.keys(queryParameters).forEach(parameter => {

--- a/src/appmixer/smartsheet/core/GetWorkspace/component.json
+++ b/src/appmixer/smartsheet/core/GetWorkspace/component.json
@@ -23,7 +23,7 @@
                         "default": 0
                     },
                     "include": {
-                        "type": "array"
+                        "type": ["array", "string"]
                     },
                     "loadAll": {
                         "type": "boolean",

--- a/src/appmixer/smartsheet/core/MoveRows/MoveRows.js
+++ b/src/appmixer/smartsheet/core/MoveRows/MoveRows.js
@@ -36,7 +36,7 @@ module.exports = {
             }
         };
 
-        const queryParameters = { 'include': input['include'],
+        const queryParameters = { 'include': input['include'] ? lib.normalizeMultiselectInput(input['include'], context, 'Include') : undefined,
             'ignoreRowsNotFound': input['ignoreRowsNotFound'] };
 
         Object.keys(queryParameters).forEach(parameter => {

--- a/src/appmixer/smartsheet/core/MoveRows/component.json
+++ b/src/appmixer/smartsheet/core/MoveRows/component.json
@@ -20,7 +20,7 @@
                     
                     
                     "include": {
-                        "type": "array"
+                        "type": ["array", "string"]
                     },
                     "ignoreRowsNotFound": {
                         "type": "boolean",

--- a/src/appmixer/smartsheet/lib.js
+++ b/src/appmixer/smartsheet/lib.js
@@ -85,6 +85,26 @@ module.exports = {
         });
 
         return typeof template === 'string' ? result : JSON.parse(result);
+    },
+
+    /**
+     * Normalize multiselect input (array or string) to comma-separated string format.
+     * Arrays are joined with commas. Strings are treated as single values or comma-separated lists.
+     * @param {string|string[]} input
+     * @param {object} context
+     * @param {string} fieldName
+     * @returns {string}
+     */
+    normalizeMultiselectInput(input, context, fieldName) {
+
+        if (Array.isArray(input)) {
+            return input.join(',');
+        } else if (typeof input === 'string') {
+            // Handle single string value or comma-separated string
+            return input.split(',').map(item => item.trim()).filter(item => item.length > 0).join(',');
+        } else {
+            throw new context.CancelError(`${fieldName} must be a string or an array`);
+        }
     }
 
 };

--- a/test/smartsheet/lib.test.js
+++ b/test/smartsheet/lib.test.js
@@ -1,0 +1,120 @@
+const assert = require('assert');
+const { normalizeMultiselectInput } = require('../../src/appmixer/smartsheet/lib');
+
+// Mock context for testing
+const mockContext = {
+    CancelError: class extends Error {
+        constructor(message) {
+            super(message);
+            this.name = 'CancelError';
+        }
+    }
+};
+
+describe('Smartsheet lib', () => {
+
+    describe('normalizeMultiselectInput', () => {
+
+        it('should return comma-separated string when input is already an array', () => {
+            const input = ['value1', 'value2'];
+            const result = normalizeMultiselectInput(input, mockContext, 'include');
+            assert.strictEqual(result, 'value1,value2');
+        });
+
+        it('should handle single string value or comma-separated string', () => {
+            // Single value without commas
+            assert.strictEqual(
+                normalizeMultiselectInput('single', mockContext, 'include'),
+                'single'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput(' single ', mockContext, 'include'),
+                'single'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput('attachments', mockContext, 'include'),
+                'attachments'
+            );
+
+            // Comma-separated values
+            assert.strictEqual(
+                normalizeMultiselectInput('value1,value2', mockContext, 'include'),
+                'value1,value2'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput('value1, value2, value3', mockContext, 'include'),
+                'value1,value2,value3'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput(' value1 , value2 , value3 ', mockContext, 'include'),
+                'value1,value2,value3'
+            );
+        });
+
+        it('should filter out empty strings after splitting', () => {
+            assert.strictEqual(
+                normalizeMultiselectInput('value1,,value2', mockContext, 'include'),
+                'value1,value2'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput('value1, , value2', mockContext, 'include'),
+                'value1,value2'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput(',', mockContext, 'include'),
+                ''
+            );
+        });
+
+        it('should throw error for invalid input types', () => {
+            assert.throws(() => {
+                normalizeMultiselectInput(123, mockContext, 'include');
+            }, /include must be a string or an array/);
+
+            assert.throws(() => {
+                normalizeMultiselectInput(true, mockContext, 'include');
+            }, /include must be a string or an array/);
+
+            assert.throws(() => {
+                normalizeMultiselectInput(null, mockContext, 'include');
+            }, /include must be a string or an array/);
+        });
+
+        it('should handle edge cases', () => {
+            assert.strictEqual(
+                normalizeMultiselectInput('   ', mockContext, 'include'),
+                ''
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput('value,', mockContext, 'include'),
+                'value'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput(',value', mockContext, 'include'),
+                'value'
+            );
+        });
+
+        it('should handle Smartsheet specific multiselect values', () => {
+            // Test with Smartsheet include options
+            assert.strictEqual(
+                normalizeMultiselectInput(['attachments', 'data', 'discussions'], mockContext, 'include'),
+                'attachments,data,discussions'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput('attachments,data,discussions', mockContext, 'include'),
+                'attachments,data,discussions'
+            );
+
+            // Test with skipRemap options
+            assert.strictEqual(
+                normalizeMultiselectInput(['cellLinks', 'reports'], mockContext, 'skipRemap'),
+                'cellLinks,reports'
+            );
+            assert.strictEqual(
+                normalizeMultiselectInput('cellLinks, reports', mockContext, 'skipRemap'),
+                'cellLinks,reports'
+            );
+        });
+    });
+});


### PR DESCRIPTION
Part of https://github.com/clientIO/appmixer-components/issues/2360

:copilot: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Components now accept single or multiple values (string or array) for include and skipRemap across CopyFolder, CopySheet, GetFolder, GetWorkspace, and MoveRows.
  - CopySheet supports conditional include/exclude query parameters for more flexible requests.

- Bug Fixes
  - Normalized multi-select inputs for consistent, error-resistant handling across affected components.

- Documentation
  - Changelog updated with details for version 2.1.0.

- Tests
  - Added test coverage for multi-select input normalization.

- Chores
  - Version bumped to 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->