### PR TITLE
test: fix `npm run test-unit` to support patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "appmixer-connectors",
     "scripts": {
         "lint": "eslint . --ext .js --no-error-on-unmatched-pattern",
-        "test-unit": "mocha --recursive --exit --exclude '**/node_modules/**' 'test/**/*.test.js' 'src/appmixer/**/artifacts/test/**/*.test.js' 'src/examples/**/artifacts/test/**/*.test.js'",
-        "test-unit-coverage": "nyc --reporter=lcov --reporter=text-summary mocha --recursive --exit --exclude '**/node_modules/**' 'test/**/*.test.js' 'src/appmixer/**/artifacts/test/**/*.test.js' 'src/examples/**/artifacts/test/**/*.test.js'"
+        "test-unit": "node scripts/run_test_unit.js",
+        "test-unit-coverage": "node scripts/run_test_unit.js --coverage"
     },
     "devDependencies": {
         "axios": "^0.22.0",

--- a/scripts/run_test_unit.js
+++ b/scripts/run_test_unit.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawn } = require('child_process');
+
+const defaultPatterns = [
+    'test/**/*.test.js',
+    'src/appmixer/**/artifacts/test/**/*.test.js',
+    'src/examples/**/artifacts/test/**/*.test.js'
+];
+
+const userArgs = process.argv.slice(2);
+const coverageMode = userArgs[0] === '--coverage';
+const filteredArgs = coverageMode ? userArgs.slice(1) : userArgs;
+
+function isExplicitTestPattern(value) {
+    return value.includes('*') || value.endsWith('.test.js') || value.includes('.test.js');
+}
+
+function toScopedPattern(value) {
+    const normalized = value.replace(/\/$/, '');
+    return `${normalized}/**/artifacts/test/**/*.test.js`;
+}
+
+const patterns = filteredArgs.length
+    ? filteredArgs.map(value => (isExplicitTestPattern(value) ? value : toScopedPattern(value)))
+    : defaultPatterns;
+
+const mochaArgs = [
+    '--recursive',
+    '--exit',
+    '--exclude',
+    '**/node_modules/**',
+    ...patterns
+];
+
+const runnerCommand = coverageMode
+    ? (process.platform === 'win32' ? 'nyc.cmd' : 'nyc')
+    : (process.platform === 'win32' ? 'mocha.cmd' : 'mocha');
+
+const runnerArgs = coverageMode
+    ? ['--reporter=lcov', '--reporter=text-summary', 'mocha', ...mochaArgs]
+    : mochaArgs;
+
+const child = spawn(runnerCommand, runnerArgs, {
+    stdio: 'inherit'
+});
+
+child.on('exit', code => {
+    process.exit(code ?? 1);
+});
+
+child.on('error', err => {
+    console.error('Failed to run mocha:', err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
When AI Agents run tests as instructed in copilot instructions :copilot:, they add a pattern to run only selected connector/file. But the command still runs all the tests. This PR fixes it

```sh
# this still ran all the tests
# AI then reran it again with `tail` or `grep`
npm run test-unit -- src/appmixer/betterstack/artifacts/test/UpdateMonitor.test.js
...
...context rot happening here...
...
```

<img width="452" height="387" alt="image" src="https://github.com/user-attachments/assets/3b860471-dd63-4004-a88b-30a7346886a4" />
