### PR TITLE
aws.s3 (minor): update upload process

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1246,6 +1246,7 @@ module.exports = {
                         "index": 3,
                         "label": "Priority",
                         "options": [
+                            { "label": "-- Clear selection --", "clearItem": true },
                             { "label": "Low", "value": "low" },
                             { "label": "Medium", "value": "medium" },
                             { "label": "High", "value": "high" }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1246,7 +1246,6 @@ module.exports = {
                         "index": 3,
                         "label": "Priority",
                         "options": [
-                            { "label": "-- Clear selection --", "clearItem": true },
                             { "label": "Low", "value": "low" },
                             { "label": "Medium", "value": "medium" },
                             { "label": "High", "value": "high" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -318,7 +317,8 @@
             "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
             "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.0",
@@ -1052,6 +1052,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -1063,6 +1064,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.4"
@@ -1096,6 +1098,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -1109,7 +1112,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1134,6 +1136,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -1195,6 +1198,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1242,6 +1246,7 @@
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
@@ -1252,6 +1257,7 @@
             "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -1261,7 +1267,8 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/autodetect-decoder-stream": {
             "version": "2.0.2",
@@ -1283,6 +1290,7 @@
             "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -1292,7 +1300,8 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
             "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/axios": {
             "version": "0.22.0",
@@ -1300,7 +1309,6 @@
             "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.14.4"
             }
@@ -1349,6 +1357,7 @@
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -1408,7 +1417,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -1548,7 +1556,8 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -1716,6 +1725,7 @@
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -1776,7 +1786,8 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -1853,6 +1864,7 @@
             "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -1956,6 +1968,7 @@
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -2066,6 +2079,7 @@
             "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -2125,6 +2139,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -2172,7 +2187,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2345,6 +2359,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2361,7 +2376,8 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/extsprintf": {
             "version": "1.3.0",
@@ -2371,7 +2387,8 @@
             "engines": [
                 "node >=0.6.0"
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "2.0.1",
@@ -2535,6 +2552,7 @@
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -2546,6 +2564,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -2574,6 +2593,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "node-domexception": "1.0.0",
                 "web-streams-polyfill": "4.0.0-beta.3"
@@ -2708,6 +2728,7 @@
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
@@ -2847,6 +2868,7 @@
             "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -2858,6 +2880,7 @@
             "deprecated": "this library is no longer supported",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
@@ -2896,6 +2919,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -2976,6 +3000,7 @@
             "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -3007,6 +3032,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -3219,7 +3245,8 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -3410,7 +3437,8 @@
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jschardet": {
             "version": "3.1.4",
@@ -3546,7 +3574,8 @@
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "dev": true,
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
+            "license": "(AFL-2.1 OR BSD-3-Clause)",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -3567,7 +3596,8 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/json5": {
             "version": "1.0.2",
@@ -3615,6 +3645,7 @@
             "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -3908,6 +3939,7 @@
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3918,6 +3950,7 @@
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -4096,6 +4129,7 @@
             "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "mustache": "bin/mustache"
             }
@@ -4125,6 +4159,7 @@
             ],
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -4136,6 +4171,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -4446,6 +4482,7 @@
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -4491,6 +4528,7 @@
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -4522,7 +4560,8 @@
             "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
             "dev": true,
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/openapi-types": {
             "version": "12.1.3",
@@ -4803,7 +4842,8 @@
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -5046,6 +5086,7 @@
             "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -5114,6 +5155,7 @@
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -5129,6 +5171,7 @@
             "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -5140,6 +5183,7 @@
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "uuid": "bin/uuid"
             }
@@ -5582,6 +5626,7 @@
             "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -5839,7 +5884,8 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true,
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -5847,6 +5893,7 @@
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -5859,7 +5906,8 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
             "dev": true,
-            "license": "Unlicense"
+            "license": "Unlicense",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -5913,7 +5961,8 @@
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true,
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
@@ -5979,6 +6028,7 @@
                 "node >=0.6.0"
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -5992,6 +6042,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -6002,7 +6053,8 @@
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -6011,6 +6063,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -6329,7 +6382,6 @@
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -6340,6 +6392,7 @@
             "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "peerDependencies": {
                 "zod": "^3.24.1"
             }

--- a/src/appmixer/aws/package-lock.json
+++ b/src/appmixer/aws/package-lock.json
@@ -1,0 +1,163 @@
+{
+    "name": "appmixer.aws",
+    "version": "0.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "appmixer.aws",
+            "version": "0.0.1",
+            "dependencies": {
+                "aws-sdk": "2.611.0",
+                "bluebird": "3.5.1"
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.611.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.611.0.tgz",
+            "integrity": "sha512-2Y0vqEUQFRJE/5Ne6IYgP2y+8XEp0jQefHxlwdqwj9n9a8OmdsmBnNaw2IVsyxySgk2ynp38+imBJaceDNKiiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "buffer": "4.9.1",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bluebird": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+            "license": "MIT"
+        },
+        "node_modules/buffer": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "integrity": "sha512-DNK4ruAqtyHaN8Zne7PkBTO+dD1Lr0YfTduMqlIyjvQIoztBkUxrvL+hKeLW8NXFKHOq/2upkxuoS9znQ9bW9A==",
+            "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer",
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "license": "MIT"
+        },
+        "node_modules/jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+            "license": "MIT"
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+            "license": "ISC"
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "license": "MIT",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        }
+    }
+}

--- a/src/appmixer/aws/package.json
+++ b/src/appmixer/aws/package.json
@@ -3,7 +3,6 @@
     "version": "0.0.1",
     "dependencies": {
         "aws-sdk": "2.611.0",
-        "bluebird": "3.5.1",
-        "s3-upload-stream": "1.0.7"
+        "bluebird": "3.5.1"
     }
 }

