### PR TITLE
Improve prompts on UPDATE vs DELETE components

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -928,10 +928,10 @@ Intended for AI assistance like Copilot, CodeRabbit, Claude, etc.
 
 Behavior JS file MUST follow these rules:
 - every required input in the component.json must be also asserted in the behavior file. If missing, throw exception with `throw new context.CancelError('<human_readable_input_name> is required!')`.
-- update or delete component must return an empty object, eg `return context.sendJson({}, 'out');` at the end of the function.
+- delete component must return an empty object, eg `return context.sendJson({}, 'out');` at the end of the function.
 
 `component.json` file MUST follow these rules:
-- update or delete component must have `outPorts: ['out']`.
+- delete component must have `outPorts: ['out']`.
 - update or delete component must have at least one required input, which is the ID of the entity being updated or deleted.
 
 # Best Practices (Humans)

--- a/.github/prompts/codestyle-1.prompt.md
+++ b/.github/prompts/codestyle-1.prompt.md
@@ -8,7 +8,7 @@ For component(s) in a given Appmixer connector:
 Read both the component.json and the behavior file (the .js file with the same name as the component directory).
 
 # Refactor the component.json file to follow these rules
-Every update and delete component must have `outPorts: ['out']` in the component.json.
+Every delete component must have `outPorts: ['out']` in the component.json.
 Every update and delete component must have at least one required input, which is the `id` of the entity being updated or deleted.
 Avoid changing `icon`.
 Every inspector input of type `toggle` must have a `defaultValue` set to `false` if not specified otherwise.
@@ -22,6 +22,6 @@ Remove any unused library imports or requires.
 When making HTTP requests with context.httpRequest, prefer destructuring the response as const { data } = await context.httpRequest({ ... }) instead of const response = await context.httpRequest({ ... }).
 Apply these changes to all components for the connector if not specified otherwise.
 Avoid `json: true` in the context.httpRequest options, as it is not needed.
-Avoid `'Content-Type': 'application/json'` in the headers of context.httpRequest, as it is not needed.
+Avoid `'Content-Type': 'application/json'` in the headers of context.httpRequest, as it is the default.
 Every required input in the component.json must be also asserted in the behavior file. If missing, throw exception with `throw new context.CancelError('<human_readable_input_name> is required!')`.
-Every update and delete component must return an empty object, eg `return context.sendJson({}, 'out');` at the end of the function.
+Every delete component must return an empty object, eg `return context.sendJson({}, 'out');` at the end of the function.

--- a/.github/prompts/generator-v2-fix-delete-components.prompt.md
+++ b/.github/prompts/generator-v2-fix-delete-components.prompt.md
@@ -6,7 +6,7 @@ description: "You are a code generator. Your task is to refactor the provided co
 # Ensure output ports for DELETE and UPDATE components
 - Applies only to components that use the DELETE method in `context.httpRequest`.
 ## Behavior javascript file
-- Ensure that components using the DELETE/PATCH/PUT method in `context.httpRequest` return `context.sendJson({}, 'out');` to indicate success.
+- Ensure that components using the DELETE method in `context.httpRequest` return `context.sendJson({}, 'out');` to indicate success.
 - Remove any unused variables caused by refactoring the output port.
 ## component.json
 - The 'out' port for these components should be defined as `["out"]`.


### PR DESCRIPTION
Based on our discussion. Maybe wait for further confirmation.

This will enforce empty responses only for DELETE components.

If one also wants to apply it to UPDATE/PATCH/PUT components, they can specify it directly in a prompt.

Other possible improvements
- ensure ID is always returned for UPDATE components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated behavior guidelines: only delete operations must return an empty object; updates no longer require this.
  - Clarified port conventions: the standard “out” port is required only for delete components.
  - Refined HTTP request guidance: avoid setting Content-Type: application/json by default in headers.
  - Simplified examples and prompts to reference delete-only scenarios for return behavior.
  - Aligned component compliance and development guidelines to reflect the above rule changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->