### PR TITLE
GoogleDrive (patch) - better File ID validation + label

### DIFF
--- a/src/appmixer/google/drive/UploadFile/UploadFile.js
+++ b/src/appmixer/google/drive/UploadFile/UploadFile.js
@@ -14,11 +14,17 @@ module.exports = {
         let filename;
         let contentType;
 
+        let fileInfo;
+        try {
+            fileInfo = await context.getFileInfo(fileId);
+        } catch (error) {
+            throw new context.CancelError('Incorrect File ID. Failed to get file information from Appmixer file storage.');
+        }
+
         if (fileNameInput) {
             filename = fileNameInput;
             contentType = mime.lookup(filename);
         } else {
-            const fileInfo = await context.getFileInfo(fileId);
             filename = fileInfo.filename;
             contentType = fileInfo.contentType || mime.lookup(filename);
         }
@@ -40,6 +46,7 @@ module.exports = {
 
             resource.parents = [folderId];
         }
+
 
         const fileStream = await context.getFileReadStream(fileId);
 

--- a/src/appmixer/google/drive/UploadFile/component.json
+++ b/src/appmixer/google/drive/UploadFile/component.json
@@ -49,8 +49,8 @@
                 "fileId": {
                     "type": "filepicker",
                     "index": 1,
-                    "label": "Appmixer File ID",
-                    "tooltip": "Select an existing file or upload a new file from your computer to Appmixer. This file will be then uploaded to Google Drive."
+                    "label": "File ID",
+                    "tooltip": "Select an existing file or upload a new file from your computer. This file will be then uploaded to Google Drive."
                 },
                 "fileName": {
                     "type": "text",

--- a/src/appmixer/google/drive/UploadFile/component.json
+++ b/src/appmixer/google/drive/UploadFile/component.json
@@ -49,8 +49,8 @@
                 "fileId": {
                     "type": "filepicker",
                     "index": 1,
-                    "label": "File ID",
-                    "tooltip": "Select an existing file or upload a new file from your computer."
+                    "label": "Appmixer File ID",
+                    "tooltip": "Select an existing file or upload a new file from your computer to Appmixer. This file will be then uploaded to Google Drive."
                 },
                 "fileName": {
                     "type": "text",

--- a/src/appmixer/google/drive/bundle.json
+++ b/src/appmixer/google/drive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.drive",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "engine": ">=6.1",
     "changelog": {
         "1.0.0": [
@@ -74,7 +74,7 @@
             "FindFilesOrFolders: fileTypes field now accepts both array and comma-separated string inputs.",
             "DeletedFileOrFolder, NewFileOrFolder, UpdatedFileOrFolder: fileTypesRestriction field now accepts both array and comma-separated string inputs."
         ],
-        "2.2.1": [
+        "2.2.2": [
             "UploadFile: fixed an issue with uploading files to shared drives."
         ]
     }


### PR DESCRIPTION
When the File ID is incorrect, it now rather cancel the flow with a descriptive error.
Also updated the UploadFile - File ID field to "`Appmixer File ID`"