### PR TITLE
HubSpot (patch) - activate subscription if inactive

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.2.2",
+    "version": "4.2.3",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -67,8 +67,9 @@
         "4.2.1": [
             "Added support for Notes: added components `Create Note`, `Delete Note`, `Find Notes` and `Update Note`."
         ],
-        "4.2.2": [
-            "Fixed an issue with triggers not working when using AuthHub. Added additional check of webhook configuration."
+        "4.2.3": [
+            "Fixed an issue with triggers not working when using AuthHub. Added additional check of webhook configuration.",
+            "Fixed an issue with triggers not registering for inactive subscriptions."
         ]
     }
 }


### PR DESCRIPTION
Fix for https://github.com/Appmixer-ai/appmixer-components/issues/2513#issuecomment-3398742105

Problem was when the HubSpot app already had subscription eg `contact.deletion` but in inactive state. `onListenerAdded` did nothing, the subscription stayed inactive and no events of deleted contacts arrived.