### PR TITLE
Monday (patch) - fix loading large number of Boards

### DIFF
--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",
@@ -61,8 +61,9 @@
         "3.0.1": [
             "Improved concurrency handling in ListBoards component to prevent redundant API calls."
         ],
-        "3.0.2": [
-            "Fixed an issue with loading column names for boards without any columns in the 'FindItems' component."
+        "3.0.3": [
+            "Fixed an issue with loading column names for boards without any columns in the 'FindItems' component.",
+            "Fixed an issue with loading board list with a large number of boards in various components."
         ]
     }
 }

--- a/src/appmixer/monday/core/ArchivedItem/component.json
+++ b/src/appmixer/monday/core/ArchivedItem/component.json
@@ -73,7 +73,7 @@
                     "source": { 
                         "url": "/component/appmixer/monday/core/ListBoards?outPort=out",
                         "data": {
-                            "properties": { "sendWholeArray": true },
+                            "properties": { "isSource": true },
                             "transform": "./ListBoards#boardsToSelectArray"
                         }
                     }

--- a/src/appmixer/monday/core/CreateItem/CreateItem.js
+++ b/src/appmixer/monday/core/CreateItem/CreateItem.js
@@ -52,7 +52,7 @@ module.exports = {
                         source: {
                             url: '/component/appmixer/monday/core/ListBoards?outPort=out',
                             data: {
-                                properties: { sendWholeArray: true },
+                                properties: { isSource: true },
                                 transform: './ListBoards#boardsToSelectArray'
                             }
                         }

--- a/src/appmixer/monday/core/DeletedItem/component.json
+++ b/src/appmixer/monday/core/DeletedItem/component.json
@@ -37,7 +37,7 @@
                     "source": { 
                         "url": "/component/appmixer/monday/core/ListBoards?outPort=out",
                         "data": {
-                            "properties": { "sendWholeArray": true },
+                            "properties": { "isSource": true },
                             "transform": "./ListBoards#boardsToSelectArray"
                         }
                     }

--- a/src/appmixer/monday/core/FindItems/component.json
+++ b/src/appmixer/monday/core/FindItems/component.json
@@ -30,7 +30,7 @@
                     "source": { 
                         "url": "/component/appmixer/monday/core/ListBoards?outPort=out",
                         "data": {
-                            "properties": { "sendWholeArray": true },
+                            "properties": { "isSource": true },
                             "transform": "./ListBoards#boardsToSelectArray"
                         }
                     }

--- a/src/appmixer/monday/core/ListBoards/ListBoards.js
+++ b/src/appmixer/monday/core/ListBoards/ListBoards.js
@@ -34,8 +34,11 @@ module.exports = {
                 return context.sendJson({ boards }, 'out');
             }
 
+            // Use simplified query if this is being called as a source for another component
+            const queryToUse = context.properties.isSource ? queries.listBoardsSimple : queries.listBoards;
+
             const options = {
-                query: queries.listBoards,
+                query: queryToUse,
                 options: {
                     variables: {
                         page: 1,
@@ -65,4 +68,3 @@ module.exports = {
         });
     }
 };
-

--- a/src/appmixer/monday/core/ListColumns/component.json
+++ b/src/appmixer/monday/core/ListColumns/component.json
@@ -26,7 +26,7 @@
                     "source": { 
                         "url": "/component/appmixer/monday/core/ListBoards?outPort=out",
                         "data": {
-                            "properties": { "sendWholeArray": true },
+                            "properties": { "isSource": true },
                             "transform": "./ListBoards#boardsToSelectArray"
                         }
                     }

--- a/src/appmixer/monday/core/ListGroups/component.json
+++ b/src/appmixer/monday/core/ListGroups/component.json
@@ -26,7 +26,7 @@
                     "source": { 
                         "url": "/component/appmixer/monday/core/ListBoards?outPort=out",
                         "data": {
-                            "properties": { "sendWholeArray": true },
+                            "properties": { "isSource": true },
                             "transform": "./ListBoards#boardsToSelectArray"
                         }
                     }

--- a/src/appmixer/monday/core/NewItem/component.json
+++ b/src/appmixer/monday/core/NewItem/component.json
@@ -93,7 +93,7 @@
                     "source": {
                         "url": "/component/appmixer/monday/core/ListBoards?outPort=out",
                         "data": {
-                            "properties": { "sendWholeArray": true },
+                            "properties": { "isSource": true },
                             "transform": "./ListBoards#boardsToSelectArray"
                         }
                     }

--- a/src/appmixer/monday/queries.js
+++ b/src/appmixer/monday/queries.js
@@ -21,6 +21,19 @@ module.exports = {
         }
     }
     `,
+    listBoardsSimple: `
+    query listBoards ($page: Int, $limit: Int) {
+        boards(
+            state: all,
+            order_by: created_at,
+            page: $page,
+            limit: $limit
+        ) {
+            id
+            name
+        }
+    }
+    `,
     listWorkspaces: `
     query listWorkspaces ($page: Int, $limit: Int) {
         workspaces(page: $page, limit: $limit) {


### PR DESCRIPTION
Followup for https://appmixer.freshdesk.com/a/tickets/9364 and https://github.com/Appmixer-ai/appmixer-components/issues/2538

This fixes the case when there are 4+ pages of Boards. Each query for Boards was 250k+ which resulted in more than 1M per minute. This ate the rate limit.

I changed the query for listing (`isSource`) to much less complex (now 110 instead of 250k).