### PR TITLE
Improve instructions for file download

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1479,7 +1479,7 @@ Use `source` property to populate field options dynamically:
 
 #### File Handling
 
-For file input components:
+##### file input components
 
 ```json
 {
@@ -1501,6 +1501,25 @@ For file input components:
     }
   }
 }
+```
+
+##### file output components
+- use `context.saveFileStream()` in behavior JS
+- must return `fileId` in output message
+- should return additional info like `fileSize`, `prompt`, etc. See component.json `outPorts.options` for more details
+
+Examples:
+
+```javascript
+const filename = `generated-image-${(new Date).toISOString()}.png`;
+const file = await context.saveFileStream(filename, readStream);
+return context.sendJson({ fileId: file.fileId, prompt, size }, 'out');
+```
+```javascript
+const outFilename = filename || `${Date.now()}_elevenlabs_soundeffect`;
+const file = await context.saveFileStream(outFilename, data);
+
+return context.sendJson({ fileId: file.fileId, input: text, fileSize: file.length }, 'out');
 ```
 
 ## Testing Guidelines


### PR DESCRIPTION
Closes https://github.com/Appmixer-ai/appmixer-cli/issues/248

## Generate component
`appmixer init ai component elevenlabs CreateSoundEffect --context 11labs.md`.

### Before
Notice `file.size` instead of `file.length`.

```js
// Save the audio file
const audioBuffer = Buffer.from(response.data.audio_base64, 'base64');
const fileNameToUse = filename || 'sound_effect.mp3';

const file = await context.saveFileStream(fileNameToUse, audioBuffer);

return context.sendJson({ fileId: file.fileId, fileSize: file.size, input: text }, 'out');
```

### After
```js
// The same as already published (human verified) code
const outFilename = filename || `${Date.now()}_elevenlabs_soundeffect`;
const file = await context.saveFileStream(outFilename, data);

return context.sendJson({ fileId: file.fileId, input: text, fileSize: file.length }, 'out');

```