### PR TITLE
Hubspot (minor): Add pipeline/stage filtering to deal components

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.3.1",
+    "version": "4.4.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -81,6 +81,12 @@
         ],
         "4.3.1": [
             "Reduced icon size for better performance."
+        ],
+        "4.4.0": [
+            "Added optional Pipeline and Stage filters to UpdatedDeal trigger.",
+            "Added optional Pipeline filter to NewDeal trigger.",
+            "Added Pipeline and Stage filter inputs to ListDeals action using CRM Search API filterGroups.",
+            "Replaced hard-coded deal stages in UpdateDeal action with dynamic ListPipelineStages cascade."
         ]
     }
 }

--- a/src/appmixer/hubspot/crm/ListDeals/ListDeals.js
+++ b/src/appmixer/hubspot/crm/ListDeals/ListDeals.js
@@ -45,19 +45,46 @@ module.exports = {
         const {
             allAtOnce,
             limit = 100,
-            search
+            search,
+            pipeline,
+            dealstage
         } = context.messages.in.content;
 
         const { auth } = context;
         const hs = new Hubspot(auth.accessToken, context.config);
 
+        // Use search API when filtering by pipeline/stage or searching
+        const useSearch = search || pipeline || dealstage;
+
         let params = {};
-        if (search) {
-            params.query = search;
+        if (useSearch) {
+            if (search) {
+                params.query = search;
+            }
+
+            const filters = [];
+            if (pipeline) {
+                filters.push({
+                    propertyName: 'pipeline',
+                    operator: 'EQ',
+                    value: pipeline
+                });
+            }
+            if (dealstage) {
+                filters.push({
+                    propertyName: 'dealstage',
+                    operator: 'EQ',
+                    value: dealstage
+                });
+            }
+
+            if (filters.length > 0) {
+                params.filterGroups = [{ filters }];
+            }
         }
 
-        const method = params.query ? 'post' : 'get';
-        const url = params.query ? 'crm/v3/objects/deals/search' : 'crm/v3/objects/deals';
+        const method = useSearch ? 'post' : 'get';
+        const url = useSearch ? 'crm/v3/objects/deals/search' : 'crm/v3/objects/deals';
         const deals = await hs.paginatedCall(method, url, params, limit);
 
         if (allAtOnce) {

--- a/src/appmixer/hubspot/crm/ListDeals/component.json
+++ b/src/appmixer/hubspot/crm/ListDeals/component.json
@@ -29,6 +29,8 @@
                 "properties": {
                     "limit": { "type": "string" },
                     "search": { "type": "string" },
+                    "pipeline": { "type": "string" },
+                    "dealstage": { "type": "string" },
                     "allAtOnce": { "type": "boolean" }
                 }
             },
@@ -47,12 +49,43 @@
                         "tooltip": "Search deals that match the given value in the title, contact names or organization.",
                         "index": 2
                     },
+                    "pipeline": {
+                        "type": "select",
+                        "label": "Pipeline",
+                        "tooltip": "Optional. Filter deals by pipeline.",
+                        "source": {
+                            "url": "/component/appmixer/hubspot/crm/ListPipelines?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/objectType": "deals"
+                                },
+                                "transform": "./ListPipelines#toSelectArray"
+                            }
+                        },
+                        "index": 3
+                    },
+                    "dealstage": {
+                        "type": "select",
+                        "label": "Deal Stage",
+                        "tooltip": "Optional. Filter deals by stage. Requires a pipeline to be selected.",
+                        "source": {
+                            "url": "/component/appmixer/hubspot/crm/ListPipelineStages?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/pipelineId": "inputs/in/pipeline",
+                                    "in/isSource": true
+                                },
+                                "transform": "./ListPipelineStages#toSelectArray"
+                            }
+                        },
+                        "index": 4
+                    },
                     "allAtOnce": {
                         "type": "toggle",
                         "label": "Send all deals at once",
                         "tooltip": "Set it to true to send all deals in one message. If false, it will send one message per each deal. Order of the deals is not guaranteed.",
                         "defaultValue": false,
-                        "index": 3
+                        "index": 5
                     }
                 }
             }

