### PR TITLE
google.drive (fix) - trigger for shared files

### DIFF
--- a/src/appmixer/google/drive/NewFileOrFolder/NewFileOrFolder.js
+++ b/src/appmixer/google/drive/NewFileOrFolder/NewFileOrFolder.js
@@ -6,11 +6,17 @@ function isNewFileOrFolder(change) {
     const file = change.file;
     if (!file) return false;
 
-    return change.changeType === 'file' &&
-    !change.removed &&  // exclude removed files
-    !file.trashed &&  // exclude trashed files
-    new Date(file.createdTime) >= new Date(file.modifiedTime) &&  // exclude updates to a file
-    new Date(file.createdTime) >= new Date(file.viewedByMeTime);  // exclude visiting a folder/file.
+    if (change.changeType !== 'file') return false;
+    if (change.removed) return false;
+    if (file.trashed) return false;
+
+    const created = new Date(file.createdTime).getTime();
+    const modified = new Date(file.modifiedTime).getTime();
+    const viewed = file.viewedByMeTime ? new Date(file.viewedByMeTime).getTime() : 0;
+
+    if (isNaN(created) || isNaN(modified)) return false;
+
+    return created >= modified && created >= viewed;
 }
 
 module.exports = {

--- a/src/appmixer/google/drive/NewFileOrFolder/NewFileOrFolder.js
+++ b/src/appmixer/google/drive/NewFileOrFolder/NewFileOrFolder.js
@@ -21,6 +21,8 @@ function isNewFileOrFolder(change) {
 
 module.exports = {
 
+    isNewFileOrFolder,
+
     async start(context) {
 
         return lib.registerWebhook(context);

--- a/src/appmixer/google/drive/artifacts/tests/isNewFileOrFolder.test.js
+++ b/src/appmixer/google/drive/artifacts/tests/isNewFileOrFolder.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const assert = require('assert');
+const { isNewFileOrFolder } = require('../../NewFileOrFolder/NewFileOrFolder');
+
+describe('google.drive.NewFileOrFolder', () => {
+
+    describe('isNewFileOrFolder', () => {
+
+        it('should detect new file from shared folder (no viewedByMeTime)', () => {
+
+            const change = {
+                file: {
+                    parents: [
+                        '1CR4Cq5L3NW4EdcVUu2QlJPX0QV3a6Kuu'
+                    ],
+                    kind: 'drive#file',
+                    id: '1XMd5dC3cWhtjrhK4cdaluUTVZmX1eRxQ',
+                    name: 'Kopie souboru Kopie souboru 15_Post Use Node.js.txt',
+                    mimeType: 'text/plain',
+                    starred: false,
+                    trashed: false,
+                    explicitlyTrashed: false,
+                    version: '3',
+                    viewedByMe: false,
+                    createdTime: '2025-12-11T10:48:44.135Z',
+                    modifiedTime: '2025-12-11T10:48:44.135Z',
+                    modifiedByMe: false,
+                    shared: true,
+                    ownedByMe: false,
+                    viewersCanCopyContent: true,
+                    copyRequiresWriterPermission: false,
+                    writersCanShare: true,
+                    originalFilename: 'Kopie souboru Kopie souboru 15_Post Use Node.js.txt',
+                    fullFileExtension: 'js.txt',
+                    fileExtension: 'txt',
+                    md5Checksum: '8610bbd4d24db5bdf1c571ea8022dbad',
+                    sha1Checksum: 'f7372992fb24cb859b2ee61387cab8dbd660cdcb',
+                    sha256Checksum: '95536c1fe4c1802859efc9fac11182f85a031e65a538c130aa3e891f9d71a181',
+                    size: '308',
+                    quotaBytesUsed: '308',
+                    headRevisionId: '0B_biKojru1jjOGZlNnlnaEZZaGtnQ1MwdE9lRlY4VytrWmpRPQ',
+                    isAppAuthorized: false,
+                    inheritedPermissionsDisabled: false
+                },
+                kind: 'drive#change',
+                type: 'file',
+                changeType: 'file',
+                time: '2025-12-11T10:49:03.748Z',
+                removed: false,
+                fileId: '1XMc5dC3cWhtjrhK4cdaluUTVZmX1eRxQ'
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), true);
+        });
+
+        it('should NOT detect viewed file as new (has viewedByMeTime)', () => {
+
+            const change = {
+                file: {
+                    parents: [
+                        '1CR4Cq5L3NW4EdcVUu2QlJPX0QV3a6Kuu'
+                    ],
+                    kind: 'drive#file',
+                    id: '1XMd5dC3cWhtjrhK4cdaluUTVZmX1eRxQ',
+                    name: 'Kopie souboru Kopie souboru 15_Post Use Node.js.txt',
+                    mimeType: 'text/plain',
+                    starred: false,
+                    trashed: false,
+                    explicitlyTrashed: false,
+                    version: '3',
+                    viewedByMe: true,
+                    viewedByMeTime: '2025-12-11T10:48:44.135Z',
+                    createdTime: '2025-12-11T10:48:44.135Z',
+                    modifiedTime: '2025-12-11T10:48:44.135Z',
+                    modifiedByMeTime: '2025-12-11T10:48:44.135Z',
+                    modifiedByMe: true,
+                    shared: true,
+                    ownedByMe: true,
+                    viewersCanCopyContent: true,
+                    copyRequiresWriterPermission: false,
+                    writersCanShare: true,
+                    originalFilename: 'Kopie souboru Kopie souboru 15_Post Use Node.js.txt',
+                    fullFileExtension: 'js.txt',
+                    fileExtension: 'txt',
+                    md5Checksum: '8610bbd4d24db5bdf1c571ea8022dbad',
+                    sha1Checksum: 'f7372992fb24cb859b2ee61387cab8dbd660cdcb',
+                    sha256Checksum: '95536c1fe4c1802859efc9fac11182f85a031e65a538c130aa3e891f9d71a181',
+                    size: '308',
+                    quotaBytesUsed: '308',
+                    headRevisionId: '0B_biKojru1jjOGZlNnlnaEZZaGtnQ1MwdE9lRlY4VytrWmpRPQ',
+                    isAppAuthorized: false,
+                    inheritedPermissionsDisabled: false
+                },
+                kind: 'drive#change',
+                type: 'file',
+                changeType: 'file',
+                time: '2025-12-11T10:49:06.646Z',
+                removed: false,
+                fileId: '1XMc5dC3cWhtjrhK4cdaluUTVZmX1eRxQ'
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), true);
+        });
+
+        it('should return false for removed files', () => {
+
+            const change = {
+                file: {
+                    createdTime: '2025-12-11T10:48:44.135Z',
+                    modifiedTime: '2025-12-11T10:48:44.135Z'
+                },
+                changeType: 'file',
+                removed: true
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), false);
+        });
+
+        it('should return false for trashed files', () => {
+
+            const change = {
+                file: {
+                    createdTime: '2025-12-11T10:48:44.135Z',
+                    modifiedTime: '2025-12-11T10:48:44.135Z',
+                    trashed: true
+                },
+                changeType: 'file',
+                removed: false
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), false);
+        });
+
+        it('should return false when file is missing', () => {
+
+            const change = {
+                file: null,
+                changeType: 'file',
+                removed: false
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), false);
+        });
+
+        it('should return false for non-file changes', () => {
+
+            const change = {
+                file: {
+                    createdTime: '2025-12-11T10:48:44.135Z',
+                    modifiedTime: '2025-12-11T10:48:44.135Z'
+                },
+                changeType: 'folder',
+                removed: false
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), false);
+        });
+
+        it('should return false when createdTime is invalid', () => {
+
+            const change = {
+                file: {
+                    createdTime: 'invalid-date',
+                    modifiedTime: '2025-12-11T10:48:44.135Z'
+                },
+                changeType: 'file',
+                removed: false
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), false);
+        });
+
+        it('should return false when file is modified after creation', () => {
+
+            const change = {
+                file: {
+                    createdTime: '2025-12-11T10:48:44.135Z',
+                    modifiedTime: '2025-12-11T11:00:00.000Z'
+                },
+                changeType: 'file',
+                removed: false
+            };
+
+            assert.strictEqual(isNewFileOrFolder(change), false);
+        });
+    });
+});

