### PR TITLE
resend:  Add scheduledAt parameter to SendEmail action

### DIFF
--- a/src/appmixer/hubspot/crm/ListDeals/ListDeals.js
+++ b/src/appmixer/hubspot/crm/ListDeals/ListDeals.js
@@ -45,19 +45,46 @@ module.exports = {
         const {
             allAtOnce,
             limit = 100,
-            search
+            search,
+            pipeline,
+            dealstage
         } = context.messages.in.content;
 
         const { auth } = context;
         const hs = new Hubspot(auth.accessToken, context.config);
 
+        // Use search API when filtering by pipeline/stage or searching
+        const useSearch = search || pipeline || dealstage;
+
         let params = {};
-        if (search) {
-            params.query = search;
+        if (useSearch) {
+            if (search) {
+                params.query = search;
+            }
+
+            const filters = [];
+            if (pipeline) {
+                filters.push({
+                    propertyName: 'pipeline',
+                    operator: 'EQ',
+                    value: pipeline
+                });
+            }
+            if (dealstage) {
+                filters.push({
+                    propertyName: 'dealstage',
+                    operator: 'EQ',
+                    value: dealstage
+                });
+            }
+
+            if (filters.length > 0) {
+                params.filterGroups = [{ filters }];
+            }
         }
 
-        const method = params.query ? 'post' : 'get';
-        const url = params.query ? 'crm/v3/objects/deals/search' : 'crm/v3/objects/deals';
+        const method = useSearch ? 'post' : 'get';
+        const url = useSearch ? 'crm/v3/objects/deals/search' : 'crm/v3/objects/deals';
         const deals = await hs.paginatedCall(method, url, params, limit);
 
         if (allAtOnce) {

--- a/src/appmixer/hubspot/crm/ListDeals/component.json
+++ b/src/appmixer/hubspot/crm/ListDeals/component.json
@@ -29,6 +29,8 @@
                 "properties": {
                     "limit": { "type": "string" },
                     "search": { "type": "string" },
+                    "pipeline": { "type": "string" },
+                    "dealstage": { "type": "string" },
                     "allAtOnce": { "type": "boolean" }
                 }
             },
@@ -47,12 +49,43 @@
                         "tooltip": "Search deals that match the given value in the title, contact names or organization.",
                         "index": 2
                     },
+                    "pipeline": {
+                        "type": "select",
+                        "label": "Pipeline",
+                        "tooltip": "Optional. Filter deals by pipeline.",
+                        "source": {
+                            "url": "/component/appmixer/hubspot/crm/ListPipelines?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/objectType": "deals"
+                                },
+                                "transform": "./ListPipelines#toSelectArray"
+                            }
+                        },
+                        "index": 3
+                    },
+                    "dealstage": {
+                        "type": "select",
+                        "label": "Deal Stage",
+                        "tooltip": "Optional. Filter deals by stage. Requires a pipeline to be selected.",
+                        "source": {
+                            "url": "/component/appmixer/hubspot/crm/ListPipelineStages?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/pipelineId": "inputs/in/pipeline",
+                                    "in/isSource": true
+                                },
+                                "transform": "./ListPipelineStages#toSelectArray"
+                            }
+                        },
+                        "index": 4
+                    },
                     "allAtOnce": {
                         "type": "toggle",
                         "label": "Send all deals at once",
                         "tooltip": "Set it to true to send all deals in one message. If false, it will send one message per each deal. Order of the deals is not guaranteed.",
                         "defaultValue": false,
-                        "index": 3
+                        "index": 5
                     }
                 }
             }

--- a/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
+++ b/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
@@ -68,7 +68,14 @@ class NewDeal extends BaseSubscriptionComponent {
             properties: propertiesToReturn
         });
 
