### PR TITLE
jira.createIssue,updateIssue:  fix custom field option labels and value formatting (patch)

### DIFF
--- a/src/appmixer/jira/bundle.json
+++ b/src/appmixer/jira/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jira",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -49,7 +49,7 @@
         "2.0.0": [
             "(breaking change) Updated FindIssues, NewIssue, and UpdatedIssue components to use the new JQL enhanced search API endpoint instead of the deprecated /rest/api/3/search endpoint."
         ],
-        "2.0.1": [
+        "2.0.2": [
             "Create Issue, Update Issue: fix support for custom fields."
         ]
     }

--- a/src/appmixer/jira/jira-commons.js
+++ b/src/appmixer/jira/jira-commons.js
@@ -140,7 +140,10 @@ module.exports = {
 
             if (Array.isArray(allowedValues)) {
                 inspector.inputs[key].type = 'select';
-                inspector.inputs[key].options = allowedValues.map(value => ({ content: value.name, value: value.id }));
+                inspector.inputs[key].options = allowedValues.map(v => ({
+                    content: v.name || v.value || v.id,
+                    value: v.id
+                }));
             }
 
             if (schema.type === 'array') {
@@ -187,15 +190,15 @@ module.exports = {
             if (!meta || !meta.schema) return;
 
             const { schema } = meta;
-            if (schema.type === 'option') {
-                issueInfo[key] = { id: value };
-            } else if (schema.type === 'array') {
+            const hasAllowedValues = Array.isArray(meta.allowedValues) && meta.allowedValues.length > 0;
+
+            if (schema.type === 'array') {
                 if (Array.isArray(value)) {
-                    if (schema.items === 'option') {
+                    if (schema.items === 'option' || (hasAllowedValues && schema.items !== 'string')) {
                         issueInfo[key] = value.map(v => ({ id: v }));
                     }
                 }
-            } else if (schema.type === 'user') {
+            } else if (schema.type === 'option' || schema.type === 'user' || hasAllowedValues) {
                 issueInfo[key] = { id: value };
             } else if (schema.type === 'number') {
                 issueInfo[key] = Number(value);


### PR DESCRIPTION
## Summary
- Fix custom field select options showing raw IDs instead of human-readable labels (`v.name || v.value || v.id` fallback)
- Fix custom field values not being formatted correctly for the Jira API (use `allowedValues` as fallback signal for option-type wrapping)

Resolves Appmixer-ai/appmixer-components#2624

🤖 Generated with [Claude Code](https://claude.com/claude-code)