--- a/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
+++ b/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
@@ -68,7 +68,14 @@ class NewDeal extends BaseSubscriptionComponent {
             properties: propertiesToReturn
         });
 
-        await context.sendArray(data.results, 'deal');
+        const { pipeline: filterPipeline } = context.properties;
+
+        let results = data.results;
+        if (filterPipeline) {
+            results = results.filter(deal => deal.properties?.pipeline === filterPipeline);
+        }
+
+        await context.sendArray(results, 'deal');
 
         return context.response();
     }

--- a/src/appmixer/hubspot/crm/NewDeal/component.json
+++ b/src/appmixer/hubspot/crm/NewDeal/component.json
@@ -11,6 +11,9 @@
     "properties": {
         "schema": {
             "properties": {
+                "pipeline": {
+                    "type": "string"
+                },
                 "properties": {
                     "type": "string"
                 }
@@ -19,6 +22,21 @@
         },
         "inspector": {
             "inputs": {
+                "pipeline": {
+                    "type": "select",
+                    "label": "Pipeline",
+                    "tooltip": "Optional. Only trigger for new deals in this pipeline. Leave empty to trigger for all pipelines.",
+                    "source": {
+                        "url": "/component/appmixer/hubspot/crm/ListPipelines?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/objectType": "deals"
+                            },
+                            "transform": "./ListPipelines#toSelectArray"
+                        }
+                    },
+                    "index": 1
+                },
                 "properties": {
                     "type": "text",
                     "label": "Properties",
@@ -29,7 +47,7 @@
                             "transform": "./GetDealsProperties#dealToLabelNameArray"
                         }
                     },
-                    "index": 1
+                    "index": 2
                 }
             }
         }

--- a/src/appmixer/hubspot/crm/UpdateDeal/component.json
+++ b/src/appmixer/hubspot/crm/UpdateDeal/component.json
@@ -48,22 +48,6 @@
                         "tooltip": "Deal Name.",
                         "index": 2
                     },
-                    "dealstage": {
-                        "type": "select",
-                        "label": "Deal Stage",
-                        "options": [
-                            { "clearItem": true, "content": "-- Clear selection --" },
-                            { "label": "Appointments scheduled", "value": "appointmentscheduled" },
-                            { "label": "Qualified to buy", "value": "qualifiedtobuy" },
-                            { "label": "Presentation scheduled", "value": "presentationscheduled" },
-                            { "label": "Decision maker bought-In", "value": "decisionmakerboughtin"},
-                            { "label": "Contract sent", "value": "contractsent"},
-                            { "label": "Closed won", "value": "closedwon" },
-                            { "label": "Closed lost", "value": "closedlost" }
-                        ],
-                        "tooltip": "Deal Stage.",
-                        "index": 3
-                    },
                     "pipeline": {
                         "type": "select",
                         "label": "Pipeline",
@@ -78,6 +62,22 @@
                             }
                         },
                         "index": 3
+                    },
+                    "dealstage": {
+                        "type": "select",
+                        "label": "Deal Stage",
+                        "tooltip": "Deal Stage. Select a pipeline first to see available stages.",
+                        "source": {
+                            "url": "/component/appmixer/hubspot/crm/ListPipelineStages?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/pipelineId": "inputs/in/pipeline",
+                                    "in/isSource": true
+                                },
+                                "transform": "./ListPipelineStages#toSelectArray"
+                            }
+                        },
+                        "index": 4
                     },
                     "hubSpotOwnerId": {
                         "type": "text",

--- a/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
@@ -74,9 +74,19 @@ class UpdatedDeal extends BaseSubscriptionComponent {
             properties: propertiesToReturn
         });
 