-        await context.sendArray(data.results, 'deal');
+        const { pipeline: filterPipeline } = context.properties;
+
+        let results = data.results;
+        if (filterPipeline) {
+            results = results.filter(deal => deal.properties?.pipeline === filterPipeline);
+        }
+
+        await context.sendArray(results, 'deal');
 
         return context.response();
     }

--- a/src/appmixer/hubspot/crm/NewDeal/component.json
+++ b/src/appmixer/hubspot/crm/NewDeal/component.json
@@ -11,6 +11,9 @@
     "properties": {
         "schema": {
             "properties": {
+                "pipeline": {
+                    "type": "string"
+                },
                 "properties": {
                     "type": "string"
                 }
@@ -19,6 +22,21 @@
         },
         "inspector": {
             "inputs": {
+                "pipeline": {
+                    "type": "select",
+                    "label": "Pipeline",
+                    "tooltip": "Optional. Only trigger for new deals in this pipeline. Leave empty to trigger for all pipelines.",
+                    "source": {
+                        "url": "/component/appmixer/hubspot/crm/ListPipelines?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/objectType": "deals"
+                            },
+                            "transform": "./ListPipelines#toSelectArray"
+                        }
+                    },
+                    "index": 1
+                },
                 "properties": {
                     "type": "text",
                     "label": "Properties",
@@ -29,7 +47,7 @@
                             "transform": "./GetDealsProperties#dealToLabelNameArray"
                         }
                     },
-                    "index": 1
+                    "index": 2
                 }
             }
         }

--- a/src/appmixer/hubspot/crm/UpdateDeal/component.json
+++ b/src/appmixer/hubspot/crm/UpdateDeal/component.json
@@ -48,22 +48,6 @@
                         "tooltip": "Deal Name.",
                         "index": 2
                     },
-                    "dealstage": {
-                        "type": "select",
-                        "label": "Deal Stage",
-                        "options": [
-                            { "clearItem": true, "content": "-- Clear selection --" },
-                            { "label": "Appointments scheduled", "value": "appointmentscheduled" },
-                            { "label": "Qualified to buy", "value": "qualifiedtobuy" },
-                            { "label": "Presentation scheduled", "value": "presentationscheduled" },
-                            { "label": "Decision maker bought-In", "value": "decisionmakerboughtin"},
-                            { "label": "Contract sent", "value": "contractsent"},
-                            { "label": "Closed won", "value": "closedwon" },
-                            { "label": "Closed lost", "value": "closedlost" }
-                        ],
-                        "tooltip": "Deal Stage.",
-                        "index": 3
-                    },
                     "pipeline": {
                         "type": "select",
                         "label": "Pipeline",
@@ -78,6 +62,22 @@
                             }
                         },
                         "index": 3
+                    },
+                    "dealstage": {
+                        "type": "select",
+                        "label": "Deal Stage",
+                        "tooltip": "Deal Stage. Select a pipeline first to see available stages.",
+                        "source": {
+                            "url": "/component/appmixer/hubspot/crm/ListPipelineStages?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/pipelineId": "inputs/in/pipeline",
+                                    "in/isSource": true
+                                },
+                                "transform": "./ListPipelineStages#toSelectArray"
+                            }
+                        },
+                        "index": 4
                     },
                     "hubSpotOwnerId": {
                         "type": "text",

--- a/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
@@ -74,9 +74,19 @@ class UpdatedDeal extends BaseSubscriptionComponent {
             properties: propertiesToReturn
         });
 
+        const { pipeline: filterPipeline, dealstage: filterStage } = context.properties;
+
         const results = [];
         data.results.forEach((deal) => {
             if (deal.updatedAt !== deal.createdAt) {
+                // Filter by pipeline if configured
+                if (filterPipeline && deal.properties?.pipeline !== filterPipeline) {
+                    return;
+                }
+                // Filter by deal stage if configured
+                if (filterStage && deal.properties?.dealstage !== filterStage) {
+                    return;
+                }
                 results.push(deal);
             }
         });

