### PR TITLE
update prompt to generate MakeApiCall 

### DIFF
--- a/.github/prompts/add-MakeAPICall-component.prompt.md
+++ b/.github/prompts/add-MakeAPICall-component.prompt.md
@@ -2,19 +2,25 @@
 mode: agent
 ---
 
-# Task: Create MakeAPICall Component for Appmixer Connector
+# Task: Create MakeApiCall Component for Appmixer Connector
 
 ## Prerequisites
 
 1. **Connector Name Required**: You MUST ask for the connector name if not specified. The connector name should be in lowercase (e.g., `github`, `notion`, `microsoft`).
 
-2. **Check if Component Exists**: Before creating, verify that a MakeAPICall component doesn't already exist for this connector:
-   - Search for `src/appmixer/{connector}/*/MakeApiCall/` directory
+2. **Check if Component Exists**: Before creating, verify that a MakeApiCall component doesn't already exist for this connector:
+   - Search for `src/appmixer/{connector}/*/MakeApiCall/` directory (note: the folder and file names should use `MakeApiCall` with lowercase 'pi')
    - If found, STOP and inform the user that the component already exists
+
+3. **Review Existing Connector Structure**: Examine the connector's existing files:
+   - `auth.js` - to understand authentication method (OAuth2, API Key, etc.)
+   - `quota.js` - if exists, to understand rate limiting resources
+   - `lib.js` - if exists, to check for API_VERSION or other constants
+   - `service.json` - to get the connector's service name
 
 ## Task Overview
 
-Create a generic MakeAPICall component that allows users to make arbitrary authenticated API calls to the specified service's API. This component is essential for advanced users who need to call API endpoints not covered by existing components.
+Create a generic MakeApiCall component that allows users to make arbitrary authenticated API calls to the specified service's API. This component is essential for advanced users who need to call API endpoints not covered by existing components.
 
 ## Research Requirements
 
@@ -35,28 +41,40 @@ Create the component in: `src/appmixer/{connector}/{module}/MakeApiCall/`
 
 Where:
 - `{connector}` = lowercase connector name (e.g., `github`, `notion`, `microsoft`)
-- `{module}` = appropriate module name (typically `core`, `list`, or connector-specific like `dynamics`)
+- `{module}` = appropriate module name (typically `core`, but check existing components in the connector to match the pattern - some use `list`, `api`, or service-specific names like `dynamics`, `sharepoint`, `gmail`)
+
+### Naming Convention
+
+**IMPORTANT**: There are two naming conventions in use across connectors:
+- `MakeApiCall` (preferred for new components)
+- `MakeAPICall` (legacy naming in some connectors)
+
+When creating a new component, use `MakeApiCall` unless the connector already has established naming patterns that differ.
 
 ### Required Files
 
 1. `component.json` - Component configuration
-2. `MakeApiCall.js` - Component behavior
+2. `MakeApiCall.js` - Component behavior (filename must match the folder name exactly)
 
 ## component.json Specification
+
+**IMPORTANT**: Follow the correct attribute order as per Appmixer standards:
+1. name, 2. author, 3. description, 4. version, 5. private (optional), 6. auth, 7. quota (if connector has quota.js), 8. inPorts, 9. outPorts, 10. icon
 
 ```json
 {
     "name": "appmixer.{connector}.{module}.MakeApiCall",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Performs an arbitrary authorized API call to {ServiceName} API.",
+    "version": "1.0.0",
     "private": false,
     "auth": {
         "service": "appmixer:{connector}",
-        "scope": []  // Add required scopes if applicable
+        "scope": []
     },
     "quota": {
         "manager": "appmixer:{connector}",
-        "resources": "general",  // or specific resource name
+        "resources": "requests",
         "scope": {
             "userId": "{{userId}}"
         }
@@ -72,8 +90,7 @@ Where:
                     },
                     "method": {
                         "type": "string",
-                        "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
-                        "default": "GET"
+                        "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
                     },
                     "body": {
                         "type": "string"
@@ -87,7 +104,7 @@ Where:
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL. Examples: /api/v1/resource, https://api.service.com/endpoint"
+                        "tooltip": "Enter the API endpoint URL. For example: <code>https://api.{service}.com/v1/resource</code>."
                     },
                     "method": {
                         "type": "select",
@@ -123,31 +140,159 @@ Where:
             ]
         }
     ],
-    "icon": "data:image/svg+xml;base64,..."  // Use connector's icon
+    "icon": "data:image/svg+xml;base64,..."
 }
 ```