--- a/src/appmixer/aws/s3/PutContent/PutContent.js
+++ b/src/appmixer/aws/s3/PutContent/PutContent.js
@@ -26,22 +26,24 @@ module.exports = {
             throw new context.CancelError('Content Type is required');
         }
 
-        if (!acl) {
-            throw new context.CancelError('Access Control is required');
-        }
-
-
         const { s3 } = commons.init(context);
 
-        const result = await s3.upload({
+        // Build upload parameters
+        const uploadParams = {
             Bucket: bucket,
             Key: key,
             Body: content,
-            ACL: acl,
             ContentType: contentType,
             Expires: expiryDate,
             ContentEncoding: 'utf8'
-        }).promise();
+        };
+
+        // Only add ACL if provided (optional for buckets with ACLs disabled)
+        if (acl) {
+            uploadParams.ACL = acl;
+        }
+
+        const result = await s3.upload(uploadParams).promise();
 
         const object = Object.assign({
             ContentType: contentType,

--- a/src/appmixer/aws/s3/PutContent/component.json
+++ b/src/appmixer/aws/s3/PutContent/component.json
@@ -25,8 +25,7 @@
                 "bucket",
                 "key",
                 "content",
-                "contentType",
-                "acl"
+                "contentType"
             ]
         },
         "inspector": {
@@ -66,8 +65,9 @@
                     "type": "select",
                     "label": "Access Control",
                     "index": 5,
-                    "tooltip": "The canned ACL to apply to the file.",
+                    "tooltip": "Optional. The canned ACL to apply to the file. Leave empty for buckets with ACLs disabled.",
                     "options": [
+                        { "value": "", "content": "None (use bucket default)" },
                         { "value": "private", "content": "private" },
                         { "value": "public-read", "content": "public-read" },
                         { "value": "public-read-write", "content": "public-read-write" },

--- a/src/appmixer/aws/s3/PutContent/component.json
+++ b/src/appmixer/aws/s3/PutContent/component.json
@@ -65,7 +65,7 @@
                     "type": "select",
                     "label": "Access Control",
                     "index": 5,
-                    "tooltip": "Optional. The canned ACL to apply to the file. Leave empty for buckets with ACLs disabled.",
+                    "tooltip": "The canned ACL to apply to the file. Leave empty for buckets with ACLs disabled.",
                     "options": [
                         { "value": "", "content": "None (use bucket default)" },
                         { "value": "private", "content": "private" },

--- a/src/appmixer/aws/s3/PutContent/component.json
+++ b/src/appmixer/aws/s3/PutContent/component.json
@@ -67,7 +67,7 @@
                     "index": 5,
                     "tooltip": "The canned ACL to apply to the file. Leave empty for buckets with ACLs disabled.",
                     "options": [
-                        { "value": "", "content": "None (use bucket default)" },
+                        { "clearItem": true, "content": "None (use bucket default)" },
                         { "value": "private", "content": "private" },
                         { "value": "public-read", "content": "public-read" },
                         { "value": "public-read-write", "content": "public-read-write" },

--- a/src/appmixer/aws/s3/PutObject/PutObject.js
+++ b/src/appmixer/aws/s3/PutObject/PutObject.js
@@ -1,5 +1,4 @@
 'use strict';
-const s3Stream = require('s3-upload-stream');
 const commons = require('../../aws-commons');
 
 /**
@@ -20,6 +19,7 @@ module.exports = {
             maxPartSize,
             concurrentParts
         } = context.messages.in.content;
+
         if (!bucket) {
             throw new context.CancelError('Bucket is required');
         }
@@ -32,48 +32,45 @@ module.exports = {
             throw new context.CancelError('File ID is required');
         }
 
-        if (!acl) {
-            throw new context.CancelError('Access Control is required');
-        }
-
-
         const { s3 } = commons.init(context);
 
-        const uploadFn = () => {
-            return new Promise(async (resolve, reject) => {
-                try {
-                    const stream = s3Stream(s3);
-                    const pipe = stream.upload({
-                        Bucket: bucket,
-                        Key: key,
-                        ACL: acl,
-                        ContentType: contentType,
-                        Expires: expiryDate
-                    }).on('error', error => {
-                        reject(error);
-                    }).on('uploaded', details => {
-                        resolve(details);
-                    });
+        // Get file stream from Appmixer storage
+        const readStream = await context.getFileReadStream(fileId);
 
-                    let sizeInBytes = 20971520; // 20 MB
-                    if (maxPartSize) {
-                        sizeInBytes = maxPartSize * 1048576;
-                    }
-                    pipe.maxPartSize(sizeInBytes);
-                    pipe.concurrentParts(concurrentParts || 1);
-
-                    const readStream = await context.getFileReadStream(fileId);
-                    readStream.pipe(pipe);
-                } catch (err) {
-                    reject(err);
-                }
-            });
-        };
-
-        return context.sendJson(Object.assign({
+        // Build upload parameters
+        const uploadParams = {
             Bucket: bucket,
+            Key: key,
+            Body: readStream,
             ContentType: contentType,
             Expires: expiryDate
-        }, await uploadFn()), 'object');
+        };
+
+        // Only add ACL if provided (optional for buckets with ACLs disabled)
+        if (acl) {
+            uploadParams.ACL = acl;
+        }
+
+        // Configure multipart upload options
+        const uploadOptions = {};
+        if (maxPartSize) {
+            uploadOptions.partSize = maxPartSize * 1048576; // Convert MB to bytes
+        }
+        if (concurrentParts) {
+            uploadOptions.queueSize = concurrentParts;
+        }
+
+        // Use AWS SDK's native upload method (handles multipart automatically)
+        const result = await s3.upload(uploadParams, uploadOptions).promise();
+
+        // Return consistent output format
+        return context.sendJson({
+            Bucket: bucket,
+            Key: result.Key,
+            ETag: result.ETag,
+            Location: result.Location,
+            ContentType: contentType,
+            Expires: expiryDate
+        }, 'object');
     }
 };

--- a/src/appmixer/aws/s3/PutObject/component.json
+++ b/src/appmixer/aws/s3/PutObject/component.json
@@ -26,8 +26,7 @@
             "required": [
                 "bucket",
                 "key",
-                "fileId",
-                "acl"
+                "fileId"
             ]
         },
         "inspector": {
@@ -61,8 +60,9 @@
                     "type": "select",
                     "label": "Access Control",
                     "index": 4,
-                    "tooltip": "The canned ACL to apply to the object.",
+                    "tooltip": "Optional. The canned ACL to apply to the object. Leave empty for buckets with ACLs disabled.",
                     "options": [
+                        { "value": "", "content": "None (use bucket default)" },
                         { "value": "private", "content": "private" },
                         { "value": "public-read", "content": "public-read" },
                         { "value": "public-read-write", "content": "public-read-write" },

--- a/src/appmixer/aws/s3/PutObject/component.json
+++ b/src/appmixer/aws/s3/PutObject/component.json
@@ -62,7 +62,7 @@
                     "index": 4,
                     "tooltip": "The canned ACL to apply to the object. Leave empty for buckets with ACLs disabled.",
                     "options": [
-                        { "value": "", "content": "None (use bucket default)" },
+                        { "clearItem": true, "content": "None (use bucket default)" },
                         { "value": "private", "content": "private" },
                         { "value": "public-read", "content": "public-read" },
                         { "value": "public-read-write", "content": "public-read-write" },

--- a/src/appmixer/aws/s3/PutObject/component.json
+++ b/src/appmixer/aws/s3/PutObject/component.json
@@ -60,7 +60,7 @@
                     "type": "select",
                     "label": "Access Control",
                     "index": 4,
-                    "tooltip": "Optional. The canned ACL to apply to the object. Leave empty for buckets with ACLs disabled.",
+                    "tooltip": "The canned ACL to apply to the object. Leave empty for buckets with ACLs disabled.",
                     "options": [
                         { "value": "", "content": "None (use bucket default)" },
                         { "value": "private", "content": "private" },

--- a/src/appmixer/aws/s3/artifacts/test/PutObject.test.js
+++ b/src/appmixer/aws/s3/artifacts/test/PutObject.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../test/utils');
+
+// Load commons so we can stub its methods before loading component.
+const commons = require('../../../aws-commons');
+
+// Component under test.
+const PutObject = require('../../PutObject/PutObject');
+
+describe('AWS S3 PutObject component', () => {
+
+    let context;
+    let s3Mock;
+
+    beforeEach(() => {
+        context = testUtils.createMockContext();
+        context.messages = {
+            in: {
+                content: {
+                    bucket: 'test-bucket',
+                    key: 'test-file.txt',
+                    fileId: 'file123',
+                    contentType: 'text/plain'
+                }
+            }
+        };
+        context.properties = { region: 'us-east-1' };
+
+        // Mock S3 upload
+        s3Mock = {
+            upload: sinon.stub().returns({
+                promise: sinon.stub().resolves({
+                    Key: 'test-file.txt',
+                    ETag: '"abc123"',
+                    Location: 'https://test-bucket.s3.amazonaws.com/test-file.txt'
+                })
+            })
+        };
+
+        // Mock commons.init to return our mocked S3
+        sinon.stub(commons, 'init').returns({ s3: s3Mock });
+
+        // Mock file stream
+        context.getFileReadStream = sinon.stub().resolves({
+            pipe: sinon.stub()
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('uploads file without ACL when ACL is not provided', async () => {
+        await PutObject.receive(context);
+
+        assert(s3Mock.upload.calledOnce, 'S3 upload should be called once');
+        const uploadParams = s3Mock.upload.firstCall.args[0];
+        
+        assert.strictEqual(uploadParams.Bucket, 'test-bucket');
+        assert.strictEqual(uploadParams.Key, 'test-file.txt');
+        assert.strictEqual(uploadParams.ContentType, 'text/plain');
+        assert(!uploadParams.ACL, 'ACL should not be set when not provided');
+    });
+
+    it('uploads file with ACL when ACL is provided', async () => {
+        context.messages.in.content.acl = 'public-read';
+
+        await PutObject.receive(context);
+
+        const uploadParams = s3Mock.upload.firstCall.args[0];
+        assert.strictEqual(uploadParams.ACL, 'public-read');
+    });
+
+    it('configures multipart upload options when provided', async () => {
+        context.messages.in.content.maxPartSize = 10; // 10 MB
+        context.messages.in.content.concurrentParts = 5;
+
+        await PutObject.receive(context);
+
+        const uploadOptions = s3Mock.upload.firstCall.args[1];
+        assert.strictEqual(uploadOptions.partSize, 10 * 1048576);
+        assert.strictEqual(uploadOptions.queueSize, 5);
+    });
+
+    it('returns correct output format', async () => {
+        await PutObject.receive(context);
+
+        assert(context.sendJson.calledOnce, 'sendJson should be called once');
+        const output = context.sendJson.firstCall.args[0];
+        
+        assert.strictEqual(output.Bucket, 'test-bucket');
+        assert.strictEqual(output.Key, 'test-file.txt');
+        assert.strictEqual(output.ETag, '"abc123"');
+        assert.strictEqual(output.Location, 'https://test-bucket.s3.amazonaws.com/test-file.txt');
+        assert.strictEqual(output.ContentType, 'text/plain');
+    });
+
+    it('throws error when bucket is missing', async () => {
+        delete context.messages.in.content.bucket;
+
+        try {
+            await PutObject.receive(context);
+            assert.fail('Should have thrown an error');
+        } catch (err) {
+            assert(err instanceof context.CancelError);
+            assert(err.message.includes('Bucket is required'));
+        }
+    });
+
+    it('throws error when key is missing', async () => {
+        delete context.messages.in.content.key;
+
+        try {
+            await PutObject.receive(context);
+            assert.fail('Should have thrown an error');
+        } catch (err) {
+            assert(err instanceof context.CancelError);
+            assert(err.message.includes('Object Key is required'));
+        }
+    });
+
+    it('throws error when fileId is missing', async () => {
+        delete context.messages.in.content.fileId;
+
+        try {
+            await PutObject.receive(context);
+            assert.fail('Should have thrown an error');
+        } catch (err) {
+            assert(err instanceof context.CancelError);
+            assert(err.message.includes('File ID is required'));
+        }
+    });
+});

--- a/src/appmixer/aws/s3/artifacts/test/PutObject.test.js
+++ b/src/appmixer/aws/s3/artifacts/test/PutObject.test.js
@@ -58,7 +58,7 @@ describe('AWS S3 PutObject component', () => {
 
         assert(s3Mock.upload.calledOnce, 'S3 upload should be called once');
         const uploadParams = s3Mock.upload.firstCall.args[0];
-        
+
         assert.strictEqual(uploadParams.Bucket, 'test-bucket');
         assert.strictEqual(uploadParams.Key, 'test-file.txt');
         assert.strictEqual(uploadParams.ContentType, 'text/plain');
@@ -90,7 +90,7 @@ describe('AWS S3 PutObject component', () => {
 
         assert(context.sendJson.calledOnce, 'sendJson should be called once');
         const output = context.sendJson.firstCall.args[0];
-        
+
         assert.strictEqual(output.Bucket, 'test-bucket');
         assert.strictEqual(output.Key, 'test-file.txt');
         assert.strictEqual(output.ETag, '"abc123"');

--- a/src/appmixer/aws/s3/bundle.json
+++ b/src/appmixer/aws/s3/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.aws.s3",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -21,6 +21,10 @@
         ],
         "1.0.6": [
             "Added validation for required fields in components."
+        ],
+        "1.1.0": [
+            "Modernized PutObject and PutContent components to use AWS SDK native upload method instead of deprecated s3-upload-stream library.",
+            "Made ACL parameter optional in PutObject and PutContent components to support S3 buckets with ACLs disabled (AWS best practice)."
         ]
     }
 }


### PR DESCRIPTION
The 2nd (smaller) part of https://github.com/Appmixer-ai/appmixer-components/issues/2586

:copilot: https://github.com/jirihofman/appmixer-connectors/pull/63

- remove deprecated library, use `s3.upload()`
- allow empty ACL

The 1st part will be done in another version, it will touch 3 connectors. There might be breaking changes.