### PR TITLE
AI OpenaAI (patch) - rename AI Agent

### DIFF
--- a/src/appmixer/ai/openai/AIAgent/component.json
+++ b/src/appmixer/ai/openai/AIAgent/component.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ai.openai.AIAgent",
-    "label": "AI Agent (OpenAI)",
+    "label": "AI Agent",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Build an AI agent responding with contextual answers or performing contextual actions.",
     "auth": {

--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ai.openai",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "changelog": {
         "1.0.0": [
             "First version."
@@ -31,6 +31,9 @@
         ],
         "1.2.0": [
             "Added support for files. AI agent now accepts a file that can be used as additional context for the prompt."
+        ],
+        "1.2.1": [
+            "Renamed the AI Agent component label to remove the OpenAI suffix for clarity in the Designer."
         ]
     }
 }


### PR DESCRIPTION
Tiny change for https://github.com/clientIO/appmixer-fe/issues/4753#issuecomment-3257585253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Renamed the component label from “AI Agent (OpenAI)” to “AI Agent” for a cleaner, more consistent display in the Designer. No functional changes.

* **Documentation**
  * Added a 1.2.1 changelog entry noting the component label update for improved clarity.

* **Chores**
  * Bumped version to 1.2.1 to reflect the labeling update and maintain release traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->