### PR TITLE
Klaviyo (patch) - more Create Campaign validations

### DIFF
--- a/src/appmixer/klaviyo/bundle.json
+++ b/src/appmixer/klaviyo/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.klaviyo",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
-        "1.0.1": [
+        "1.0.2": [
             "Initial version"
         ]
     }

--- a/src/appmixer/klaviyo/campaign/CreateCampaign/CreateCampaign.js
+++ b/src/appmixer/klaviyo/campaign/CreateCampaign/CreateCampaign.js
@@ -106,8 +106,6 @@ module.exports = {
                         }
                         audiencesExcludedIds.push(audience.listId);
                     };
-                } else {
-                    return;
                 }
             });
 

--- a/src/appmixer/klaviyo/campaign/CreateCampaign/CreateCampaign.js
+++ b/src/appmixer/klaviyo/campaign/CreateCampaign/CreateCampaign.js
@@ -86,7 +86,7 @@ module.exports = {
             });
         }
 
-        const audiencesExcludedArr = audiencesExcluded.ADD;
+        const audiencesExcludedArr = audiencesExcluded?.ADD;
 
         // Add excluded audiences if provided
         if (audiencesExcludedArr && Array.isArray(audiencesExcludedArr) && audiencesExcludedArr.length > 0) {
@@ -130,7 +130,11 @@ module.exports = {
 
             if (staticSendPastRecipientsImmediately !== undefined) {
                 sendStrategy.options = sendStrategy.options || {};
-                sendStrategy.options.send_past_recipients_immediately = staticSendPastRecipientsImmediately;
+                // Otherwise throws an error:
+                // 'send_past_recipients_immediately' is not a valid field for the resource 'NonLocalStaticSend'
+                if (sendStrategy.options.is_local) {
+                    sendStrategy.options.send_past_recipients_immediately = staticSendPastRecipientsImmediately;
+                }
             }
         } else if (sendStrategyMethod === 'throttled') {
             sendStrategy.datetime = throttledDatetime;

--- a/src/appmixer/klaviyo/campaign/CreateCampaign/component.json
+++ b/src/appmixer/klaviyo/campaign/CreateCampaign/component.json
@@ -264,7 +264,7 @@
                         "type": "toggle",
                         "label": "Send Past Recipients Immediately",
                         "index": 6,
-                        "tooltip": "Whether to send to past recipients immediately. Ignored when 'Use Local Time' is set to false.",
+                        "tooltip": "Whether to send to past recipients immediately. Ignored when 'Use Local Time' is set to false",
                         "when": {
                             "eq": {
                                 "./sendStrategyMethod": "static"

--- a/src/appmixer/klaviyo/campaign/CreateCampaign/component.json
+++ b/src/appmixer/klaviyo/campaign/CreateCampaign/component.json
@@ -65,7 +65,7 @@
                 "then": { "required": [] },
                 "else": {
                     "anyOf": [
-                        { "required": ["staticDatetime"] },
+                        { "required": ["staticDatetime", "staticIsLocal"] },
                         { "required": ["throttledDatetime","throttlePercentage"] },
                         { "required": ["stoDate"] }
                     ]
@@ -241,6 +241,7 @@
                     "staticDatetime": {
                         "type": "date-time",
                         "label": "Static Send Date/Time",
+                        "tooltip": "Datetime must be in the future and in ISO 8601 format (e.g., 2025-10-31T13:00:00Z for UTC)",
                         "index": 6,
                         "when": {
                             "eq": {
@@ -263,7 +264,7 @@
                         "type": "toggle",
                         "label": "Send Past Recipients Immediately",
                         "index": 6,
-                        "tooltip": "Whether to send to past recipients immediately",
+                        "tooltip": "Whether to send to past recipients immediately. Ignored when 'Use Local Time' is set to false.",
                         "when": {
                             "eq": {
                                 "./sendStrategyMethod": "static"

--- a/src/appmixer/klaviyo/campaign/UpdateCampaign/UpdateCampaign.js
+++ b/src/appmixer/klaviyo/campaign/UpdateCampaign/UpdateCampaign.js
@@ -144,7 +144,8 @@ module.exports = {
                             // Otherwise throws an error:
                             // 'send_past_recipients_immediately' is not a valid field for the resource 'NonLocalStaticSend'
                             if (sendStrategy.options.is_local) {
-                                sendStrategy.options.send_past_recipients_immediately = staticSendPastRecipientsImmediately;
+                                sendStrategy.options
+                                    .send_past_recipients_immediately = staticSendPastRecipientsImmediately;
                             }
                         }
                     }

--- a/src/appmixer/klaviyo/campaign/UpdateCampaign/UpdateCampaign.js
+++ b/src/appmixer/klaviyo/campaign/UpdateCampaign/UpdateCampaign.js
@@ -141,7 +141,11 @@ module.exports = {
                             sendStrategy.options.is_local = staticIsLocal;
                         }
                         if (staticSendPastRecipientsImmediately !== undefined) {
-                            sendStrategy.options.send_past_recipients_immediately = staticSendPastRecipientsImmediately;
+                            // Otherwise throws an error:
+                            // 'send_past_recipients_immediately' is not a valid field for the resource 'NonLocalStaticSend'
+                            if (sendStrategy.options.is_local) {
+                                sendStrategy.options.send_past_recipients_immediately = staticSendPastRecipientsImmediately;
+                            }
                         }
                     }
                 } else if (sendStrategyMethod === 'throttled') {

--- a/src/appmixer/klaviyo/campaign/UpdateCampaign/component.json
+++ b/src/appmixer/klaviyo/campaign/UpdateCampaign/component.json
@@ -218,6 +218,7 @@
                     "staticDatetime": {
                         "type": "date-time",
                         "label": "Static Send Date/Time",
+                        "tooltip": "Datetime must be in the future and in ISO 8601 format (e.g., 2025-10-31T13:00:00Z for UTC)",
                         "index": 7,
                         "when": {
                             "eq": {
@@ -240,7 +241,7 @@
                         "type": "toggle",
                         "label": "Send Past Recipients Immediately",
                         "index": 8,
-                        "tooltip": "Whether to send to past recipients immediately",
+                        "tooltip": "Whether to send to past recipients immediately. Ignored when 'Use Local Time' is set to false",
                         "when": {
                             "eq": {
                                 "./sendStrategyMethod": "static"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevent errors when excluded audiences are omitted.
  - Apply “Send Past Recipients Immediately” only when “Use Local Time” is enabled.

- Improvements
  - Scheduling now requires both Static Send Date/Time and Use Local Time where applicable to reduce misconfiguration.

- Documentation
  - Added tooltip: Static Send Date/Time must be a future ISO 8601 datetime.
  - Clarified tooltip: “Send Past Recipients Immediately” is ignored when “Use Local Time” is off.

- Chores
  - Version bumped to 1.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->