### PR TITLE
monday ListBoards (fix) - prevent internal 504

### DIFF
--- a/src/appmixer/monday/artifacts/test/ListBoards.test.js
+++ b/src/appmixer/monday/artifacts/test/ListBoards.test.js
@@ -122,4 +122,38 @@ module.exports = {
         assert.strictEqual(slowStaticCache.set.callCount, 1, 'staticCache.set should be called to populate cache');
         assert.strictEqual(slowStaticCache.get.callCount, 10, 'staticCache.get should be called for each receive call');
     });
+
+    it('should use simplified query when isSource is true', async () => {
+
+        const apiKey = 'test-api-key-isSource';
+        const context = createMockContext({
+            auth: { apiKey },
+            properties: { isSource: true }
+        });
+
+        await ListBoards.receive(context);
+
+        // Verify that aggregator.fetch was called with 3 arguments (no isSource parameter)
+        assert(fetchStub.called, 'aggregator.fetch should have been called');
+        const callArgs = fetchStub.getCall(0).args;
+        assert.strictEqual(callArgs.length, 3, 'aggregator.fetch should be called with 3 arguments (options, page, pageSize)');
+        assert.strictEqual(callArgs[1], 1, 'initial page should be 1');
+        assert.strictEqual(callArgs[2], 50, 'page size should be 50');
+    });
+
+    it('should use full query when isSource is false', async () => {
+
+        const apiKey = 'test-api-key-not-source';
+        const context = createMockContext({
+            auth: { apiKey },
+            properties: { isSource: false }
+        });
+
+        await ListBoards.receive(context);
+
+        assert(fetchStub.called, 'aggregator.fetch should have been called');
+        const callArgs = fetchStub.getCall(0).args;
+        // Verify aggregator.fetch called with 3 arguments (options, page, pageSize - no isSource)
+        assert.strictEqual(callArgs.length, 3, 'aggregator.fetch should be called with 3 arguments');
+    });
 });

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "3.0.3",
+    "version": "3.0.5",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",
@@ -64,6 +64,9 @@
         "3.0.3": [
             "Fixed an issue with loading column names for boards without any columns in the 'FindItems' component.",
             "Fixed an issue with loading board list with a large number of boards in various components."
+        ],
+        "3.0.4": [
+            "Fixed an issue where fetching boards in ListBoards component could exceed internal timeout for accounts with a large number of boards."
         ]
     }
 }

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -65,7 +65,7 @@
             "Fixed an issue with loading column names for boards without any columns in the 'FindItems' component.",
             "Fixed an issue with loading board list with a large number of boards in various components."
         ],
-        "3.0.4": [
+        "3.0.5": [
             "Fixed an issue where fetching boards in ListBoards component could exceed internal timeout for accounts with a large number of boards."
         ]
     }

--- a/src/appmixer/monday/core/ListBoards/ListBoards.js
+++ b/src/appmixer/monday/core/ListBoards/ListBoards.js
@@ -13,7 +13,9 @@ const aggregator = new PagingAggregator(
         return accumulator.concat(chunk.boards);
     },
     (accumulator, chunk, page, pageSize) => {
-        const isDone = !chunk.boards.length || chunk.boards.length < pageSize;
+        // Limiting number of API calls in source mode to avoid long runs of fetching flow variables.
+        const pageCountLimitReached = page >= 10;
+        const isDone = !chunk.boards.length || chunk.boards.length < pageSize || pageCountLimitReached;
         return isDone ? -1 : page + 1;
     }
 );


### PR DESCRIPTION
Another quick fix for https://appmixer.freshdesk.com/a/tickets/9364 - this time internal 504. This happens when the account has large number of Boards (~1000+)

Limiting to max 10 API calls (I saw values between 7sec to 22sec for 10 pages)