+        const { pipeline: filterPipeline, dealstage: filterStage } = context.properties;
+
         const results = [];
         data.results.forEach((deal) => {
             if (deal.updatedAt !== deal.createdAt) {
+                // Filter by pipeline if configured
+                if (filterPipeline && deal.properties?.pipeline !== filterPipeline) {
+                    return;
+                }
+                // Filter by deal stage if configured
+                if (filterStage && deal.properties?.dealstage !== filterStage) {
+                    return;
+                }
                 results.push(deal);
             }
         });

--- a/src/appmixer/hubspot/crm/UpdatedDeal/component.json
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/component.json
@@ -11,6 +11,12 @@
     "properties": {
         "schema": {
             "properties": {
+                "pipeline": {
+                    "type": "string"
+                },
+                "dealstage": {
+                    "type": "string"
+                },
                 "properties": {
                     "type": "string"
                 }
@@ -19,6 +25,37 @@
         },
         "inspector": {
             "inputs": {
+                "pipeline": {
+                    "type": "select",
+                    "label": "Pipeline",
+                    "tooltip": "Optional. Only trigger for deals in this pipeline. Leave empty to trigger for all pipelines.",
+                    "source": {
+                        "url": "/component/appmixer/hubspot/crm/ListPipelines?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/objectType": "deals"
+                            },
+                            "transform": "./ListPipelines#toSelectArray"
+                        }
+                    },
+                    "index": 1
+                },
+                "dealstage": {
+                    "type": "select",
+                    "label": "Deal Stage",
+                    "tooltip": "Optional. Only trigger for deals in this stage. Leave empty to trigger for all stages. Requires a pipeline to be selected.",
+                    "source": {
+                        "url": "/component/appmixer/hubspot/crm/ListPipelineStages?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/pipelineId": "properties/pipeline",
+                                "in/isSource": true
+                            },
+                            "transform": "./ListPipelineStages#toSelectArray"
+                        }
+                    },
+                    "index": 2
+                },
                 "properties": {
                     "type": "text",
                     "label": "Properties",
@@ -29,7 +66,7 @@
                             "transform": "./GetDealsProperties#dealToLabelNameArray"
                         }
                     },
-                    "index": 1
+                    "index": 3
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds dynamic pipeline and stage filtering to HubSpot deal components. All filters are **optional** for backward compatibility.

## Changes

| Component | What changed |
|---|---|
| **UpdatedDeal** (trigger) | Added optional Pipeline + Stage selectors. Filters results after batch/read by `deal.properties.pipeline` and `deal.properties.dealstage` |
| **NewDeal** (trigger) | Added optional Pipeline selector. Filters results after batch/read by `deal.properties.pipeline` |
| **ListDeals** (action) | Added Pipeline + Stage inputs. Uses `POST crm/v3/objects/deals/search` with `filterGroups` when pipeline/stage is selected |
| **UpdateDeal** (action) | Replaced 7 hard-coded default pipeline stages with dynamic `ListPipelineStages` cascade (same pattern as CreateDeal) |

## Implementation Details

- Reuses existing `ListPipelines` / `ListPipelineStages` components and the cascade pattern already proven in `CreateDeal`
- Trigger filtering happens **after** the `batch/read` API call (comparing `deal.properties.pipeline` / `deal.properties.dealstage`)
- `ListDeals` uses HubSpot Search API `filterGroups` for server-side filtering
- All new filters are optional — empty value means no filter (all pipelines/stages), ensuring backward compatibility
- `ListPipelineStages` already handles graceful fallback (returns empty array when no pipeline is selected)

## HubSpot API References

- [CRM Search API](https://developers.hubspot.com/docs/api-reference/search/guide) — `POST /crm/v3/objects/deals/search` with `filterGroups`
- [Pipelines API](https://developers.hubspot.com/docs/api-reference/crm-pipelines-v3/guide) — `GET /crm/v3/pipelines/deals`
- Pipeline stages — `GET /crm/v3/pipelines/deals/{pipelineId}/stages`