### PR TITLE
utils.files: fix the maxWait type

### DIFF
--- a/src/appmixer/utils/files/ArchiveFile/component.json
+++ b/src/appmixer/utils/files/ArchiveFile/component.json
@@ -7,7 +7,7 @@
     "quota": {
         "manager": "appmixer:utils:files",
         "resources": "storeFile",
-        "maxWait": "60000"
+        "maxWait": 60000
     },
     "inPorts": [
         {

--- a/src/appmixer/utils/files/DownloadFile/component.json
+++ b/src/appmixer/utils/files/DownloadFile/component.json
@@ -7,7 +7,7 @@
     "quota": {
         "manager": "appmixer:utils:files",
         "resources": "storeFile",
-        "maxWait": "60000"
+        "maxWait": 60000
     },
     "inPorts": [
         {

--- a/src/appmixer/utils/files/SaveFile/component.json
+++ b/src/appmixer/utils/files/SaveFile/component.json
@@ -7,7 +7,7 @@
     "quota": {
         "manager": "appmixer:utils:files",
         "resources": "storeFile",
-        "maxWait": "60000"
+        "maxWait": 60000
     },
     "inPorts": [
         {

--- a/src/appmixer/utils/files/bundle.json
+++ b/src/appmixer/utils/files/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.files",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "changelog": {
         "1.0.0": [
             "Accept array type for content input"
@@ -25,6 +25,9 @@
         ],
         "1.4.2": [
             "Lower maxWait for quota to 60 seconds to avoid unnecessary timeouts. Affects ArchiveFile, DownloadFile and SaveFile components."
+        ],
+        "1.4.3": [
+            "Save File, Download File, Archive File: fix quota manager maxWait value format - it should be an integer."
         ]
     }
 }


### PR DESCRIPTION
maxWait: string was causing validation issue during pack: 

```
[ERROR]:  Your component manifest file at src\appmixer\utils\files\SaveFile\component.json is not valid. Please fix the errors below and try again.
[ERROR]:  - 
  instancePath: /quota/maxWait
  schemaPath:   #/properties/quota/properties/maxWait/type
  keyword:      type
  params:
    type: integer
  message:      must be integer
```