### PR TITLE
Unkey (fix): add `credits` fields to `CreateKey`

### DIFF
--- a/src/appmixer/unkey/bundle.json
+++ b/src/appmixer/unkey/bundle.json
@@ -1,8 +1,8 @@
 {
     "name": "appmixer.unkey",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": [
+        "1.0.1": [
             "Initial release with key management components: CreateKey, GetKey, UpdateKey, DeleteKey, VerifyKey, ListKeys, GetAPI, and UpdateKeyRemaining."
         ]
     }

--- a/src/appmixer/unkey/core/CreateKey/CreateKey.js
+++ b/src/appmixer/unkey/core/CreateKey/CreateKey.js
@@ -14,7 +14,8 @@ module.exports = {
             expires,
             ratelimits,
             enabled,
-            recoverable
+            recoverable,
+            credits
         } = context.messages.in.content;
 
         if (!apiId) {
@@ -82,6 +83,19 @@ module.exports = {
 
         if (typeof enabled === 'boolean') body.enabled = enabled;
         if (typeof recoverable === 'boolean') body.recoverable = recoverable;
+
+        // Parse and validate credits object
+        if (credits) {
+            try {
+                const parsedCredits = JSON.parse(credits);
+                if (typeof parsedCredits !== 'object' || parsedCredits === null) {
+                    throw new context.CancelError('Credits must be a JSON object');
+                }
+                body.credits = parsedCredits;
+            } catch (e) {
+                throw new context.CancelError('Invalid JSON in credits field: ' + e.message);
+            }
+        }
 
         const response = await context.httpRequest({
             method: 'POST',

--- a/src/appmixer/unkey/core/CreateKey/CreateKey.js
+++ b/src/appmixer/unkey/core/CreateKey/CreateKey.js
@@ -66,7 +66,7 @@ module.exports = {
             }
         }
 
-        if (expires) body.expires = expires;
+        if (expires) body.expires = new Date(expires).getTime();
 
         // Parse and validate ratelimits array
         if (ratelimits) {

--- a/src/appmixer/unkey/core/CreateKey/component.json
+++ b/src/appmixer/unkey/core/CreateKey/component.json
@@ -44,7 +44,8 @@
                         "type": "string"
                     },
                     "expires": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "date-time"
                     },
                     "ratelimits": {
                         "type": "string"
@@ -112,10 +113,10 @@
                         "tooltip": "JSON array of permissions (e.g., [\"documents.read\", \"documents.write\"]). Supports wildcards."
                     },
                     "expires": {
-                        "type": "number",
-                        "label": "Expires (Unix timestamp ms)",
+                        "type": "date-time",
+                        "label": "Expires",
                         "index": 9,
-                        "tooltip": "Unix timestamp in milliseconds when key expires. Omit for permanent keys."
+                        "tooltip": "Date and time when the key will expire. Omit for permanent keys."
                     },
                     "ratelimits": {
                         "type": "textarea",

--- a/src/appmixer/unkey/core/CreateKey/component.json
+++ b/src/appmixer/unkey/core/CreateKey/component.json
@@ -54,6 +54,9 @@
                     },
                     "recoverable": {
                         "type": "boolean"
+                    },
+                    "credits": {
+                        "type": "string"
                     }
                 },
                 "required": ["apiId"]
@@ -120,17 +123,23 @@
                         "index": 10,
                         "tooltip": "JSON array of rate limit objects with name, limit, duration (ms), and autoApply fields."
                     },
+                    "credits": {
+                        "type": "textarea",
+                        "label": "Credits (JSON)",
+                        "index": 11,
+                        "tooltip": "JSON object for usage-based limits with 'remaining' (required) and 'refill' (optional) fields. Controls total usage with global consistency."
+                    },
                     "enabled": {
                         "type": "toggle",
                         "label": "Enabled",
-                        "index": 11,
+                        "index": 12,
                         "defaultValue": true,
                         "tooltip": "Whether the key is active immediately upon creation"
                     },
                     "recoverable": {
                         "type": "toggle",
                         "label": "Recoverable",
-                        "index": 12,
+                        "index": 13,
                         "defaultValue": false,
                         "tooltip": "Store plaintext key in encrypted vault for later retrieval. Only enable if absolutely necessary."
                     }

--- a/src/appmixer/unkey/core/UpdateKey/UpdateKey.js
+++ b/src/appmixer/unkey/core/UpdateKey/UpdateKey.js
@@ -20,7 +20,7 @@ module.exports = {
 
         if (name !== undefined && name !== null) body.name = name;
         if (externalId !== undefined && externalId !== null) body.externalId = externalId;
-        if (expires !== undefined && expires !== null) body.expires = expires;
+        if (expires !== undefined && expires !== null) body.expires = new Date(expires).getTime();
         if (typeof enabled === 'boolean') body.enabled = enabled;
 
         await context.httpRequest({

--- a/src/appmixer/unkey/core/UpdateKey/component.json
+++ b/src/appmixer/unkey/core/UpdateKey/component.json
@@ -29,7 +29,8 @@
                         "type": "string"
                     },
                     "expires": {
-                        "type": "integer"
+                        "type": "string",
+                        "format": "date-time"
                     },
                     "enabled": {
                         "type": "boolean"
@@ -58,10 +59,10 @@
                         "tooltip": "Links the key to a user or entity in your system"
                     },
                     "expires": {
-                        "type": "number",
-                        "label": "Expires (Unix milliseconds)",
+                        "type": "date-time",
+                        "label": "Expires",
                         "index": 4,
-                        "tooltip": "Unix timestamp in milliseconds when the key will expire"
+                        "tooltip": "Date and time when the key will expire"
                     },
                     "enabled": {
                         "type": "toggle",


### PR DESCRIPTION
After clarification of the docs by Unkey in https://github.com/unkeyed/unkey/issues/4574 it is now clear how to use `credentials` field.

- Added that to `CreateKey` so that increment/decrement can be used afterwards by `UpdateKeyCredits`.
- changed `expires` to be datepicker in Inspector

Fixes https://github.com/Appmixer-ai/appmixer-components/issues/2567#issuecomment-3879084077 - Issue 1