### PR TITLE
Hubspot (patch): Remove debug log from ListPipelineStages

### DIFF
--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -82,7 +82,7 @@
         "4.3.1": [
             "Reduced icon size for better performance."
         ],
-        "4.4.0": [
+        "4.4.1": [
             "Added optional Pipeline and Stage filters to UpdatedDeal trigger.",
             "Added optional Pipeline filter to NewDeal trigger.",
             "Added Pipeline and Stage filter inputs to ListDeals action using CRM Search API filterGroups.",

--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [

--- a/src/appmixer/hubspot/crm/ListPipelineStages/ListPipelineStages.js
+++ b/src/appmixer/hubspot/crm/ListPipelineStages/ListPipelineStages.js
@@ -19,12 +19,6 @@ module.exports = {
 
         const objectType = 'deals';
 
-        await context.log({
-            step: 'request',
-            accessToken: auth.accessToken,
-            url: `crm/v3/pipelines/${objectType}/${pipelineId}/stages`
-        });
-
         try {
             const { data } = await hs.call('get', `crm/v3/pipelines/${objectType}/${pipelineId}/stages`);
 


### PR DESCRIPTION
## Problem

`ListPipelineStages` contained a leftover `context.log()` call that logged the `accessToken` to component logs — a security concern.

## Changes

- Removed the debug `context.log()` call from `ListPipelineStages.js`
- Bumped version to 4.4.1
- Added changelog entry

## Files changed
- `src/appmixer/hubspot/crm/ListPipelineStages/ListPipelineStages.js`
- `src/appmixer/hubspot/bundle.json`