--- a/src/appmixer/hubspot/crm/UpdatedDeal/component.json
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/component.json
@@ -11,6 +11,12 @@
     "properties": {
         "schema": {
             "properties": {
+                "pipeline": {
+                    "type": "string"
+                },
+                "dealstage": {
+                    "type": "string"
+                },
                 "properties": {
                     "type": "string"
                 }
@@ -19,6 +25,37 @@
         },
         "inspector": {
             "inputs": {
+                "pipeline": {
+                    "type": "select",
+                    "label": "Pipeline",
+                    "tooltip": "Optional. Only trigger for deals in this pipeline. Leave empty to trigger for all pipelines.",
+                    "source": {
+                        "url": "/component/appmixer/hubspot/crm/ListPipelines?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/objectType": "deals"
+                            },
+                            "transform": "./ListPipelines#toSelectArray"
+                        }
+                    },
+                    "index": 1
+                },
+                "dealstage": {
+                    "type": "select",
+                    "label": "Deal Stage",
+                    "tooltip": "Optional. Only trigger for deals in this stage. Leave empty to trigger for all stages. Requires a pipeline to be selected.",
+                    "source": {
+                        "url": "/component/appmixer/hubspot/crm/ListPipelineStages?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/pipelineId": "properties/pipeline",
+                                "in/isSource": true
+                            },
+                            "transform": "./ListPipelineStages#toSelectArray"
+                        }
+                    },
+                    "index": 2
+                },
                 "properties": {
                     "type": "text",
                     "label": "Properties",
@@ -29,7 +66,7 @@
                             "transform": "./GetDealsProperties#dealToLabelNameArray"
                         }
                     },
-                    "index": 1
+                    "index": 3
                 }
             }
         }

--- a/src/appmixer/resend/email/SendEmail/SendEmail.js
+++ b/src/appmixer/resend/email/SendEmail/SendEmail.js
@@ -14,7 +14,8 @@ module.exports = {
             bcc: rawBcc,
             reply_to: rawReplyTo,
             headers,
-            idempotency_key
+            idempotency_key,
+            scheduled_at
         } = context.messages.in.content;
 
         // Helper to normalize address fields
@@ -66,6 +67,10 @@ module.exports = {
             } catch (error) {
                 throw new context.CancelError('Invalid headers format. Must be valid JSON.');
             }
+        }
+
+        if (scheduled_at) {
+            data.scheduled_at = new Date(scheduled_at).toISOString();
         }
 
         const requestHeaders = { 'Authorization': `Bearer ${context.auth.apiKey}` };

--- a/src/appmixer/resend/email/SendEmail/component.json
+++ b/src/appmixer/resend/email/SendEmail/component.json
@@ -48,6 +48,9 @@
 					},
 					"idempotency_key": {
 						"type": "string"
+					},
+					"scheduled_at": {
+						"type": "string"
 					}
 				},
 				"required": [
@@ -117,6 +120,12 @@
 						"index": 10,
 						"label": "Idempotency Key",
 						"tooltip": "Add an idempotency key to prevent duplicated emails. Should be unique per API request."
+					},
+					"scheduled_at": {
+						"type": "date-time",
+						"index": 11,
+						"label": "Schedule At",
+						"tooltip": "Schedule the email to be sent later. Use ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z). The date must be within 72 hours from now."
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Exposes the Resend API `scheduled_at` body parameter in the SendEmail action, allowing users to schedule emails for future delivery.

## Changes

**SendEmail/component.json:**
- Added `scheduled_at` string property to input schema
- Added `Schedule At` date-time input field (index 11) with tooltip explaining ISO 8601 format and 72-hour limit

**SendEmail/SendEmail.js:**
- Extracts `scheduled_at` from input
- Converts to ISO 8601 string and adds to request body when provided

## Resend API Reference

https://resend.com/docs/api-reference/emails/send-email

> `scheduled_at` (string) — Schedule email to be sent later. The date should be in ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z).