+
+### Notes on component.json:
+
+1. **auth.service**: Must match the connector's auth.js service identifier. Check `auth.js` in the connector root. Common patterns:
+   - Single service: `"appmixer:{connector}"` (e.g., `"appmixer:notion"`)
+   - Nested service: `"appmixer:{connector}:{subservice}"` (e.g., `"appmixer:microsoft:dynamics"`)
+
+2. **auth.scope**: Only include if the connector uses OAuth2 with scopes. Copy scopes from other components in the same connector.
+
+3. **quota**: Only include if the connector has a `quota.js` file. Check existing components for the correct `resources` value.
+
+4. **icon**: Copy the icon from another component in the same connector, or use the icon from `service.json`.
+
+5. **tooltip examples**: Use `<code>` tags for inline code examples in tooltips. Make examples service-specific.
 
 ## MakeApiCall.js Specification
 
 The behavior file should handle:
-1. Extract `url`, `method`, and `body` from input
-2. Build authenticated request with proper headers
-3. Handle API-specific requirements (version headers, base URL, etc.)
-4. Parse and send response
+1. Validate required inputs (`url` and `method`)
+2. Extract `url`, `method`, and `body` from input
+3. Build authenticated request with proper headers
+4. Handle API-specific requirements (version headers, base URL, etc.)
+5. Parse and send response
+
+**IMPORTANT Code Style Rules:**
+- Use 4 spaces for indentation
+- Add one empty line after the `receive` function definition
+- Use `'use strict';` at the top
+- Validate required fields with `throw new context.CancelError('...')`
 
 ### Common Patterns
 
-**Pattern 1: Relative URL with Base URL from Auth Context**
+**Pattern 1: Full URL (most common) - OAuth2 Authentication**
+
+Use this when the API expects users to provide full URLs including the base URL.
+
 ```javascript
 'use strict';
 
 module.exports = {
+
     async receive(context) {
+
         const { url, method, body } = context.messages.in.content;
+
+        if (!url) {
+            throw new context.CancelError('API Endpoint URL is required!');
+        }
+
+        if (!method) {
+            throw new context.CancelError('HTTP Method is required!');
+        }
 
         const requestOptions = {
             method: method,
-            url: (context.resource || context.auth.resource) + url,
+            url: url,
+            headers: {
+                'Authorization': `Bearer ${context.auth.accessToken}`,
+                'Content-Type': 'application/json'
+            }
+        };
+
+        if (body) {
+            requestOptions.data = JSON.parse(body);
+        }
+
+        const response = await context.httpRequest(requestOptions);
+
+        return context.sendJson({
+            status: response.status,
+            headers: response.headers,
+            body: response.data
+        }, 'out');
+    }
+};
+```
+
+**Pattern 2: Full URL with API Version Header**
+
+Use this when the API requires a version header (e.g., GitHub, Notion).
+
+```javascript
+'use strict';
+
+const { API_VERSION } = require('../../lib');  // If lib.js exists with API_VERSION
+
+module.exports = {
+
+    async receive(context) {
+
+        const { url, method, body } = context.messages.in.content;
+
+        if (!url) {
+            throw new context.CancelError('API Endpoint URL is required!');
+        }
+
+        if (!method) {
+            throw new context.CancelError('HTTP Method is required!');
+        }
+
+        const requestOptions = {
+            method: method,
+            url: url,
+            headers: {
+                'Authorization': `Bearer ${context.auth.accessToken}`,
+                'Content-Type': 'application/json',
+                '{Service}-Version': API_VERSION  // e.g., 'Notion-Version', 'X-GitHub-Api-Version'
+            }
+        };
+
+        if (body) {
+            requestOptions.data = JSON.parse(body);
+        }
+
+        const response = await context.httpRequest(requestOptions);
+
+        return context.sendJson({
+            status: response.status,
+            headers: response.headers,
+            body: response.data
+        }, 'out');
+    }
+};
+```
+
+**Pattern 3: Relative URL with Base URL from Auth Context**
+
+Use this when the base URL is stored in auth context (e.g., Microsoft Dynamics, services with tenant-specific URLs).
+
+```javascript
+'use strict';
+
+module.exports = {
+
+    async receive(context) {
+
+        const { url, method, body } = context.messages.in.content;
+
+        if (!url) {
+            throw new context.CancelError('API Endpoint URL is required!');
+        }
+
+        if (!method) {
+            throw new context.CancelError('HTTP Method is required!');
+        }
+
+        const baseUrl = context.resource || context.auth.resource;
+        const requestOptions = {
+            method: method,
+            url: baseUrl + url,
             headers: {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${context.accessToken || context.auth?.accessToken}`
