### PR TITLE
Resend (minor): Add scheduledAt parameter to SendEmail action

### DIFF
--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.resend",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "changelog": {
         "1.0.3": [
             "Initial version"
+        ],
+        "1.1.0": [
+            "Added scheduledAt parameter to SendEmail action for scheduling emails up to 72 hours in advance."
         ]
     }
 }

--- a/src/appmixer/resend/email/SendEmail/SendEmail.js
+++ b/src/appmixer/resend/email/SendEmail/SendEmail.js
@@ -14,7 +14,8 @@ module.exports = {
             bcc: rawBcc,
             reply_to: rawReplyTo,
             headers,
-            idempotency_key
+            idempotency_key,
+            scheduled_at
         } = context.messages.in.content;
 
         // Helper to normalize address fields
@@ -66,6 +67,10 @@ module.exports = {
             } catch (error) {
                 throw new context.CancelError('Invalid headers format. Must be valid JSON.');
             }
+        }
+
+        if (scheduled_at) {
+            data.scheduled_at = new Date(scheduled_at).toISOString();
         }
 
         const requestHeaders = { 'Authorization': `Bearer ${context.auth.apiKey}` };

--- a/src/appmixer/resend/email/SendEmail/component.json
+++ b/src/appmixer/resend/email/SendEmail/component.json
@@ -48,6 +48,9 @@
 					},
 					"idempotency_key": {
 						"type": "string"
+					},
+					"scheduled_at": {
+						"type": "string"
 					}
 				},
 				"required": [
@@ -117,6 +120,12 @@
 						"index": 10,
 						"label": "Idempotency Key",
 						"tooltip": "Add an idempotency key to prevent duplicated emails. Should be unique per API request."
+					},
+					"scheduled_at": {
+						"type": "date-time",
+						"index": 11,
+						"label": "Schedule At",
+						"tooltip": "Schedule the email to be sent later. Use ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z). The date must be within 72 hours from now."
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Exposes the Resend API `scheduled_at` body parameter in the SendEmail action, allowing users to schedule emails for future delivery.

## Changes

**SendEmail/component.json:**
- Added `scheduled_at` string property to input schema
- Added `Schedule At` date-time input field (index 11) with tooltip explaining ISO 8601 format and 72-hour limit

**SendEmail/SendEmail.js:**
- Extracts `scheduled_at` from input
- Converts to ISO 8601 string and adds to request body when provided

Fully backward compatible — the field is optional.

## Resend API Reference

https://resend.com/docs/api-reference/emails/send-email

> `scheduled_at` (string) — Schedule email to be sent later. The date should be in ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z).