### PR TITLE
facebookbusiness (patch): fix validateAccessToken + bump API to v25.0

### DIFF
--- a/src/appmixer/facebookbusiness/auth.js
+++ b/src/appmixer/facebookbusiness/auth.js
@@ -16,7 +16,7 @@ module.exports = {
                 'scope': context.scope.join(', '),
                 'state': context.ticket
             };
-            return 'https://www.facebook.com/v20.0/dialog/oauth?' + new URLSearchParams(params).toString();
+            return 'https://www.facebook.com/v22.0/dialog/oauth?' + new URLSearchParams(params).toString();
         },
 
         requestAccessToken: async context => {
@@ -28,7 +28,7 @@ module.exports = {
                 'code': context.authorizationCode
             };
 
-            const url = 'https://graph.facebook.com/v20.0/oauth/access_token';
+            const url = 'https://graph.facebook.com/v22.0/oauth/access_token';
 
             const response = await context.httpRequest.get(url + '?' + new URLSearchParams(params).toString());
             let newDate = new Date();
@@ -46,7 +46,7 @@ module.exports = {
 
         requestProfileInfo: async context => {
 
-            const url = `https://graph.facebook.com/v20.0/me?access_token=${context.accessToken}`;
+            const url = `https://graph.facebook.com/v22.0/me?access_token=${context.accessToken}`;
             const response = await context.httpRequest.get(url);
             return response.data;
         },
@@ -61,7 +61,7 @@ module.exports = {
                 'grant_type': 'fb_exchange_token'
             };
 
-            const url = 'https://graph.facebook.com/v20.0/oauth/access_token';
+            const url = 'https://graph.facebook.com/v22.0/oauth/access_token';
 
             const response = await context.httpRequest.get(url + '?' + new URLSearchParams(params).toString());
             let newDate = new Date();
@@ -75,7 +75,8 @@ module.exports = {
         validateAccessToken: async context => {
 
             try {
-                await this.requestProfileInfo(context);
+                const url = `https://graph.facebook.com/v22.0/me?access_token=${context.accessToken}`;
+                await context.httpRequest.get(url);
                 return true;
             } catch (err) {
                 return false;

--- a/src/appmixer/facebookbusiness/auth.js
+++ b/src/appmixer/facebookbusiness/auth.js
@@ -16,7 +16,7 @@ module.exports = {
                 'scope': context.scope.join(', '),
                 'state': context.ticket
             };
-            return 'https://www.facebook.com/v22.0/dialog/oauth?' + new URLSearchParams(params).toString();
+            return 'https://www.facebook.com/v25.0/dialog/oauth?' + new URLSearchParams(params).toString();
         },
 
         requestAccessToken: async context => {
@@ -28,7 +28,7 @@ module.exports = {
                 'code': context.authorizationCode
             };
 
-            const url = 'https://graph.facebook.com/v22.0/oauth/access_token';
+            const url = 'https://graph.facebook.com/v25.0/oauth/access_token';
 
             const response = await context.httpRequest.get(url + '?' + new URLSearchParams(params).toString());
             let newDate = new Date();
@@ -46,7 +46,7 @@ module.exports = {
 
         requestProfileInfo: async context => {
 
-            const url = `https://graph.facebook.com/v22.0/me?access_token=${context.accessToken}`;
+            const url = `https://graph.facebook.com/v25.0/me?access_token=${context.accessToken}`;
             const response = await context.httpRequest.get(url);
             return response.data;
         },
@@ -61,7 +61,7 @@ module.exports = {
                 'grant_type': 'fb_exchange_token'
             };
 
-            const url = 'https://graph.facebook.com/v22.0/oauth/access_token';
+            const url = 'https://graph.facebook.com/v25.0/oauth/access_token';
 
             const response = await context.httpRequest.get(url + '?' + new URLSearchParams(params).toString());
             let newDate = new Date();
@@ -75,7 +75,7 @@ module.exports = {
         validateAccessToken: async context => {
 
             try {
-                const url = `https://graph.facebook.com/v22.0/me?access_token=${context.accessToken}`;
+                const url = `https://graph.facebook.com/v25.0/me?access_token=${context.accessToken}`;
                 await context.httpRequest.get(url);
                 return true;
             } catch (err) {

--- a/src/appmixer/facebookbusiness/bundle.json
+++ b/src/appmixer/facebookbusiness/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.facebookbusiness",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "changelog": {
         "1.0.0": ["Initial version"],
         "2.0.0": [
@@ -11,6 +11,10 @@
         "2.1.0": [
             "Add support for custom delimiter in AddMembersFromCSVToAudience, ReplaceMembersFromCSVInAudience and RemoveMembersInCSVFromAudience.",
             "Removed dependency on fbgraph library."
+        ],
+        "2.1.1": [
+            "Fix validateAccessToken in auth.js.",
+            "Bump Graph API from v20.0 to v25.0."
         ]
     }
 }

--- a/src/appmixer/facebookbusiness/lib.js
+++ b/src/appmixer/facebookbusiness/lib.js
@@ -307,7 +307,7 @@ async function sendBatchToFacebook(
         access_token: context.auth.accessToken
     };
 
-    const url = `https://graph.facebook.com/v20.0/${audienceId}/${operation}`;
+    const url = `https://graph.facebook.com/v22.0/${audienceId}/${operation}`;
 
     await context.log({
         step: 'batch',

--- a/src/appmixer/facebookbusiness/lib.js
+++ b/src/appmixer/facebookbusiness/lib.js
@@ -307,7 +307,7 @@ async function sendBatchToFacebook(
         access_token: context.auth.accessToken
     };
 
-    const url = `https://graph.facebook.com/v22.0/${audienceId}/${operation}`;
+    const url = `https://graph.facebook.com/v25.0/${audienceId}/${operation}`;
 
     await context.log({
         step: 'batch',

--- a/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/AddMemberToAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/AddMemberToAudience.js
@@ -44,7 +44,7 @@ module.exports = {
             access_token: accessToken
         };
 
-        const url = `https://graph.facebook.com/v20.0/${audienceId}/users`;
+        const url = `https://graph.facebook.com/v22.0/${audienceId}/users`;
         const response = await context.httpRequest.post(url, body);
 
         if (!response || !response.data || response.data.num_received !== 1) {

--- a/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/AddMemberToAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/AddMemberToAudience.js
@@ -44,7 +44,7 @@ module.exports = {
             access_token: accessToken
         };
 
-        const url = `https://graph.facebook.com/v22.0/${audienceId}/users`;
+        const url = `https://graph.facebook.com/v25.0/${audienceId}/users`;
         const response = await context.httpRequest.post(url, body);
 
         if (!response || !response.data || response.data.num_received !== 1) {

--- a/src/appmixer/facebookbusiness/marketing/CreateAudience/CreateAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/CreateAudience/CreateAudience.js
@@ -21,7 +21,7 @@ module.exports = {
             }
         });
 
-        const url = `https://graph.facebook.com/v22.0/act_${accountId}/customaudiences?access_token=${accessToken}`;
+        const url = `https://graph.facebook.com/v25.0/act_${accountId}/customaudiences?access_token=${accessToken}`;
 
         const { data } = await context.httpRequest.post(url, formData, {
             headers: { 'Content-Type': 'multipart/form-data' }

--- a/src/appmixer/facebookbusiness/marketing/CreateAudience/CreateAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/CreateAudience/CreateAudience.js
@@ -21,7 +21,7 @@ module.exports = {
             }
         });
 
-        const url = `https://graph.facebook.com/v20.0/act_${accountId}/customaudiences?access_token=${accessToken}`;
+        const url = `https://graph.facebook.com/v22.0/act_${accountId}/customaudiences?access_token=${accessToken}`;
 
         const { data } = await context.httpRequest.post(url, formData, {
             headers: { 'Content-Type': 'multipart/form-data' }

--- a/src/appmixer/facebookbusiness/marketing/DeleteAudience/DeleteAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/DeleteAudience/DeleteAudience.js
@@ -5,7 +5,7 @@ module.exports = {
         const { audienceId } = context.messages.in.content;
         const accessToken = context.auth.accessToken;
 
-        const url = `https://graph.facebook.com/v20.0/${audienceId}?access_token=${accessToken}`;
+        const url = `https://graph.facebook.com/v22.0/${audienceId}?access_token=${accessToken}`;
         const { data } = await context.httpRequest.delete(url);
         return context.sendJson({ id: audienceId, ...data }, 'out');
     }

--- a/src/appmixer/facebookbusiness/marketing/DeleteAudience/DeleteAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/DeleteAudience/DeleteAudience.js
@@ -5,7 +5,7 @@ module.exports = {
         const { audienceId } = context.messages.in.content;
         const accessToken = context.auth.accessToken;
 
-        const url = `https://graph.facebook.com/v22.0/${audienceId}?access_token=${accessToken}`;
+        const url = `https://graph.facebook.com/v25.0/${audienceId}?access_token=${accessToken}`;
         const { data } = await context.httpRequest.delete(url);
         return context.sendJson({ id: audienceId, ...data }, 'out');
     }

--- a/src/appmixer/facebookbusiness/marketing/GetAdAccounts/GetAdAccounts.js
+++ b/src/appmixer/facebookbusiness/marketing/GetAdAccounts/GetAdAccounts.js
@@ -9,7 +9,7 @@ module.exports = {
         }
 
         const accessToken = context.auth.accessToken;
-        const url = `https://graph.facebook.com/v22.0/me/adaccounts?access_token=${accessToken}&fields=id,account_id,name,account_status`;
+        const url = `https://graph.facebook.com/v25.0/me/adaccounts?access_token=${accessToken}&fields=id,account_id,name,account_status`;
         const { data } = await context.httpRequest.get(url);
         return context.sendJson({ accounts: data.data }, 'out');
     },

--- a/src/appmixer/facebookbusiness/marketing/GetAdAccounts/GetAdAccounts.js
+++ b/src/appmixer/facebookbusiness/marketing/GetAdAccounts/GetAdAccounts.js
@@ -9,7 +9,7 @@ module.exports = {
         }
 
         const accessToken = context.auth.accessToken;
-        const url = `https://graph.facebook.com/v20.0/me/adaccounts?access_token=${accessToken}&fields=id,account_id,name,account_status`;
+        const url = `https://graph.facebook.com/v22.0/me/adaccounts?access_token=${accessToken}&fields=id,account_id,name,account_status`;
         const { data } = await context.httpRequest.get(url);
         return context.sendJson({ accounts: data.data }, 'out');
     },

--- a/src/appmixer/facebookbusiness/marketing/GetCampaigns/GetCampaigns.js
+++ b/src/appmixer/facebookbusiness/marketing/GetCampaigns/GetCampaigns.js
@@ -13,7 +13,7 @@ module.exports = {
         const fields = Object.keys(this.fields);
         const { data } = await context.httpRequest({
             headers: { 'Content-Type': 'application/json' },
-            url: `https://graph.facebook.com/v20.0/act_${accountId}/campaigns?access_token=${accessToken}&fields=${fields.join(',')}`
+            url: `https://graph.facebook.com/v22.0/act_${accountId}/campaigns?access_token=${accessToken}&fields=${fields.join(',')}`
         });
 
         if (outputType === 'first') {

--- a/src/appmixer/facebookbusiness/marketing/GetCampaigns/GetCampaigns.js
+++ b/src/appmixer/facebookbusiness/marketing/GetCampaigns/GetCampaigns.js
@@ -13,7 +13,7 @@ module.exports = {
         const fields = Object.keys(this.fields);
         const { data } = await context.httpRequest({
             headers: { 'Content-Type': 'application/json' },
-            url: `https://graph.facebook.com/v22.0/act_${accountId}/campaigns?access_token=${accessToken}&fields=${fields.join(',')}`
+            url: `https://graph.facebook.com/v25.0/act_${accountId}/campaigns?access_token=${accessToken}&fields=${fields.join(',')}`
         });
 
         if (outputType === 'first') {

--- a/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/GetCustomAudiences.js
+++ b/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/GetCustomAudiences.js
@@ -9,7 +9,7 @@ module.exports = {
         }
 
         const accessToken = context.auth.accessToken;
-        const url = `https://graph.facebook.com/v22.0/act_${accountId}/customaudiences?access_token=${accessToken}&fields=id,name,description`;
+        const url = `https://graph.facebook.com/v25.0/act_${accountId}/customaudiences?access_token=${accessToken}&fields=id,name,description`;
         const { data } = await context.httpRequest.get(url);
         return context.sendJson({ customAudiences: data.data }, 'out');
     },

--- a/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/GetCustomAudiences.js
+++ b/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/GetCustomAudiences.js
@@ -9,7 +9,7 @@ module.exports = {
         }
 
         const accessToken = context.auth.accessToken;
-        const url = `https://graph.facebook.com/v20.0/act_${accountId}/customaudiences?access_token=${accessToken}&fields=id,name,description`;
+        const url = `https://graph.facebook.com/v22.0/act_${accountId}/customaudiences?access_token=${accessToken}&fields=id,name,description`;
         const { data } = await context.httpRequest.get(url);
         return context.sendJson({ customAudiences: data.data }, 'out');
     },

--- a/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/RemoveMemberFromAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/RemoveMemberFromAudience.js
@@ -44,7 +44,7 @@ module.exports = {
             access_token: accessToken
         };
 
-        const url = `https://graph.facebook.com/v22.0/${audienceId}/users`;
+        const url = `https://graph.facebook.com/v25.0/${audienceId}/users`;
         const response = await context.httpRequest.delete(url, { data: body });
 
         if (!response || !response.data || response.data.num_received !== 1) {

--- a/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/RemoveMemberFromAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/RemoveMemberFromAudience.js
@@ -44,7 +44,7 @@ module.exports = {
             access_token: accessToken
         };
 
-        const url = `https://graph.facebook.com/v20.0/${audienceId}/users`;
+        const url = `https://graph.facebook.com/v22.0/${audienceId}/users`;
         const response = await context.httpRequest.delete(url, { data: body });
 
         if (!response || !response.data || response.data.num_received !== 1) {

--- a/src/appmixer/facebookbusiness/marketing/UpdateAudience/UpdateAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/UpdateAudience/UpdateAudience.js
@@ -19,7 +19,7 @@ module.exports = {
             }
         });
 
-        const url = `https://graph.facebook.com/v22.0/${audienceId}?access_token=${accessToken}`;
+        const url = `https://graph.facebook.com/v25.0/${audienceId}?access_token=${accessToken}`;
 
         const { data } = await context.httpRequest.post(url, formData, {
             headers: { 'Content-Type': 'multipart/form-data' }

--- a/src/appmixer/facebookbusiness/marketing/UpdateAudience/UpdateAudience.js
+++ b/src/appmixer/facebookbusiness/marketing/UpdateAudience/UpdateAudience.js
@@ -19,7 +19,7 @@ module.exports = {
             }
         });
 
-        const url = `https://graph.facebook.com/v20.0/${audienceId}?access_token=${accessToken}`;
+        const url = `https://graph.facebook.com/v22.0/${audienceId}?access_token=${accessToken}`;
 
         const { data } = await context.httpRequest.post(url, formData, {
             headers: { 'Content-Type': 'multipart/form-data' }


### PR DESCRIPTION
- Fix broken validateAccessToken: was calling this.requestProfileInfo() which fails because 'this' in arrow function is outer scope (undefined). Now directly calls Graph API /me endpoint.
- Update all Graph API URLs from v20.0 to v25.0 across all components.