@@ -160,13 +305,14 @@ module.exports = {
 
         try {
             const response = await context.httpRequest(requestOptions);
-            
+
             return context.sendJson({
                 status: response.status,
                 headers: response.headers,
                 body: response.data
             }, 'out');
         } catch (error) {
+            // Extract meaningful error message from API response
             const axiosError = error.response?.data;
             error.message = `${error.message}: ${axiosError?.error?.message || axiosError?.message || ''}`;
             throw error;
@@ -175,23 +321,33 @@ module.exports = {
 };
 ```
 
-**Pattern 2: Full URL with API Version Header**
+**Pattern 4: API Key Authentication**
+
+Use this for services using API Key authentication (check auth.js for `type: 'apiKey'`).
+
 ```javascript
 'use strict';
 
-const { API_VERSION } = require('../../lib');  // If lib.js exists
-
 module.exports = {
+
     async receive(context) {
+
         const { url, method, body } = context.messages.in.content;
+
+        if (!url) {
+            throw new context.CancelError('API Endpoint URL is required!');
+        }
+
+        if (!method) {
+            throw new context.CancelError('HTTP Method is required!');
+        }
 
         const requestOptions = {
             method: method,
             url: url,
             headers: {
-                'Authorization': `Bearer ${context.auth.accessToken}`,
-                'Content-Type': 'application/json',
-                'API-Version': API_VERSION  // Service-specific version header
+                'Authorization': `Bearer ${context.auth.apiKey}`,  // or 'X-API-Key': context.auth.apiKey
+                'Content-Type': 'application/json'
             }
         };
 
@@ -201,7 +357,7 @@ module.exports = {
 
         const response = await context.httpRequest(requestOptions);
 
-        await context.sendJson({
+        return context.sendJson({
             status: response.status,
             headers: response.headers,
             body: response.data
@@ -214,73 +370,89 @@ module.exports = {
 
 Research and implement the following based on the service's API documentation:
 
-1. **Authentication Method**:
-   - Bearer token: `Authorization: Bearer {token}`
-   - Basic auth: Use `auth: { user, password }` in httpRequest
-   - API key in header: `X-API-Key: {key}`
+### 1. Authentication Method
 
-2. **Required Headers**:
-   - API Version (e.g., GitHub: `X-GitHub-Api-Version: 2022-11-28`)
-   - Accept header (e.g., Notion: `Notion-Version: 2022-06-28`)
-   - Content-Type (usually `application/json`)
+Check the connector's `auth.js` to determine which pattern to use:
 
-3. **Base URL Handling**:
-   - If relative URLs: prepend base URL from `context.auth.resource` or hardcoded
-   - If full URLs: use `url` directly
+| auth.js `type` | Authorization Header |
+|----------------|---------------------|
+| `oauth2` | `Authorization: Bearer ${context.auth.accessToken}` |
+| `apiKey` | `Authorization: Bearer ${context.auth.apiKey}` or `X-API-Key: ${context.auth.apiKey}` |
+| Basic auth | Use `auth: { user: context.auth.apiKey, password: 'X' }` in httpRequest |
 
-4. **Error Handling**:
-   - Extract meaningful error messages from API responses
-   - Handle rate limiting, authentication errors appropriately
+### 2. Required Headers
+
+Common API-specific headers to check for:
+- **API Version**: GitHub (`X-GitHub-Api-Version: 2022-11-28`), Notion (`Notion-Version: 2022-06-28`)
+- **Accept header**: GitHub (`accept: application/vnd.github+json`)
+- **Content-Type**: Usually `application/json`, but some APIs use `application/x-www-form-urlencoded` (e.g., Stripe)
+
+### 3. Base URL Handling
+
+| Scenario | Implementation |
+|----------|---------------|
+| Full URLs expected | Use `url` directly |
+| Relative URLs with dynamic base | Use `context.auth.resource + url` |
+| Relative URLs with static base | Use hardcoded base URL + `url` |
+
+### 4. Error Handling
+
+Only add try/catch if the API returns error details in a non-standard format. Most APIs work fine without explicit error handling since Axios/httpRequest will throw on non-2xx status codes.
 
 ## Examples Reference
 
-Study these existing implementations:
+Study these existing implementations for reference:
 
-1. **Microsoft Dynamics** (`src/appmixer/microsoft/dynamics/MakeApiCall/`)
-   - Uses base URL from auth context
-   - Prepends URL with resource
-   - Has comprehensive error handling
-
-2. **Notion** (`src/appmixer/notion/core/MakeApiCall/`)
-   - Uses full URLs
-   - Includes API version header
-   - References lib.js for constants
-
-3. **GitHub** (`src/appmixer/github/list/MakeApiCall/`)
-   - Uses full URLs
-   - Includes accept and version headers
-   - Clean structure
+| Connector | Location | Key Features |
+|-----------|----------|--------------|
+| **Notion** | `src/appmixer/notion/core/MakeApiCall/` | Full URLs, API version header from lib.js |
+| **GitHub** | `src/appmixer/github/list/MakeApiCall/` | Full URLs, accept + version headers |
+| **Microsoft Dynamics** | `src/appmixer/microsoft/dynamics/MakeApiCall/` | Relative URLs, base URL from auth context, error handling |
+| **Stripe** | `src/appmixer/stripe/core/MakeAPICall/` | API Key auth, form-urlencoded content type |
+| **Clerk** | `src/appmixer/clerk/core/MakeApiCall/` | API Key auth, full URLs |
 
 ## Validation Checklist
 
 Before completing, verify:
 
-- [ ] Connector name is specified
-- [ ] Component doesn't already exist
+- [ ] Connector name is specified and component doesn't already exist
+- [ ] Reviewed existing connector files (auth.js, quota.js, lib.js, service.json)
 - [ ] API documentation researched (or knowledge used with disclaimer)
-- [ ] Correct module selected (core, list, or service-specific)
-- [ ] Auth service matches connector auth.js
-- [ ] Quota manager matches connector quota.js (if exists)
-- [ ] Required headers identified from API docs
-- [ ] Base URL handling correct for the API
-- [ ] Error handling implemented
-- [ ] Icon included (use connector's icon)
-- [ ] Examples in tooltips are service-specific and accurate
+- [ ] Correct module selected (check existing components for pattern)
+- [ ] `component.json` follows attribute order: name, author, description, version, private, auth, quota, inPorts, outPorts, icon
+- [ ] `auth.service` matches connector's auth.js exactly
+- [ ] `quota` section included only if connector has quota.js
+- [ ] Required headers identified from API docs (version headers, accept headers)
+- [ ] Base URL handling correct for the API (full vs relative URLs)
+- [ ] Required field validation with `throw new context.CancelError(...)`
+- [ ] Icon copied from another component in the same connector
+- [ ] Tooltip examples use `<code>` tags and are service-specific
+- [ ] Code style: 4-space indentation, empty line after function definition, `'use strict';` at top
 
-## Output Format
+## Post-Creation Steps
 
-1. Create both files with proper content
-2. Use .github/prompts/post-refactor-bundle-update.prompt.md to update the connector bundle minor version
-3. Provide a summary of:
-   - API research findings
+After creating both files:
+
+1. **Update bundle.json**: Increment the minor version and add changelog entry:
+   ```json
+   "changelog": {
+       "x.y.z": ["Added MakeApiCall component."]
+   }
+   ```
+
+2. **Verify no errors**: Run `npm run test-lint` or check for TypeScript/ESLint errors
+
+3. **Provide summary** with:
+   - API research findings (base URL, auth method, required headers)
    - Key API requirements implemented
-   - Example usage
+   - Example usage showing a sample API call
    - Any assumptions made or documentation gaps
 
 ## Success Criteria
 
-- Component allows making any authenticated API call to the service
-- Proper authentication headers included
-- API-specific requirements (versions, headers) implemented
-- Error messages are informative
-- Code follows Appmixer conventions and existing patterns
+- [ ] Component allows making any authenticated API call to the service
+- [ ] Proper authentication headers included (matching auth.js pattern)
+- [ ] API-specific requirements (versions, headers) implemented correctly
+- [ ] Required field validation implemented
+- [ ] Code follows Appmixer conventions (indentation, empty lines, strict mode)
+- [ ] bundle.json updated with new version and changelog


### PR DESCRIPTION
Improve the prompt that will help us later.

## Changes Made

1. **Added prerequisite to review connector structure** - New step to examine `auth.js`, `quota.js`, `lib.js`, and `service.json` before creating the component

2. **Clarified naming convention** - Added guidance on the `MakeApiCall` vs `MakeAPICall` naming inconsistency, recommending `MakeApiCall` for new components

3. **Updated component.json attribute order** - Listed the correct order: name, author, description, version, private, auth, quota, inPorts, outPorts, icon

4. **Added `version` field** - The template now includes `"version": "1.0.0"` which was missing

5. **Removed `default` from schema** - The `default` value should only be in inspector's `defaultValue`, not in schema

6. **Added notes section for component.json** - Detailed guidance on auth.service, auth.scope, quota, icon, and tooltip formatting

7. **Updated MakeApiCall.js patterns** - 
   - Added required field validation with `throw new context.CancelError(...)`
   - Added code style rules (4-space indentation, empty lines, strict mode)
   - Provided 4 distinct patterns: Full URL OAuth2, Full URL with Version Header, Relative URL, API Key auth
   - Added more detailed comments

8. **Improved API-Specific Considerations** - Converted to tables for easier reference

9. **Updated Examples Reference** - Converted to a table with locations and key features

10. **Enhanced Validation Checklist** - More comprehensive checklist aligned with standards

11. **Added Post-Creation Steps** - Clear instructions for bundle.json update and verification

12. **Added Success Criteria** - Checklist format for verifying completion
