### PR TITLE
Google Drive (patch) - trigger fix

### DIFF
--- a/src/appmixer/google/drive/bundle.json
+++ b/src/appmixer/google/drive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.drive",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "engine": ">=6.1",
     "changelog": {
         "1.0.0": [
@@ -76,6 +76,9 @@
         ],
         "2.2.2": [
             "UploadFile: fixed an issue with uploading files to shared drives."
+        ],
+        "2.2.3": [
+            "Fixed an issue with triggers NewFileOrFolder, UpdatedFileOrFolder, and DeletedFileOrFolder which could result in errors when accessing file parents in some scenarios (e.g., read-only access and/or shared drives)."
         ]
     }
 }

--- a/src/appmixer/google/drive/lib.js
+++ b/src/appmixer/google/drive/lib.js
@@ -178,7 +178,8 @@ const isSubfolderStructureChanged = (change, folderIds) => {
     const file = change.file;
     if (!file) return false;
     if (file.mimeType !== 'application/vnd.google-apps.folder') return;
-    const isSubfolder = arraysOverlap(file.parents.concat(file.id), folderIds);
+    // In some cases, `file.parents` may be undefined (e.g., with read-only access and/or shared drives).
+    const isSubfolder = arraysOverlap((file.parents || []).concat(file.id), folderIds);
     const isKnown = folderIds.includes(file.id);
 
     if (isSubfolder && change.removed) {


### PR DESCRIPTION
Ensure `file.parents` is an array. https://community.latenode.com/t/issues-with-missing-parent-references-in-google-drive-api-php/32857/2

Fixes https://github.com/Appmixer-ai/appmixer-components/issues/2548