### PR TITLE
Vapi: Sync 4 E2E flows from Appmixer

### DIFF
--- a/src/appmixer/vapi/artifacts/test-flows/test-flow-assistant-crud.json
+++ b/src/appmixer/vapi/artifacts/test-flows/test-flow-assistant-crud.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Vapi - assistant-crud",
-    "description": "End-to-end test for Vapi connector - tests CRUD operations for assistants",
     "flow": {
         "on-start": {
             "type": "appmixer.utils.controls.OnStart",
@@ -88,11 +86,15 @@
                                             "variable": "$.set-variables.out.firstMessage",
                                             "functions": []
                                         }
-                                    }
+                                    },
+                                    "model": {},
+                                    "voice": {}
                                 },
                                 "lambda": {
                                     "name": "{{{var-name}}}",
-                                    "firstMessage": "{{{var-first-msg}}}"
+                                    "firstMessage": "{{{var-first-msg}}}",
+                                    "model": "{\n    \"provider\": \"openai\",\n    \"model\": \"gpt-4o-mini\",\n    \"temperature\": 0.7,\n    \"messages\": [\n      {\n        \"role\": \"system\",\n        \"content\": \"You are a helpful customer support assistant. Answer politely and clearly.\"\n      }\n    ]\n  }",
+                                    "voice": "{\n    \"provider\": \"11labs\",\n    \"voiceId\": \"t0jbNlBVZ17f02VDIeMI\"\n  }"
                                 }
                             }
                         }
@@ -102,7 +104,7 @@
         },
         "assert-create": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
+            "x": 1216,
             "y": 16,
             "version": "1.0.0",
             "source": {
@@ -138,13 +140,15 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{check-id}}}",
-                                                "assertion": "notEmpty"
+                                                "type": "string",
+                                                "assertion": "notEmpty",
+                                                "field": "{{{check-id}}}"
                                             },
                                             {
-                                                "field": "{{{check-name}}}",
+                                                "expected": "{{{expected-name}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{expected-name}}}"
+                                                "field": "{{{check-name}}}",
+                                                "type": "string"
                                             }
                                         ]
                                     }
@@ -192,7 +196,7 @@
         },
         "assert-get": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
+            "x": 1216,
             "y": 144,
             "version": "1.0.0",
             "source": {
@@ -228,13 +232,15 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{check-retrieved-id}}}",
-                                                "assertion": "notEmpty"
+                                                "type": "string",
+                                                "assertion": "notEmpty",
+                                                "field": "{{{check-retrieved-id}}}"
                                             },
                                             {
-                                                "field": "{{{check-retrieved-name}}}",
+                                                "expected": "{{{expected-retrieved-name}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{expected-retrieved-name}}}"
+                                                "field": "{{{check-retrieved-name}}}",
+                                                "type": "string"
                                             }
                                         ]
                                     }
@@ -290,7 +296,7 @@
         "get-updated-assistant": {
             "type": "appmixer.vapi.core.GetAssistant",
             "x": 1040,
-            "y": 400,
+            "y": 272,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -324,8 +330,8 @@
         },
         "assert-update": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
-            "y": 400,
+            "x": 1216,
+            "y": 272,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -356,9 +362,10 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{check-updated-name}}}",
+                                                "expected": "{{{expected-updated-name}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{expected-updated-name}}}"
+                                                "field": "{{{check-updated-name}}}",
+                                                "type": "string"
                                             }
                                         ]
                                     }
@@ -371,7 +378,7 @@
         },
         "after-all": {
             "type": "appmixer.utils.test.AfterAll",
-            "x": 1392,
+            "x": 1424,
             "y": 144,
             "version": "1.0.0",
             "source": {
@@ -432,7 +439,7 @@
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1792,
             "y": 144,
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "in": {
                     "delete-assistant": [
@@ -441,10 +448,7 @@
                 }
             },
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "delete-assistant": {
@@ -461,7 +465,7 @@
                                     }
                                 },
                                 "lambda": {
-                                    "recipients": "test@appmixer.com",
+                                    "recipients": "test@appmixer.ai",
                                     "testCase": "E2E Vapi - assistant-crud",
                                     "result": "{{{result-var}}}"
                                 }
@@ -471,5 +475,8 @@
                 }
             }
         }
