### PR TITLE
Slack (patch) - Tasks + AuthHub fixes

### DIFF
--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -51,7 +51,7 @@
         "5.0.2": [
             "Fixed an issue with invalid user selection in UploadFileToUser and SendDirectMessage components."
         ],
-        "5.1.1": [
+        "5.1.2": [
             "Added new component: `Request Approval` - Slack Task allows human approval inside workflows, with Slack user selection.",
             "Added new component: `Find Request Approvals` - List and filter Slack Workflow Approvals. Only available with ACL enabled for private components."
         ]

--- a/src/appmixer/slack/routes-tasks.js
+++ b/src/appmixer/slack/routes-tasks.js
@@ -135,8 +135,9 @@ module.exports = (context) => {
                 const parsed = querystring.parse(rawBody);
                 const payload = JSON.parse(parsed.payload);
 
-                // Validate Slack signature
-                if (!slackLib.isValidPayload(context, req)) {
+                // Validate Slack signature if this is engine pod and not using AuthHub
+                const isFromAuthHub = !!req.headers?.['x-appmixer-forwarded-from-authhub'];
+                if (!isFromAuthHub && !slackLib.isValidPayload(context, req)) {
                     return h.response(undefined).code(401);
                 }
 
@@ -173,7 +174,8 @@ module.exports = (context) => {
                             url: tenantInteractionsURL,
                             method: 'POST',
                             headers: {
-                                'Content-Type': 'application/x-www-form-urlencoded'
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                                'x-appmixer-forwarded-from-authhub': true
                                 // Not sending Slack signature headers, we already validated them
                             },
                             data: req.payload


### PR DESCRIPTION
- [x] do not validate payload on tenant when it is forwarded from AuthHub. it is already validated there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly handle Slack interaction requests forwarded via AuthHub, ensuring they’re processed without unnecessary signature checks while retaining validation for direct Slack requests. Improves reliability of tenant interactions.

- Tests
  - Added coverage to verify behavior for AuthHub-forwarded Slack interactions.

- Chores
  - Bumped Slack bundle version to 5.1.2 and updated the changelog accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->