### PR TITLE
ci: fix SonarQube

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.6.0'
+          node-version: 24.6.0
           cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Cache node_modules for connectors
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
- npm ci, same as Node.js

Previous fix didn't work - it fails on another dependency. This should behave the same way as the Node.js CI pipeline.