### PR TITLE
HubSpot (fix) - ensure webhook configuration outside of AuthHub

### DIFF
--- a/src/appmixer/hubspot/BaseSubscriptionComponent.js
+++ b/src/appmixer/hubspot/BaseSubscriptionComponent.js
@@ -23,6 +23,75 @@ class BaseSubscriptionComponent {
         throw new Error('Must be extended to return subscriptions');
     }
 
+    async ensureWebhook(context) {
+
+        // Skip the check if using AuthHub
+        if (context.config.usesAuthHub) {
+            return;
+        }
+
+        // Check if we have appId and apiKey
+        const { appId, apiKey } = context.config;
+        if (!appId || !apiKey) {
+            throw new context.CancelError('HubSpot appId or apiKey missing in configuration.');
+        }
+
+        let webhookConfiguredProperly = false;
+        let existingTargetURL = null;
+        const targetURL = context.appmixerApiUrl + '/plugins/appmixer/hubspot/events';
+
+        // Use cache to avoid hitting HubSpot API too often
+        const cacheKey = 'hubspot_webhook_' + appId + '_' + apiKey;
+        let lock;
+        try {
+            // Only one trigger at a time
+            lock = await context.lock(appId + apiKey);
+
+            const targetURLCached = await context.staticCache.get(cacheKey);
+            if (targetURLCached) {
+                existingTargetURL = targetURLCached;
+            } else {
+                // Check webhooks/v3/${appId}/settings
+                const { data } = await context.httpRequest({
+                    method: 'GET',
+                    url: `https://api.hubapi.com/webhooks/v3/${appId}/settings?hapikey=${apiKey}`
+                });
+
+                await context.staticCache.set(
+                    cacheKey,
+                    data?.targetUrl || null,
+                    context.config.webhookTargetURLCacheTTL || (20 * 1000)
+                );
+
+                existingTargetURL = data?.targetUrl;
+            }
+
+            if (existingTargetURL) {
+                webhookConfiguredProperly = existingTargetURL === targetURL;
+            } else {
+                webhookConfiguredProperly = false;
+            }
+        } catch (error) {
+            // Axios errors expose the HTTP response in error.response
+            const status = error?.response?.status ?? error?.status;
+            context.log({ step: 'hubspot-plugin-error', status, code: error.code, error });
+            if (status === 404) {
+                // Webhook not found, need to register
+                context.log({ step: 'hubspot-plugin-webhook-not-found-registering', message: `Registering webhook with target URL ${targetURL}` });
+                await this.hubspot.registerWebhook(targetURL);
+            } else {
+                // Unexpected error - propagate and fail the startup
+                context.log({ step: 'hubspot-plugin-error-while-fetching-webhook-settings', status, code: error.code, error, message: `Failed to set up webhook with target URL ${targetURL}` });
+                throw new context.CancelError(`Error while fetching webhook settings: ${error.message}`);
+            }
+        } finally {
+            lock?.unlock();
+        }
+        if (!webhookConfiguredProperly) {
+            throw new context.CancelError(`HubSpot webhook not configured properly, wrong target URL. Expected: ${targetURL}, existing: ${existingTargetURL}`);
+        }
+    }
+
     async receive(context) {
 
         throw new Error('Must be extended');
@@ -31,6 +100,9 @@ class BaseSubscriptionComponent {
     async start(context) {
 
         this.configureHubspot(context);
+
+        await this.ensureWebhook(context);
+
         // Use hub_id from context to differentiate between different HubSpot portals/users.
         const portalId = context.auth?.profileInfo?.hub_id;
         return context.addListener(`${this.subscriptionType}:${portalId}`, { apiKey: context.config.apiKey, appId: context.config.appId });

--- a/src/appmixer/hubspot/BaseSubscriptionComponent.js
+++ b/src/appmixer/hubspot/BaseSubscriptionComponent.js
@@ -41,11 +41,11 @@ class BaseSubscriptionComponent {
         const targetURL = context.appmixerApiUrl + '/plugins/appmixer/hubspot/events';
 
         // Use cache to avoid hitting HubSpot API too often
-        const cacheKey = 'hubspot_webhook_' + appId + '_' + apiKey;
+        const cacheKey = 'hubspot_webhook_' + appId;
         let lock;
         try {
             // Only one trigger at a time
-            lock = await context.lock(appId + apiKey);
+            lock = await context.lock(cacheKey);
 
             const targetURLCached = await context.staticCache.get(cacheKey);
             if (targetURLCached) {

--- a/src/appmixer/hubspot/BaseSubscriptionComponent.js
+++ b/src/appmixer/hubspot/BaseSubscriptionComponent.js
@@ -60,7 +60,8 @@ class BaseSubscriptionComponent {
                 await context.staticCache.set(
                     cacheKey,
                     data?.targetUrl || null,
-                    context.config.webhookTargetURLCacheTTL || (20 * 1000)
+                    // 1 hour cache by default
+                    context.config.webhookTargetURLCacheTTL || (60 * 60 * 1000)
                 );
 
                 existingTargetURL = data?.targetUrl;

--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -66,6 +66,9 @@
         ],
         "4.2.1": [
             "Added support for Notes: added components `Create Note`, `Delete Note`, `Find Notes` and `Update Note`."
+        ],
+        "4.2.2": [
+            "Fixed an issue with triggers not working when using AuthHub. Added additional check of webhook configuration."
         ]
     }
 }

--- a/src/appmixer/hubspot/plugin.js
+++ b/src/appmixer/hubspot/plugin.js
@@ -15,7 +15,6 @@ module.exports = async context => {
     const isAuthHubInUse = !appId && !apiKey && !!clientId && !clientSecret;
     if (!(appId && apiKey) && !isAuthHubInUse && !isAuthHubPod) {
         context.log('error', 'HubSpot module not configured properly, missing appId or apiKey.');
-        return {};
     }
 
     // Register webhook only in Engine pod and if not using AuthHub.

--- a/src/appmixer/hubspot/plugin.js
+++ b/src/appmixer/hubspot/plugin.js
@@ -1,34 +1,6 @@
 'use strict';
-const Hubspot = require('./Hubspot');
 
 module.exports = async context => {
-
-    const config = require('./config')(context);
-    const { appId, apiKey } = config;
-    const { clientId, clientSecret } = context.config;
-
-    /** Is this AuthHub or Engine pod? */
-    const isAuthHubPod = !!process.env.AUTH_HUB_URL && !process.env.AUTH_HUB_TOKEN;
-
-    // When using AuthHub, the configuration is not needed in the Engine.
-    // How do we know if we are using AuthHub? We have `clientId` but not `clientSecret` and no `appId` or `apiKey`.
-    const isAuthHubInUse = !appId && !apiKey && !!clientId && !clientSecret;
-    if (!(appId && apiKey) && !isAuthHubInUse && !isAuthHubPod) {
-        context.log('error', 'HubSpot module not configured properly, missing appId or apiKey.');
-    }
-
-    // Register webhook only in Engine pod and if not using AuthHub.
-    // If appId or apiKey is missing, we cannot register the webhook here. Instead, the component startup will fail later with a clear error message.
-    if (!isAuthHubPod && !isAuthHubInUse && appId && apiKey) {
-        const baseUrl = context.appmixerApiUrl;
-        const eventsUrl = context.http.router.getPluginEndpoint('/events');
-        const url = baseUrl.concat(eventsUrl);
-        const hs = new Hubspot('', config);
-        await hs.registerWebhook(url);
-        context.hubspot = hs;
-    } else {
-        context.log('info', 'Auth hub detected, no need to register HubSpot webhook.');
-    }
 
     require('./routes')(context);
 };

--- a/src/appmixer/hubspot/plugin.js
+++ b/src/appmixer/hubspot/plugin.js
@@ -19,7 +19,8 @@ module.exports = async context => {
     }
 
     // Register webhook only in Engine pod and if not using AuthHub.
-    if (!isAuthHubPod && !isAuthHubInUse) {
+    // If appId or apiKey is missing, we cannot register the webhook here. Instead, the component startup will fail later with a clear error message.
+    if (!isAuthHubPod && !isAuthHubInUse && appId && apiKey) {
         const baseUrl = context.appmixerApiUrl;
         const eventsUrl = context.http.router.getPluginEndpoint('/events');
         const url = baseUrl.concat(eventsUrl);


### PR DESCRIPTION
Fix for https://github.com/clientIO/appmixer-components/issues/2513
- please look at the alternative solution as well

This might be just adding more complexity when none is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed trigger reliability with AuthHub.
  - Added startup webhook verification that fails fast when HubSpot webhook target mismatches.
  - Ensures webhook is registered when missing (404) and surfaces clear errors on other HubSpot failures.

- Chores
  - Bumped HubSpot bundle version to 4.2.2 and added changelog entry.

- Tests
  - Expanded tests for webhook verification, mismatch handling, and 404-based registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->