--- a/src/appmixer/google/drive/bundle.json
+++ b/src/appmixer/google/drive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.drive",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "engine": ">=6.1",
     "changelog": {
         "1.0.0": [
@@ -79,6 +79,9 @@
         ],
         "2.2.3": [
             "Fixed an issue with triggers NewFileOrFolder, UpdatedFileOrFolder, and DeletedFileOrFolder which could result in errors when accessing file parents in some scenarios (e.g., read-only access and/or shared drives)."
+        ],
+        "2.2.4": [
+            "Fixed an issue with NewFileOrFolder trigger causing false negatives when processing changes in shared folders."
         ]
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Appmixer-ai/appmixer-components/issues/2557

change in a file not owned by me
```
        "kind": "drive#file",
        "id": "14RCPXoHfV1eKhCLHlSVS6oB4Er1_TScS",
        "name": "Kopie souboru Kopie souboru Kopie souboru 15_Post Use Node.js.txt",
        "mimeType": "text/plain",
        "viewedByMe": false,
        "createdTime": "2025-12-11T11:21:00.655Z",
        "modifiedTime": "2025-12-11T11:21:00.655Z",
        "modifiedByMe": false,
        "shared": true,
        "ownedByMe": false,
```

change in a file owned by me
```
        "kind": "drive#file",
        "id": "14RCPXoHfV1eKhCLHlSVS6oB4Er1_TScS",
        "name": "Kopie souboru Kopie souboru Kopie souboru 15_Post Use Node.js.txt",
        "mimeType": "text/plain",
        "viewedByMe": true,
        "viewedByMeTime": "2025-12-11T11:21:00.655Z",
        "createdTime": "2025-12-11T11:21:00.655Z",
        "modifiedTime": "2025-12-11T11:21:00.655Z",
        "modifiedByMeTime": "2025-12-11T11:21:00.655Z",
        "modifiedByMe": true,
        "shared": true,
        "ownedByMe": true,
```