-    }
+    },
+    "name": "E2E Vapi - assistant-crud",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/vapi/artifacts/test-flows/test-flow-assistant-list-find.json
+++ b/src/appmixer/vapi/artifacts/test-flows/test-flow-assistant-list-find.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Vapi - assistant-list-find",
-    "description": "End-to-end test for Vapi connector - tests ListAssistants and FindAssistants components",
     "flow": {
         "on-start": {
             "type": "appmixer.utils.controls.OnStart",
@@ -135,10 +133,19 @@
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
-                                    "outputType": {}
+                                    "outputType": {},
+                                    "orgId": {
+                                        "4d79bc4b-50a0-48df-b6a5-c02b93c2c1d7": {
+                                            "variable": "$.set-variables.out.testOrgId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "createdAtGt": {}
                                 },
                                 "lambda": {
-                                    "outputType": "array"
+                                    "outputType": "array",
+                                    "orgId": "{{{4d79bc4b-50a0-48df-b6a5-c02b93c2c1d7}}}",
+                                    "createdAtGt": "2026-01-26T18:30:00.000Z"
                                 }
                             }
                         }
@@ -213,7 +220,7 @@
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1568,
             "y": 80,
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "in": {
                     "after-all": [
@@ -222,10 +229,7 @@
                 }
             },
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "after-all": {
@@ -242,7 +246,7 @@
                                     }
                                 },
                                 "lambda": {
-                                    "recipients": "test@appmixer.com",
+                                    "recipients": "test@appmixer.ai",
                                     "testCase": "E2E Vapi - assistant-list-find",
                                     "result": "{{{result-var}}}"
                                 }
@@ -252,5 +256,8 @@
                 }
             }
         }
-    }
+    },
+    "name": "E2E Vapi - assistant-list-find",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/vapi/artifacts/test-flows/test-flow-squad-crud.json
+++ b/src/appmixer/vapi/artifacts/test-flows/test-flow-squad-crud.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Vapi - squad-crud",
-    "description": "End-to-end test for Vapi connector - tests squad CRUD operations (Create, Get, Update, Delete)",
     "flow": {
         "on-start": {
             "type": "appmixer.utils.controls.OnStart",
@@ -77,10 +75,15 @@
                                             "variable": "$.set-variables.out.squadName",
                                             "functions": []
                                         }
-                                    }
+                                    },
+                                    "members": {}
                                 },
                                 "lambda": {
-                                    "name": "{{{var-squad-name}}}"
+                                    "name": "{{{var-squad-name}}}",
+                                    "members": [
+                                        "eca8d673-2278-4c82-a4fd-1f2d48497eec",
+                                        "722fbece-c573-4dae-a575-f54e04e34c8b"
+                                    ]
                                 }
                             }
                         }
@@ -90,7 +93,7 @@
         },
         "assert-create": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
+            "x": 1264,
             "y": 16,
             "source": {
                 "in": {
@@ -126,13 +129,15 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{squad-id-check}}}",
-                                                "assertion": "notEmpty"
+                                                "type": "string",
+                                                "assertion": "notEmpty",
+                                                "field": "{{{squad-id-check}}}"
                                             },
                                             {
-                                                "field": "{{{squad-name-check}}}",
+                                                "expected": "{{{expected-name}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{expected-name}}}"
+                                                "field": "{{{squad-name-check}}}",
+                                                "type": "string"
                                             }
                                         ]
                                     }
@@ -146,7 +151,7 @@
         "get-squad": {
             "type": "appmixer.vapi.core.GetSquad",
             "x": 656,
-            "y": 144,
+            "y": 160,
             "source": {
                 "in": {
                     "create-squad": [
@@ -180,8 +185,8 @@
         },
         "assert-get": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
-            "y": 144,
+            "x": 1264,
+            "y": 160,
             "source": {
                 "in": {
                     "get-squad": [
@@ -220,14 +225,16 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{retrieved-id}}}",
+                                                "type": "string",
+                                                "expected": "{{{created-id}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{created-id}}}"
+                                                "field": "{{{retrieved-id}}}"
                                             },
                                             {
-                                                "field": "{{{retrieved-name}}}",
+                                                "expected": "{{{expected-name}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{expected-name}}}"
+                                                "field": "{{{retrieved-name}}}",
+                                                "type": "string"
                                             }
                                         ]
                                     }
@@ -241,7 +248,7 @@
         "update-squad": {
             "type": "appmixer.vapi.core.UpdateSquad",
             "x": 848,
-            "y": 272,
+            "y": 320,
             "source": {
                 "in": {
                     "get-squad": [
@@ -268,11 +275,15 @@
                                             "variable": "$.set-variables.out.updatedSquadName",
                                             "functions": []
                                         }
-                                    }
+                                    },
+                                    "members": {}
                                 },
                                 "lambda": {
                                     "squadId": "{{{var-squad-id}}}",
-                                    "name": "{{{var-updated-name}}}"
+                                    "name": "{{{var-updated-name}}}",
+                                    "members": [
+                                        "eca8d673-2278-4c82-a4fd-1f2d48497eec"
+                                    ]
                                 }
                             }
                         }
