### PR TITLE
CI: fix SonarQube pipeline

### DIFF
--- a/test/vercel/FindProjects.integration.test.js
+++ b/test/vercel/FindProjects.integration.test.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const path = require('path');
 const dotenv = require('dotenv');
-const fetch = require('node-fetch');
 
 // Load environment variables
 dotenv.config({ path: path.join(__dirname, '../.env') });

--- a/test/vercel/integration.test.js
+++ b/test/vercel/integration.test.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const path = require('path');
 const dotenv = require('dotenv');
-const fetch = require('node-fetch');
 
 // Load environment variables
 dotenv.config({ path: path.join(__dirname, '../.env') });


### PR DESCRIPTION
Remove unused 'node-fetch' import from integration tests. This should fix failing Sonar pipelines - example: https://github.com/Appmixer-ai/appmixer-connectors/actions/runs/18675048890/job/53243187879