### PR TITLE
Quickbooks.(patch) Log and Tooltip for deprecated minorVersion usage

### DIFF
--- a/src/appmixer/quickbooks/accounting/Attachable/Attachable.js
+++ b/src/appmixer/quickbooks/accounting/Attachable/Attachable.js
@@ -1,6 +1,6 @@
 'use strict';
 const FormData = require('form-data');
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 module.exports = {
 
@@ -14,6 +14,9 @@ module.exports = {
             entityType,
             attachment
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         // make it multipart/form-data
         const data = new FormData();

--- a/src/appmixer/quickbooks/accounting/Attachable/component.json
+++ b/src/appmixer/quickbooks/accounting/Attachable/component.json
@@ -29,7 +29,7 @@
                         "index": 2,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "entityType": {
                         "type": "select",
@@ -45,7 +45,7 @@
                         "type": "filepicker",
                         "index": 4,
                         "label": "Attachment",
-                        "tooltip": "The file to be attached. For allowed extensions see the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/workflows/attach-images-and-notes#approved-file-types'>docs</a>."
+                        "tooltip": "The file to be attached. For allowed extensions see the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/workflows/attach-images-and-notes#approved-file-types'>docs</a>."
                     }
                 }
             },

--- a/src/appmixer/quickbooks/accounting/Attachable/component.json
+++ b/src/appmixer/quickbooks/accounting/Attachable/component.json
@@ -28,7 +28,8 @@
                         "type": "number",
                         "index": 2,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "entityType": {
                         "type": "select",

--- a/src/appmixer/quickbooks/accounting/CreateBill/CreateBill.js
+++ b/src/appmixer/quickbooks/accounting/CreateBill/CreateBill.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 module.exports = {
 
@@ -13,6 +13,9 @@ module.exports = {
             dueDate,
             ...optionalInputs
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         let lineItems = [];
         try {

--- a/src/appmixer/quickbooks/accounting/CreateBill/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateBill/component.json
@@ -29,7 +29,7 @@
                         "index": 2,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "currency": {
                         "type": "text",
@@ -51,7 +51,7 @@
                         "type": "textarea",
                         "index": 5,
                         "label": "Line Items JSON",
-                        "tooltip": "Line items in a raw JSON format. This is only for an advanced use. See <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/invoice#create-an-invoice'>Quickbooks documentation</a> for more details. An example: <code>[{ \"DetailType\": \"AccountBasedExpenseLineDetail\", \"Amount\": 50, \"Description\": \"My service\", \"AccountBasedExpenseLineDetail\": { \"AccountRef\": {\"value\":7} } }]</code>."
+                        "tooltip": "Line items in a raw JSON format. This is only for an advanced use. See <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/invoice#create-an-invoice'>Quickbooks documentation</a> for more details. An example: <code>[{ \"DetailType\": \"AccountBasedExpenseLineDetail\", \"Amount\": 50, \"Description\": \"My service\", \"AccountBasedExpenseLineDetail\": { \"AccountRef\": {\"value\":7} } }]</code>."
                     },
                     "txnDate": {
                         "type": "date-time",

--- a/src/appmixer/quickbooks/accounting/CreateBill/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateBill/component.json
@@ -28,7 +28,8 @@
                         "type": "number",
                         "index": 2,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "currency": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/CreateCustomer/CreateCustomer.js
+++ b/src/appmixer/quickbooks/accounting/CreateCustomer/CreateCustomer.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 module.exports = {
 
@@ -9,6 +9,9 @@ module.exports = {
             minorVersion,
             ...optionalInputs
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         const options = {
             path: `v3/company/${context.profileInfo.companyId}/customer?minorversion=${minorVersion}`,

--- a/src/appmixer/quickbooks/accounting/CreateCustomer/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateCustomer/component.json
@@ -57,7 +57,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "primaryEmailAddrAddress": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/CreateCustomer/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateCustomer/component.json
@@ -56,7 +56,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "primaryEmailAddrAddress": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/CreateInvoice/CreateInvoice.js
+++ b/src/appmixer/quickbooks/accounting/CreateInvoice/CreateInvoice.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 const getAddress = (context, type) => {
 
@@ -34,6 +34,9 @@ module.exports = {
             customerMemo,
             ...optionalInputs
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         // SalesItemLineDetail only from inspector expression fields.
         const lineItemsArray = lineItems?.AND?.map(item => {

--- a/src/appmixer/quickbooks/accounting/CreateInvoice/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateInvoice/component.json
@@ -40,7 +40,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "currency": {
                         "type": "text",
@@ -107,7 +107,7 @@
                         "type": "textarea",
                         "index": 5,
                         "label": "Line Items JSON",
-                        "tooltip": "Line items in a raw JSON format. This is only for an advanced use. See <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/invoice#create-an-invoice'>Quickbooks documentation</a> for more details. An example: [{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 50, \"Description\": \"My service\", \"SalesItemLineDetail\": { \"Qty\": 2 } }]."
+                        "tooltip": "Line items in a raw JSON format. This is only for an advanced use. See <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/invoice#create-an-invoice'>Quickbooks documentation</a> for more details. An example: [{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 50, \"Description\": \"My service\", \"SalesItemLineDetail\": { \"Qty\": 2 } }]."
                     },
                     "docNumber": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/CreateInvoice/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateInvoice/component.json
@@ -39,7 +39,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "currency": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/CreateVendor/CreateVendor.js
+++ b/src/appmixer/quickbooks/accounting/CreateVendor/CreateVendor.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 module.exports = {
 
@@ -9,6 +9,9 @@ module.exports = {
             minorVersion,
             ...optionalInputs
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         const options = {
             path: `v3/company/${context.profileInfo.companyId}/vendor?minorversion=${minorVersion}`,

--- a/src/appmixer/quickbooks/accounting/CreateVendor/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateVendor/component.json
@@ -54,7 +54,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "primaryEmailAddrAddress": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/CreateVendor/component.json
+++ b/src/appmixer/quickbooks/accounting/CreateVendor/component.json
@@ -53,7 +53,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "primaryEmailAddrAddress": {
                         "type": "text",

--- a/src/appmixer/quickbooks/accounting/DeleteBill/DeleteBill.js
+++ b/src/appmixer/quickbooks/accounting/DeleteBill/DeleteBill.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 module.exports = {
 
@@ -10,6 +10,9 @@ module.exports = {
             minorVersion,
             syncToken
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         const options = {
             path: `v3/company/${context.profileInfo.companyId}/bill?operation=delete&minorversion=${minorVersion}`,

--- a/src/appmixer/quickbooks/accounting/DeleteBill/component.json
+++ b/src/appmixer/quickbooks/accounting/DeleteBill/component.json
@@ -28,7 +28,7 @@
                         "index": 2,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "syncToken": {
                         "type": "number",

--- a/src/appmixer/quickbooks/accounting/DeleteBill/component.json
+++ b/src/appmixer/quickbooks/accounting/DeleteBill/component.json
@@ -27,7 +27,8 @@
                         "type": "number",
                         "index": 2,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "syncToken": {
                         "type": "number",

--- a/src/appmixer/quickbooks/accounting/FindCustomer/component.json
+++ b/src/appmixer/quickbooks/accounting/FindCustomer/component.json
@@ -197,8 +197,8 @@
                                         "value": "<="
                                     },
                                     {
-                                        "label": ">= ",
-                                        "value": ">= "
+                                        "label": ">=",
+                                        "value": ">="
                                     },
                                     {
                                         "label": "IN",

--- a/src/appmixer/quickbooks/accounting/GetBill/GetBill.js
+++ b/src/appmixer/quickbooks/accounting/GetBill/GetBill.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 module.exports = {
 
@@ -9,6 +9,9 @@ module.exports = {
             billId,
             minorVersion
         } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         const options = {
             path: `v3/company/${context.profileInfo.companyId}/bill/${billId}?minorversion=${minorVersion}`,

--- a/src/appmixer/quickbooks/accounting/GetBill/component.json
+++ b/src/appmixer/quickbooks/accounting/GetBill/component.json
@@ -28,7 +28,7 @@
                         "index": 2,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     }
                 }
             },

--- a/src/appmixer/quickbooks/accounting/GetBill/component.json
+++ b/src/appmixer/quickbooks/accounting/GetBill/component.json
@@ -27,7 +27,8 @@
                         "type": "number",
                         "index": 2,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     }
                 }
             },

--- a/src/appmixer/quickbooks/accounting/GetCompanyInfo/GetCompanyInfo.js
+++ b/src/appmixer/quickbooks/accounting/GetCompanyInfo/GetCompanyInfo.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest } = require('../../commons');
+const { makeRequest, logDeprecatedMinorVersion } = require('../../commons');
 
 /**
  * Component for making API requests.
@@ -10,6 +10,9 @@ module.exports = {
     async receive(context) {
 
         const { minorVersion } = context.messages.in.content;
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         const options = {
             path: `v3/company/${context.profileInfo.companyId}/companyinfo/${context.profileInfo.companyId}?minorversion=${minorVersion}`,

--- a/src/appmixer/quickbooks/accounting/GetCompanyInfo/component.json
+++ b/src/appmixer/quickbooks/accounting/GetCompanyInfo/component.json
@@ -22,7 +22,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     }
                 }
             }

--- a/src/appmixer/quickbooks/accounting/GetCompanyInfo/component.json
+++ b/src/appmixer/quickbooks/accounting/GetCompanyInfo/component.json
@@ -23,7 +23,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     }
                 }
             }

--- a/src/appmixer/quickbooks/accounting/ListAccounts/ListAccounts.js
+++ b/src/appmixer/quickbooks/accounting/ListAccounts/ListAccounts.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest, sendArrayOutput } = require('../../commons');
+const { makeRequest, sendArrayOutput, logDeprecatedMinorVersion } = require('../../commons');
 
 /**
  * Component for making API requests.
@@ -15,6 +15,9 @@ module.exports = {
         if (generateOutputPortOptions) {
             return this.getOutputPortOptions(context, outputType);
         }
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         /** A query for filtering the results. */
         let query = 'select * from account';

--- a/src/appmixer/quickbooks/accounting/ListAccounts/component.json
+++ b/src/appmixer/quickbooks/accounting/ListAccounts/component.json
@@ -28,7 +28,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",
@@ -39,13 +39,13 @@
                         ],
                         "index": 2,
                         "label": "Search Type",
-                        "tooltip": "Choose whether you want to search by Name or use <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
+                        "tooltip": "Choose whether you want to search by Name or use <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
                     },
                     "term": {
                         "type": "textarea",
                         "label": "Query",
                         "index": 3,
-                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all accounts with a name that contains 'foo', you would provide <code>Name LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
+                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all accounts with a name that contains 'foo', you would provide <code>Name LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
                     },
                     "maxResults": {
                         "type": "number",

--- a/src/appmixer/quickbooks/accounting/ListAccounts/component.json
+++ b/src/appmixer/quickbooks/accounting/ListAccounts/component.json
@@ -27,7 +27,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",

--- a/src/appmixer/quickbooks/accounting/ListClasses/ListClasses.js
+++ b/src/appmixer/quickbooks/accounting/ListClasses/ListClasses.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest, sendArrayOutput } = require('../../commons');
+const { makeRequest, sendArrayOutput, logDeprecatedMinorVersion } = require('../../commons');
 
 /**
  * Component for making API requests.
@@ -15,6 +15,9 @@ module.exports = {
         if (generateOutputPortOptions) {
             return this.getOutputPortOptions(context, outputType);
         }
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         /** A query for filtering the results. */
         let query = 'select * from class';

--- a/src/appmixer/quickbooks/accounting/ListClasses/component.json
+++ b/src/appmixer/quickbooks/accounting/ListClasses/component.json
@@ -28,7 +28,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",
@@ -39,13 +39,13 @@
                         ],
                         "index": 2,
                         "label": "Search Type",
-                        "tooltip": "Choose whether you want to search by Name or use <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
+                        "tooltip": "Choose whether you want to search by Name or use <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
                     },
                     "term": {
                         "type": "textarea",
                         "label": "Query",
                         "index": 3,
-                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all classes with a name that contains 'foo', you would provide <code>Name LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
+                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all classes with a name that contains 'foo', you would provide <code>Name LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
                     },
                     "maxResults": {
                         "type": "number",

--- a/src/appmixer/quickbooks/accounting/ListClasses/component.json
+++ b/src/appmixer/quickbooks/accounting/ListClasses/component.json
@@ -27,7 +27,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",

--- a/src/appmixer/quickbooks/accounting/ListCustomers/ListCustomers.js
+++ b/src/appmixer/quickbooks/accounting/ListCustomers/ListCustomers.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest, sendArrayOutput } = require('../../commons');
+const { makeRequest, sendArrayOutput, logDeprecatedMinorVersion } = require('../../commons');
 
 /**
  * Component for making API requests.
@@ -15,6 +15,9 @@ module.exports = {
         if (generateOutputPortOptions) {
             return this.getOutputPortOptions(context, outputType);
         }
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         /** A query for filtering the results. */
         let query = 'select * from customer';

--- a/src/appmixer/quickbooks/accounting/ListCustomers/component.json
+++ b/src/appmixer/quickbooks/accounting/ListCustomers/component.json
@@ -28,7 +28,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",

--- a/src/appmixer/quickbooks/accounting/ListCustomers/component.json
+++ b/src/appmixer/quickbooks/accounting/ListCustomers/component.json
@@ -29,7 +29,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",
@@ -40,13 +40,13 @@
                         ],
                         "index": 2,
                         "label": "Search Type",
-                        "tooltip": "Choose whether you want to search by Name or use <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
+                        "tooltip": "Choose whether you want to search by Name or use <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
                     },
                     "term": {
                         "type": "textarea",
                         "label": "Query",
                         "index": 3,
-                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all accounts with a name that contains 'foo', you would provide <code>Name LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
+                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all accounts with a name that contains 'foo', you would provide <code>Name LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
                     },
                     "maxResults": {
                         "type": "number",

--- a/src/appmixer/quickbooks/accounting/ListJournals/ListJournals.js
+++ b/src/appmixer/quickbooks/accounting/ListJournals/ListJournals.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest, sendArrayOutput } = require('../../commons');
+const { makeRequest, sendArrayOutput, logDeprecatedMinorVersion } = require('../../commons');
 
 /**
  * Component for making API requests.
@@ -15,6 +15,9 @@ module.exports = {
         if (generateOutputPortOptions) {
             return this.getOutputPortOptions(context, outputType);
         }
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         /** A query for filtering the results. */
         let query = 'select * from JournalEntry';

--- a/src/appmixer/quickbooks/accounting/ListJournals/component.json
+++ b/src/appmixer/quickbooks/accounting/ListJournals/component.json
@@ -28,7 +28,7 @@
                         "index": 1,
                         "label": "Minor Version",
                         "defaultValue": 75,
-                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",
@@ -39,13 +39,13 @@
                         ],
                         "index": 2,
                         "label": "Search Type",
-                        "tooltip": "Choose whether you want to search by DocNumber or use <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
+                        "tooltip": "Choose whether you want to search by DocNumber or use <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
                     },
                     "term": {
                         "type": "textarea",
                         "label": "Query",
                         "index": 3,
-                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all classes with a name that contains 'foo', you would provide <code>docnumber LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
+                        "tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all classes with a name that contains 'foo', you would provide <code>docnumber LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
                     },
                     "maxResults": {
                         "type": "number",

--- a/src/appmixer/quickbooks/accounting/ListJournals/component.json
+++ b/src/appmixer/quickbooks/accounting/ListJournals/component.json
@@ -27,7 +27,8 @@
                         "type": "number",
                         "index": 1,
                         "label": "Minor Version",
-                        "tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+                        "defaultValue": 75,
+                        "tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
                     },
                     "searchType": {
                         "type": "select",

--- a/src/appmixer/quickbooks/accounting/ListVendors/ListVendors.js
+++ b/src/appmixer/quickbooks/accounting/ListVendors/ListVendors.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeRequest, sendArrayOutput } = require('../../commons');
+const { makeRequest, sendArrayOutput, logDeprecatedMinorVersion } = require('../../commons');
 
 /**
  * Component for making API requests.
@@ -15,6 +15,9 @@ module.exports = {
         if (generateOutputPortOptions) {
             return this.getOutputPortOptions(context, outputType);
         }
+
+        // Log warning for deprecated minor versions
+        await logDeprecatedMinorVersion(context, minorVersion);
 
         /** A query for filtering the results. */
         let query = 'select * from vendor';

--- a/src/appmixer/quickbooks/accounting/ListVendors/component.json
+++ b/src/appmixer/quickbooks/accounting/ListVendors/component.json
@@ -38,7 +38,8 @@
 						"type": "number",
 						"index": 1,
 						"label": "Minor Version",
-						"tooltip": "Minor version of the request. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+						"defaultValue": 75,
+						"tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
 					},
 					"searchType": {
 						"type": "select",

--- a/src/appmixer/quickbooks/accounting/ListVendors/component.json
+++ b/src/appmixer/quickbooks/accounting/ListVendors/component.json
@@ -39,7 +39,7 @@
 						"index": 1,
 						"label": "Minor Version",
 						"defaultValue": 75,
-						"tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
+						"tooltip": "Minor version of the request. Note: Versions below 75 are ignored and will default to version 75. Use version 75 or higher for current features. See the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions'>docs</a> for more details."
 					},
 					"searchType": {
 						"type": "select",
@@ -59,13 +59,13 @@
 						],
 						"index": 2,
 						"label": "Search Type",
-						"tooltip": "Choose whether you want to search by Name or use <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
+						"tooltip": "Choose whether you want to search by Name or use <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/class#query-a-class'>advanced query</a> to filter records."
 					},
 					"term": {
 						"type": "textarea",
 						"label": "Query",
 						"index": 3,
-						"tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all classes with a name that contains 'foo', you would provide <code>DisplayName LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target=_blank href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
+						"tooltip": "Search by name or provide an advanced query. When providing a query note that only the part after the WHERE clause should be provided. For example, if you want to search for all classes with a name that contains 'foo', you would provide <code>DisplayName LIKE '%foo%'</code> as the query. For even more advanced queries, use Query component. For more details and limitations of the query, see the <a target='_blank' rel='noopener noreferrer' href='https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/data-queries'>Query operations and syntax docs</a>."
 					},
 					"maxResults": {
 						"type": "number",

--- a/src/appmixer/quickbooks/accounting/Query/component.json
+++ b/src/appmixer/quickbooks/accounting/Query/component.json
@@ -24,7 +24,7 @@
                         "type": "textarea",
                         "label": "Query",
                         "index": 1,
-                        "tooltip": "See <a target=_blank href='https://intuitdeveloper.github.io/intuit-api-docs/docs/graphql-concepts/'>Quickbooks docs</a> for details."
+                        "tooltip": "See <a target='_blank' rel='noopener noreferrer' href='https://intuitdeveloper.github.io/intuit-api-docs/docs/graphql-concepts/'>Quickbooks docs</a> for details."
                     },
                     "outputType": {
                         "type": "select",

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.quickbooks",
-    "version": "1.5.4",
+    "version": "1.5.5",
     "changelog": {
         "1.0.0": ["Initial version."],
         "1.1.0": [
@@ -45,6 +45,9 @@
         ],
         "1.5.4": [
             "Improve performance of receiving webhooks by eliminating wait for confirmation when message is sent to the New Customer, New Invoice, Updated Customer or Updated Invoice component."
+        ],
+        "1.5.5": [
+            "Added warning logs for deprecated minor versions."
         ]
     }
 }

--- a/src/appmixer/quickbooks/commons.js
+++ b/src/appmixer/quickbooks/commons.js
@@ -222,5 +222,16 @@ module.exports = {
         }
     },
 
-    getBaseUrl
+    getBaseUrl,
+
+    /**
+     * Log a warning if the user specified a deprecated minor version
+     * @param {Object} context - Appmixer context
+     * @param {number} minorVersion - The minor version specified by the user
+     */
+    async logDeprecatedMinorVersion(context, minorVersion) {
+        if (minorVersion && minorVersion < 75) {
+            await context.log({ message: `You specified version ${minorVersion}, but versions below 75 are no longer supported and will be ignored. The API will default to version 75. Please update to version 75 or higher. See https://developer.intuit.com/app/developer/qbo/docs/learn/explore-the-quickbooks-online-api/minor-versions for more details.` });
+        }
+    }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warnings when using QuickBooks minor versions below 75.

- **Documentation**
  - Updated Minor Version tooltips to note versions below 75 are ignored and default to 75; recommend 75+ and updated docs links to open safely.
  - Normalized various inspector tooltip link attributes for consistency.

- **Chores**
  - Set default QuickBooks Minor Version to 75 across accounting components.
  - Bumped QuickBooks bundle to 1.5.5 and updated changelog.

- **Bug Fixes**
  - Fixed operator label/value normalization (e.g., ">=").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->