@@ -282,8 +293,8 @@
         },
         "get-updated-squad": {
             "type": "appmixer.vapi.core.GetSquad",
-            "x": 1040,
-            "y": 400,
+            "x": 1056,
+            "y": 320,
             "source": {
                 "in": {
                     "update-squad": [
@@ -317,8 +328,8 @@
         },
         "assert-update": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
-            "y": 272,
+            "x": 1264,
+            "y": 320,
             "source": {
                 "in": {
                     "get-updated-squad": [
@@ -349,9 +360,10 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{updated-name}}}",
+                                                "expected": "{{{expected-updated-name}}}",
                                                 "assertion": "equal",
-                                                "expected": "{{{expected-updated-name}}}"
+                                                "field": "{{{updated-name}}}",
+                                                "type": "string"
                                             }
                                         ]
                                     }
@@ -364,8 +376,8 @@
         },
         "after-all": {
             "type": "appmixer.utils.test.AfterAll",
-            "x": 1392,
-            "y": 144,
+            "x": 1488,
+            "y": 160,
             "source": {
                 "in": {
                     "assert-create": [
@@ -388,8 +400,8 @@
         },
         "delete-squad": {
             "type": "appmixer.vapi.core.DeleteSquad",
-            "x": 1616,
-            "y": 144,
+            "x": 1696,
+            "y": 160,
             "source": {
                 "in": {
                     "after-all": [
@@ -423,8 +435,8 @@
         },
         "process-results": {
             "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 1792,
-            "y": 144,
+            "x": 1904,
+            "y": 160,
             "source": {
                 "in": {
                     "delete-squad": [
@@ -432,12 +444,9 @@
                     ]
                 }
             },
-            "version": "1.0.0",
+            "version": "1.0.1",
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "delete-squad": {
@@ -445,18 +454,26 @@
                                 "type": "json2new",
                                 "modifiers": {
                                     "recipients": {},
-                                    "testCase": {},
                                     "result": {
                                         "result-var": {
                                             "variable": "$.after-all.out",
                                             "functions": []
                                         }
+                                    },
+                                    "testCase": {
+                                        "5c08bf74-de48-412d-8748-d663064ce824": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
                                     }
                                 },
                                 "lambda": {
-                                    "recipients": "test@appmixer.com",
-                                    "testCase": "E2E Vapi - squad-crud",
-                                    "result": "{{{result-var}}}"
+                                    "recipients": "test@appmixer.ai",
+                                    "result": "{{{result-var}}}",
+                                    "testCase": "{{{5c08bf74-de48-412d-8748-d663064ce824}}}"
                                 }
                             }
                         }
@@ -464,5 +481,8 @@
                 }
             }
         }
-    }
+    },
+    "name": "E2E Vapi - squad-crud",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/vapi/artifacts/test-flows/test-flow-squad-list-find.json
+++ b/src/appmixer/vapi/artifacts/test-flows/test-flow-squad-list-find.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Vapi - squad-list-find",
-    "description": "End-to-end test for Vapi connector - tests ListAssistants and FindSquads components",
     "flow": {
         "on-start": {
             "type": "appmixer.utils.controls.OnStart",
@@ -119,7 +117,7 @@
         "find-squads": {
             "type": "appmixer.vapi.core.FindSquads",
             "x": 656,
-            "y": 144,
+            "y": 160,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -135,10 +133,12 @@
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
-                                    "outputType": {}
+                                    "outputType": {},
+                                    "createdAtGt": {}
                                 },
                                 "lambda": {
-                                    "outputType": "array"
+                                    "outputType": "array",
+                                    "createdAtGt": "2026-01-27T21:30:00.000Z"
                                 }
                             }
                         }
@@ -213,7 +213,7 @@
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1584,
             "y": 80,
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "in": {
                     "after-all": [
@@ -222,10 +222,7 @@
                 }
             },
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "after-all": {
@@ -242,7 +239,7 @@
                                     }
                                 },
                                 "lambda": {
-                                    "recipients": "test@appmixer.com",
+                                    "recipients": "test@appmixer.ai",
                                     "testCase": "E2E Vapi - squad-list-find",
                                     "result": "{{{result-var}}}"
                                 }
@@ -252,5 +249,8 @@
                 }
             }
         }
-    }
+    },
+    "name": "E2E Vapi - squad-list-find",
+    "type": "automation",
+    "notes": {}
 }


### PR DESCRIPTION
## Synced Flows
- `src/appmixer/vapi/artifacts/test-flows/test-flow-assistant-crud.json` - E2E Vapi - assistant-crud
- `src/appmixer/vapi/artifacts/test-flows/test-flow-assistant-list-find.json` - E2E Vapi - assistant-list-find
- `src/appmixer/vapi/artifacts/test-flows/test-flow-squad-crud.json` - E2E Vapi - squad-crud
- `src/appmixer/vapi/artifacts/test-flows/test-flow-squad-list-find.json` - E2E Vapi - squad-list-find
---
*Synced from Appmixer-ai/appmixer-connectors via Appmixer Component Preview*