### PR TITLE
googleAds (minor): Add CSV mapping

### DIFF
--- a/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
@@ -29,6 +29,74 @@ function emailCsv(rows) {
     return [header, ...lines].join('\n');
 }
 
+const SHARED_CSV_HEADER = 'first_name,last_name,personal_emails,personal_phone,mobile_phone,additional_personal_emails,personal_emails_validation_status,personal_emails_last_seen,linkedin_url,personal_address,personal_address_2,personal_city,personal_state,personal_zip,personal_zip4,contact_country,gender,age_range,married,children,income_range,net_worth,homeowner,job_title,job_title_normalized,job_title_last_updated,seniority_level,seniority_level_2,department,department_2,business_email,programmatic_business_emails,business_email_validation_status,business_email_last_seen,direct_number,professional_address,professional_address_2,professional_city,professional_state,professional_zip,professional_zip4,company_name,company_domain,company_phone,company_sic,company_naics,company_address,company_city,company_state,company_zip,company_country,company_revenue,company_employee_count,primary_industry,company_last_updated,last_updated';
+
+function sharedAudienceCsv(overrides = {}) {
+    const columns = SHARED_CSV_HEADER.split(',');
+    const defaults = {
+        first_name: 'Avery',
+        last_name: 'Stone',
+        personal_emails: 'avery.stone@example.test',
+        personal_phone: '+12025550101',
+        mobile_phone: '+12025550102',
+        additional_personal_emails: 'avery.alt@example.test',
+        personal_emails_validation_status: 'Valid',
+        personal_emails_last_seen: '2026-01-15 19:00:00',
+        linkedin_url: 'https://linkedin.example.test/in/avery-stone',
+        personal_address: '101 Cedar Ave',
+        personal_city: 'Springfield',
+        personal_state: 'IL',
+        personal_zip: '62704',
+        contact_country: 'US',
+        gender: 'X',
+        age_range: '35-44',
+        married: 'N',
+        homeowner: 'Y',
+        job_title: 'Founder',
+        job_title_normalized: 'founder',
+        job_title_last_updated: '2026-01-10 08:00:00',
+        seniority_level: 'Cxo',
+        seniority_level_2: 'owner',
+        department: 'Operations',
+        department_2: 'Leadership',
+        business_email: 'avery@work.example.test',
+        programmatic_business_emails: '\\N',
+        business_email_validation_status: 'Valid',
+        business_email_last_seen: '2026-01-15 19:00:00',
+        direct_number: '+12025550103',
+        professional_address: '200 Market St',
+        professional_city: 'Chicago',
+        professional_state: 'IL',
+        professional_zip: '60601',
+        company_name: 'Example Company',
+        company_domain: 'example.test',
+        company_phone: '+12025550999',
+        company_sic: '7372',
+        company_naics: '541511',
+        company_address: '200 Market St',
+        company_city: 'Chicago',
+        company_state: 'IL',
+        company_zip: '60601',
+        company_country: 'US',
+        company_revenue: '5000000',
+        company_employee_count: '25',
+        primary_industry: 'Software',
+        company_last_updated: '2026-01-12 10:00:00',
+        last_updated: '2026-01-15 19:00:00'
+    };
+
+    const row = columns.map(column => overrides[column] ?? defaults[column] ?? '');
+    return [SHARED_CSV_HEADER, row.join(',')].join('\n');
+}
+
+function googleAdsSchema(mappings) {
+    return { ADD: mappings };
+}
+
+const BASIC_EMAIL_SCHEMA = googleAdsSchema([
+    { csvHeader: 'email', googleAdsType: 'email' }
+]);
+
 // ---------------------------------------------------------------------------
 // Shared API response stubs
 // ---------------------------------------------------------------------------
@@ -126,6 +194,19 @@ describe('AddUsersFromCSVToUserList', () => {
                 message: 'User List ID is required!'
             });
         });
+
+        it('throws when schema is missing', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810'
+            };
+
+            await assert.rejects(() => AddUsersFromCSVToUserList.receive(context), {
+                message: 'Schema is required!'
+            });
+        });
     });
 
     // -----------------------------------------------------------------------
@@ -145,7 +226,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             // Return the same CSV stream on every getFileReadStream call
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(CSV)));
@@ -232,7 +314,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -260,7 +343,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context, { partialFailureError: { code: 3, message: 'Invalid email' } });
@@ -276,54 +360,183 @@ describe('AddUsersFromCSVToUserList', () => {
     });
 
     // -----------------------------------------------------------------------
-    // Column-name flexibility
+    // Explicit schema mapping
     // -----------------------------------------------------------------------
 
-    describe('Column-name flexibility', () => {
+    describe('Explicit schema mapping', () => {
 
-        async function uploadCsv(csvContent) {
+        it('uses the mapped email column', async () => {
             context.messages.in.content = {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'email_address', googleAdsType: 'email' }])
             };
-            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csvContent)));
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('email_address\nalice@example.com\n')));
             stubApiResponses(context);
+
             await AddUsersFromCSVToUserList.receive(context);
+
             const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
-            return outCalls[0].args[0];
-        }
-
-        it('handles "email_address" column alias', async () => {
-            const result = await uploadCsv('email_address\nalice@example.com\n');
-            assert.strictEqual(result.totalUsers, 1);
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles "phone_number" column alias', async () => {
-            const result = await uploadCsv('phone_number\n+14155552671\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses the mapped phone column', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'phone_number', googleAdsType: 'phoneNumber' }])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('phone_number\n+14155552671\n')));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles case-insensitive column names (EMAIL, Phone)', async () => {
-            const result = await uploadCsv('EMAIL,Phone\nalice@example.com,+14155552671\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('matches mapped headers case-insensitively', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'email', googleAdsType: 'email' },
+                    { csvHeader: 'phone', googleAdsType: 'phoneNumber' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('EMAIL,Phone\nalice@example.com,+14155552671\n')));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles address-based matching (first_name + last_name + country_code)', async () => {
-            const csv = 'first_name,last_name,country_code\nJohn,Doe,US\n';
-            const result = await uploadCsv(csv);
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses mapped address fields', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'first_name', googleAdsType: 'firstName' },
+                    { csvHeader: 'last_name', googleAdsType: 'lastName' },
+                    { csvHeader: 'country_code', googleAdsType: 'countryCode' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('first_name,last_name,country_code\nJohn,Doe,US\n')));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles "mobile_id" column', async () => {
-            const result = await uploadCsv('mobile_id\nAEBE52E7-03EE-455A-B3C4-E57283966239\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses the mapped mobile ID column', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'mobile_id', googleAdsType: 'mobileId' }])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('mobile_id\nAEBE52E7-03EE-455A-B3C4-E57283966239\n')));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles "third_party_user_id" column', async () => {
-            const result = await uploadCsv('third_party_user_id\nuser_42\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses the mapped third-party user ID column', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'third_party_user_id', googleAdsType: 'thirdPartyUserId' }])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('third_party_user_id\nuser_42\n')));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
+        });
+
+        it('accepts the anonymized shared Facebook-style CSV format', async () => {
+            const csv = sharedAudienceCsv();
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'personal_emails', googleAdsType: 'email' },
+                    { csvHeader: 'additional_personal_emails', googleAdsType: 'email' },
+                    { csvHeader: 'business_email', googleAdsType: 'email' },
+                    { csvHeader: 'personal_phone', googleAdsType: 'phoneNumber' },
+                    { csvHeader: 'mobile_phone', googleAdsType: 'phoneNumber' },
+                    { csvHeader: 'direct_number', googleAdsType: 'phoneNumber' },
+                    { csvHeader: 'first_name', googleAdsType: 'firstName' },
+                    { csvHeader: 'last_name', googleAdsType: 'lastName' },
+                    { csvHeader: 'contact_country', googleAdsType: 'countryCode' },
+                    { csvHeader: 'personal_zip', googleAdsType: 'postalCode' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const addOpsCall = context.httpRequest.getCalls()
+                .find(c => c.args[0].url.includes(':addOperations'));
+            const userIdentifiers = addOpsCall.args[0].data.operations[0].create.userIdentifiers;
+
+            assert.strictEqual(userIdentifiers.filter(identifier => identifier.hashedEmail).length, 3);
+            assert.strictEqual(userIdentifiers.filter(identifier => identifier.hashedPhoneNumber).length, 3);
+            assert.ok(
+                userIdentifiers.some(identifier => identifier.addressInfo
+                    && identifier.addressInfo.countryCode === 'US'
+                    && identifier.addressInfo.postalCode === '62704')
+            );
+        });
+
+        it('uses explicit schema mapping for arbitrary CSV headers', async () => {
+            const csv = 'alpha,beta,gamma,delta\ncasey@example.test,Casey,Rivera,US\n';
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'alpha', googleAdsType: 'email' },
+                    { csvHeader: 'beta', googleAdsType: 'firstName' },
+                    { csvHeader: 'gamma', googleAdsType: 'lastName' },
+                    { csvHeader: 'delta', googleAdsType: 'countryCode' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
+            stubApiResponses(context);
+
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const addOpsCall = context.httpRequest.getCalls()
+                .find(c => c.args[0].url.includes(':addOperations'));
+            const userIdentifiers = addOpsCall.args[0].data.operations[0].create.userIdentifiers;
+
+            assert.strictEqual(userIdentifiers.filter(identifier => identifier.hashedEmail).length, 1);
+            assert.ok(userIdentifiers.some(identifier => identifier.addressInfo));
         });
     });
 
@@ -360,7 +573,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -391,6 +605,7 @@ describe('AddUsersFromCSVToUserList', () => {
                 loginCustomerId: null,
                 userListResourceName: USER_LIST_RESOURCE,
                 uploadMode: 'ADD',
+                schema: BASIC_EMAIL_SCHEMA,
                 batchSize: 10000,
                 columnSeparator: ',',
                 adPersonalization: null,
@@ -480,7 +695,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -501,6 +717,7 @@ describe('AddUsersFromCSVToUserList', () => {
                 customerId: '7123133715',
                 developerToken: 'dev-token',
                 userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA,
                 uploadMode: 'REPLACE'
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
@@ -528,6 +745,7 @@ describe('AddUsersFromCSVToUserList', () => {
                 customerId: '7123133715',
                 developerToken: 'dev-token',
                 userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA,
                 adPersonalization: 'GRANTED',
                 adUserData: 'GRANTED'
             };
@@ -550,7 +768,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -576,7 +795,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '712-313-3715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -601,7 +821,8 @@ describe('AddUsersFromCSVToUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             // create-job still gets called; run does not because nothing was added

--- a/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
@@ -1,101 +1,20 @@
 'use strict';
 
 const assert = require('assert');
-const { Readable } = require('stream');
 const sinon = require('sinon');
 const testUtils = require('../../../../../test/utils');
 const AddUsersFromCSVToUserList = require('../../core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList');
+const {
+    BASIC_EMAIL_SCHEMA,
+    csvStream,
+    emailCsv,
+    googleAdsSchema,
+    sharedAudienceCsv
+} = require('./helpers');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Create a Readable stream from a string (simulates getFileReadStream output).
- */
-function csvStream(content) {
-    const r = new Readable();
-    r.push(content);
-    r.push(null);
-    return r;
-}
-
-/**
- * Build a minimal valid CSV with an email column.
- */
-function emailCsv(rows) {
-    const header = 'email';
-    const lines = rows.map(r => r.email);
-    return [header, ...lines].join('\n');
-}
-
-const SHARED_CSV_HEADER = 'first_name,last_name,personal_emails,personal_phone,mobile_phone,additional_personal_emails,personal_emails_validation_status,personal_emails_last_seen,linkedin_url,personal_address,personal_address_2,personal_city,personal_state,personal_zip,personal_zip4,contact_country,gender,age_range,married,children,income_range,net_worth,homeowner,job_title,job_title_normalized,job_title_last_updated,seniority_level,seniority_level_2,department,department_2,business_email,programmatic_business_emails,business_email_validation_status,business_email_last_seen,direct_number,professional_address,professional_address_2,professional_city,professional_state,professional_zip,professional_zip4,company_name,company_domain,company_phone,company_sic,company_naics,company_address,company_city,company_state,company_zip,company_country,company_revenue,company_employee_count,primary_industry,company_last_updated,last_updated';
-
-function sharedAudienceCsv(overrides = {}) {
-    const columns = SHARED_CSV_HEADER.split(',');
-    const defaults = {
-        first_name: 'Avery',
-        last_name: 'Stone',
-        personal_emails: 'avery.stone@example.test',
-        personal_phone: '+12025550101',
-        mobile_phone: '+12025550102',
-        additional_personal_emails: 'avery.alt@example.test',
-        personal_emails_validation_status: 'Valid',
-        personal_emails_last_seen: '2026-01-15 19:00:00',
-        linkedin_url: 'https://linkedin.example.test/in/avery-stone',
-        personal_address: '101 Cedar Ave',
-        personal_city: 'Springfield',
-        personal_state: 'IL',
-        personal_zip: '62704',
-        contact_country: 'US',
-        gender: 'X',
-        age_range: '35-44',
-        married: 'N',
-        homeowner: 'Y',
-        job_title: 'Founder',
-        job_title_normalized: 'founder',
-        job_title_last_updated: '2026-01-10 08:00:00',
-        seniority_level: 'Cxo',
-        seniority_level_2: 'owner',
-        department: 'Operations',
-        department_2: 'Leadership',
-        business_email: 'avery@work.example.test',
-        programmatic_business_emails: '\\N',
-        business_email_validation_status: 'Valid',
-        business_email_last_seen: '2026-01-15 19:00:00',
-        direct_number: '+12025550103',
-        professional_address: '200 Market St',
-        professional_city: 'Chicago',
-        professional_state: 'IL',
-        professional_zip: '60601',
-        company_name: 'Example Company',
-        company_domain: 'example.test',
-        company_phone: '+12025550999',
-        company_sic: '7372',
-        company_naics: '541511',
-        company_address: '200 Market St',
-        company_city: 'Chicago',
-        company_state: 'IL',
-        company_zip: '60601',
-        company_country: 'US',
-        company_revenue: '5000000',
-        company_employee_count: '25',
-        primary_industry: 'Software',
-        company_last_updated: '2026-01-12 10:00:00',
-        last_updated: '2026-01-15 19:00:00'
-    };
-
-    const row = columns.map(column => overrides[column] ?? defaults[column] ?? '');
-    return [SHARED_CSV_HEADER, row.join(',')].join('\n');
-}
-
-function googleAdsSchema(mappings) {
-    return { ADD: mappings };
-}
-
-const BASIC_EMAIL_SCHEMA = googleAdsSchema([
-    { csvHeader: 'email', googleAdsType: 'email' }
-]);
 
 // ---------------------------------------------------------------------------
 // Shared API response stubs

--- a/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
@@ -126,6 +126,20 @@ describe('AddUsersFromCSVToUserList', () => {
                 message: 'Schema is required!'
             });
         });
+
+        it('throws when schema contains an unsupported googleAdsType', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'email', googleAdsType: 'emal' }])
+            };
+
+            await assert.rejects(() => AddUsersFromCSVToUserList.receive(context), {
+                message: 'Unsupported Google Ads Type: emal'
+            });
+        });
     });
 
     // -----------------------------------------------------------------------

--- a/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
@@ -29,6 +29,74 @@ function emailCsv(rows) {
     return [header, ...lines].join('\n');
 }
 
+const SHARED_CSV_HEADER = 'first_name,last_name,personal_emails,personal_phone,mobile_phone,additional_personal_emails,personal_emails_validation_status,personal_emails_last_seen,linkedin_url,personal_address,personal_address_2,personal_city,personal_state,personal_zip,personal_zip4,contact_country,gender,age_range,married,children,income_range,net_worth,homeowner,job_title,job_title_normalized,job_title_last_updated,seniority_level,seniority_level_2,department,department_2,business_email,programmatic_business_emails,business_email_validation_status,business_email_last_seen,direct_number,professional_address,professional_address_2,professional_city,professional_state,professional_zip,professional_zip4,company_name,company_domain,company_phone,company_sic,company_naics,company_address,company_city,company_state,company_zip,company_country,company_revenue,company_employee_count,primary_industry,company_last_updated,last_updated';
+
+function sharedAudienceCsv(overrides = {}) {
+    const columns = SHARED_CSV_HEADER.split(',');
+    const defaults = {
+        first_name: 'Avery',
+        last_name: 'Stone',
+        personal_emails: 'avery.stone@example.test',
+        personal_phone: '+12025550101',
+        mobile_phone: '+12025550102',
+        additional_personal_emails: 'avery.alt@example.test',
+        personal_emails_validation_status: 'Valid',
+        personal_emails_last_seen: '2026-01-15 19:00:00',
+        linkedin_url: 'https://linkedin.example.test/in/avery-stone',
+        personal_address: '101 Cedar Ave',
+        personal_city: 'Springfield',
+        personal_state: 'IL',
+        personal_zip: '62704',
+        contact_country: 'US',
+        gender: 'X',
+        age_range: '35-44',
+        married: 'N',
+        homeowner: 'Y',
+        job_title: 'Founder',
+        job_title_normalized: 'founder',
+        job_title_last_updated: '2026-01-10 08:00:00',
+        seniority_level: 'Cxo',
+        seniority_level_2: 'owner',
+        department: 'Operations',
+        department_2: 'Leadership',
+        business_email: 'avery@work.example.test',
+        programmatic_business_emails: '\\N',
+        business_email_validation_status: 'Valid',
+        business_email_last_seen: '2026-01-15 19:00:00',
+        direct_number: '+12025550103',
+        professional_address: '200 Market St',
+        professional_city: 'Chicago',
+        professional_state: 'IL',
+        professional_zip: '60601',
+        company_name: 'Example Company',
+        company_domain: 'example.test',
+        company_phone: '+12025550999',
+        company_sic: '7372',
+        company_naics: '541511',
+        company_address: '200 Market St',
+        company_city: 'Chicago',
+        company_state: 'IL',
+        company_zip: '60601',
+        company_country: 'US',
+        company_revenue: '5000000',
+        company_employee_count: '25',
+        primary_industry: 'Software',
+        company_last_updated: '2026-01-12 10:00:00',
+        last_updated: '2026-01-15 19:00:00'
+    };
+
+    const row = columns.map(column => overrides[column] ?? defaults[column] ?? '');
+    return [SHARED_CSV_HEADER, row.join(',')].join('\n');
+}
+
+function googleAdsSchema(mappings) {
+    return { ADD: mappings };
+}
+
+const BASIC_EMAIL_SCHEMA = googleAdsSchema([
+    { csvHeader: 'email', googleAdsType: 'email' }
+]);
+
 // ---------------------------------------------------------------------------
 // Shared API response stubs
 // ---------------------------------------------------------------------------
@@ -123,6 +191,19 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 message: 'User List ID is required!'
             });
         });
+
+        it('throws when schema is missing', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810'
+            };
+
+            await assert.rejects(() => RemoveUsersInCSVFromUserList.receive(context), {
+                message: 'Schema is required!'
+            });
+        });
     });
 
     // -----------------------------------------------------------------------
@@ -142,7 +223,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(CSV)));
             stubApiResponses(context);
@@ -226,7 +308,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -247,7 +330,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -273,7 +357,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -300,7 +385,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context, { partialFailureError: { code: 3, message: 'User not found' } });
@@ -315,54 +401,183 @@ describe('RemoveUsersInCSVFromUserList', () => {
     });
 
     // -----------------------------------------------------------------------
-    // Column-name flexibility
+    // Explicit schema mapping
     // -----------------------------------------------------------------------
 
-    describe('Column-name flexibility', () => {
+    describe('Explicit schema mapping', () => {
 
-        async function removeCsv(csvContent) {
+        it('uses the mapped email column', async () => {
             context.messages.in.content = {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'email_address', googleAdsType: 'email' }])
             };
-            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csvContent)));
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('email_address\nalice@example.com\n')));
             stubApiResponses(context);
+
             await RemoveUsersInCSVFromUserList.receive(context);
+
             const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
-            return outCalls[0].args[0];
-        }
-
-        it('handles "email_address" column alias', async () => {
-            const result = await removeCsv('email_address\nalice@example.com\n');
-            assert.strictEqual(result.totalUsers, 1);
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles "phone_number" column alias', async () => {
-            const result = await removeCsv('phone_number\n+14155552671\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses the mapped phone column', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'phone_number', googleAdsType: 'phoneNumber' }])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('phone_number\n+14155552671\n')));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles case-insensitive column names (EMAIL, Phone)', async () => {
-            const result = await removeCsv('EMAIL,Phone\nalice@example.com,+14155552671\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('matches mapped headers case-insensitively', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'email', googleAdsType: 'email' },
+                    { csvHeader: 'phone', googleAdsType: 'phoneNumber' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('EMAIL,Phone\nalice@example.com,+14155552671\n')));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles address-based matching (first_name + last_name + country_code)', async () => {
-            const csv = 'first_name,last_name,country_code\nJohn,Doe,US\n';
-            const result = await removeCsv(csv);
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses mapped address fields', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'first_name', googleAdsType: 'firstName' },
+                    { csvHeader: 'last_name', googleAdsType: 'lastName' },
+                    { csvHeader: 'country_code', googleAdsType: 'countryCode' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('first_name,last_name,country_code\nJohn,Doe,US\n')));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles "mobile_id" column', async () => {
-            const result = await removeCsv('mobile_id\nAEBE52E7-03EE-455A-B3C4-E57283966239\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses the mapped mobile ID column', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'mobile_id', googleAdsType: 'mobileId' }])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('mobile_id\nAEBE52E7-03EE-455A-B3C4-E57283966239\n')));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
         });
 
-        it('handles "third_party_user_id" column', async () => {
-            const result = await removeCsv('third_party_user_id\nuser_42\n');
-            assert.strictEqual(result.totalUsers, 1);
+        it('uses the mapped third-party user ID column', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'third_party_user_id', googleAdsType: 'thirdPartyUserId' }])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream('third_party_user_id\nuser_42\n')));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const outCalls = context.sendJson.getCalls().filter(c => c.args[1] === 'out');
+            assert.strictEqual(outCalls[0].args[0].totalUsers, 1);
+        });
+
+        it('accepts the anonymized shared Facebook-style CSV format', async () => {
+            const csv = sharedAudienceCsv();
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'personal_emails', googleAdsType: 'email' },
+                    { csvHeader: 'additional_personal_emails', googleAdsType: 'email' },
+                    { csvHeader: 'business_email', googleAdsType: 'email' },
+                    { csvHeader: 'personal_phone', googleAdsType: 'phoneNumber' },
+                    { csvHeader: 'mobile_phone', googleAdsType: 'phoneNumber' },
+                    { csvHeader: 'direct_number', googleAdsType: 'phoneNumber' },
+                    { csvHeader: 'first_name', googleAdsType: 'firstName' },
+                    { csvHeader: 'last_name', googleAdsType: 'lastName' },
+                    { csvHeader: 'contact_country', googleAdsType: 'countryCode' },
+                    { csvHeader: 'personal_zip', googleAdsType: 'postalCode' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const addOpsCall = context.httpRequest.getCalls()
+                .find(c => c.args[0].url.includes(':addOperations'));
+            const userIdentifiers = addOpsCall.args[0].data.operations[0].remove.userIdentifiers;
+
+            assert.strictEqual(userIdentifiers.filter(identifier => identifier.hashedEmail).length, 3);
+            assert.strictEqual(userIdentifiers.filter(identifier => identifier.hashedPhoneNumber).length, 3);
+            assert.ok(
+                userIdentifiers.some(identifier => identifier.addressInfo
+                    && identifier.addressInfo.countryCode === 'US'
+                    && identifier.addressInfo.postalCode === '62704')
+            );
+        });
+
+        it('uses explicit schema mapping for arbitrary CSV headers', async () => {
+            const csv = 'alpha,beta,gamma,delta\ncasey@example.test,Casey,Rivera,US\n';
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7122133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([
+                    { csvHeader: 'alpha', googleAdsType: 'email' },
+                    { csvHeader: 'beta', googleAdsType: 'firstName' },
+                    { csvHeader: 'gamma', googleAdsType: 'lastName' },
+                    { csvHeader: 'delta', googleAdsType: 'countryCode' }
+                ])
+            };
+            context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
+            stubApiResponses(context);
+
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const addOpsCall = context.httpRequest.getCalls()
+                .find(c => c.args[0].url.includes(':addOperations'));
+            const userIdentifiers = addOpsCall.args[0].data.operations[0].remove.userIdentifiers;
+
+            assert.strictEqual(userIdentifiers.filter(identifier => identifier.hashedEmail).length, 1);
+            assert.ok(userIdentifiers.some(identifier => identifier.addressInfo));
         });
     });
 
@@ -389,7 +604,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -416,6 +632,7 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 developerToken: 'dev-token',
                 loginCustomerId: null,
                 userListResourceName: USER_LIST_RESOURCE,
+                schema: BASIC_EMAIL_SCHEMA,
                 batchSize: 10000,
                 columnSeparator: ',',
                 adPersonalization: null,
@@ -503,6 +720,7 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 customerId: '7122133715',
                 developerToken: 'dev-token',
                 userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA,
                 adPersonalization: 'GRANTED',
                 adUserData: 'GRANTED'
             };
@@ -525,7 +743,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -551,7 +770,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '712-213-3715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             stubApiResponses(context);
@@ -576,7 +796,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 developerToken: 'dev-token',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.getFileReadStream = sinon.stub().callsFake(() => Promise.resolve(csvStream(csv)));
             context.httpRequest.callsFake(({ url }) => {

--- a/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
@@ -123,6 +123,20 @@ describe('RemoveUsersInCSVFromUserList', () => {
                 message: 'Schema is required!'
             });
         });
+
+        it('throws when schema contains an unsupported googleAdsType', async () => {
+            context.messages.in.content = {
+                fileId: 'file-abc',
+                customerId: '7123133715',
+                developerToken: 'dev-token',
+                userListId: '9329730810',
+                schema: googleAdsSchema([{ csvHeader: 'email', googleAdsType: 'emal' }])
+            };
+
+            await assert.rejects(() => RemoveUsersInCSVFromUserList.receive(context), {
+                message: 'Unsupported Google Ads Type: emal'
+            });
+        });
     });
 
     // -----------------------------------------------------------------------

--- a/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
@@ -1,101 +1,20 @@
 'use strict';
 
 const assert = require('assert');
-const { Readable } = require('stream');
 const sinon = require('sinon');
 const testUtils = require('../../../../../test/utils');
 const RemoveUsersInCSVFromUserList = require('../../core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList');
+const {
+    BASIC_EMAIL_SCHEMA,
+    csvStream,
+    emailCsv,
+    googleAdsSchema,
+    sharedAudienceCsv
+} = require('./helpers');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Create a Readable stream from a string (simulates getFileReadStream output).
- */
-function csvStream(content) {
-    const r = new Readable();
-    r.push(content);
-    r.push(null);
-    return r;
-}
-
-/**
- * Build a minimal valid CSV with an email column.
- */
-function emailCsv(rows) {
-    const header = 'email';
-    const lines = rows.map(r => r.email);
-    return [header, ...lines].join('\n');
-}
-
-const SHARED_CSV_HEADER = 'first_name,last_name,personal_emails,personal_phone,mobile_phone,additional_personal_emails,personal_emails_validation_status,personal_emails_last_seen,linkedin_url,personal_address,personal_address_2,personal_city,personal_state,personal_zip,personal_zip4,contact_country,gender,age_range,married,children,income_range,net_worth,homeowner,job_title,job_title_normalized,job_title_last_updated,seniority_level,seniority_level_2,department,department_2,business_email,programmatic_business_emails,business_email_validation_status,business_email_last_seen,direct_number,professional_address,professional_address_2,professional_city,professional_state,professional_zip,professional_zip4,company_name,company_domain,company_phone,company_sic,company_naics,company_address,company_city,company_state,company_zip,company_country,company_revenue,company_employee_count,primary_industry,company_last_updated,last_updated';
-
-function sharedAudienceCsv(overrides = {}) {
-    const columns = SHARED_CSV_HEADER.split(',');
-    const defaults = {
-        first_name: 'Avery',
-        last_name: 'Stone',
-        personal_emails: 'avery.stone@example.test',
-        personal_phone: '+12025550101',
-        mobile_phone: '+12025550102',
-        additional_personal_emails: 'avery.alt@example.test',
-        personal_emails_validation_status: 'Valid',
-        personal_emails_last_seen: '2026-01-15 19:00:00',
-        linkedin_url: 'https://linkedin.example.test/in/avery-stone',
-        personal_address: '101 Cedar Ave',
-        personal_city: 'Springfield',
-        personal_state: 'IL',
-        personal_zip: '62704',
-        contact_country: 'US',
-        gender: 'X',
-        age_range: '35-44',
-        married: 'N',
-        homeowner: 'Y',
-        job_title: 'Founder',
-        job_title_normalized: 'founder',
-        job_title_last_updated: '2026-01-10 08:00:00',
-        seniority_level: 'Cxo',
-        seniority_level_2: 'owner',
-        department: 'Operations',
-        department_2: 'Leadership',
-        business_email: 'avery@work.example.test',
-        programmatic_business_emails: '\\N',
-        business_email_validation_status: 'Valid',
-        business_email_last_seen: '2026-01-15 19:00:00',
-        direct_number: '+12025550103',
-        professional_address: '200 Market St',
-        professional_city: 'Chicago',
-        professional_state: 'IL',
-        professional_zip: '60601',
-        company_name: 'Example Company',
-        company_domain: 'example.test',
-        company_phone: '+12025550999',
-        company_sic: '7372',
-        company_naics: '541511',
-        company_address: '200 Market St',
-        company_city: 'Chicago',
-        company_state: 'IL',
-        company_zip: '60601',
-        company_country: 'US',
-        company_revenue: '5000000',
-        company_employee_count: '25',
-        primary_industry: 'Software',
-        company_last_updated: '2026-01-12 10:00:00',
-        last_updated: '2026-01-15 19:00:00'
-    };
-
-    const row = columns.map(column => overrides[column] ?? defaults[column] ?? '');
-    return [SHARED_CSV_HEADER, row.join(',')].join('\n');
-}
-
-function googleAdsSchema(mappings) {
-    return { ADD: mappings };
-}
-
-const BASIC_EMAIL_SCHEMA = googleAdsSchema([
-    { csvHeader: 'email', googleAdsType: 'email' }
-]);
 
 // ---------------------------------------------------------------------------
 // Shared API response stubs

--- a/src/appmixer/googleAds/artifacts/test/helpers.js
+++ b/src/appmixer/googleAds/artifacts/test/helpers.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { Readable } = require('stream');
+
+function csvStream(content) {
+    const readable = new Readable();
+    readable.push(content);
+    readable.push(null);
+    return readable;
+}
+
+function emailCsv(rows) {
+    const header = 'email';
+    const lines = rows.map(row => row.email);
+    return [header, ...lines].join('\n');
+}
+
+const SHARED_CSV_HEADER = 'first_name,last_name,personal_emails,personal_phone,mobile_phone,additional_personal_emails,personal_emails_validation_status,personal_emails_last_seen,linkedin_url,personal_address,personal_address_2,personal_city,personal_state,personal_zip,personal_zip4,contact_country,gender,age_range,married,children,income_range,net_worth,homeowner,job_title,job_title_normalized,job_title_last_updated,seniority_level,seniority_level_2,department,department_2,business_email,programmatic_business_emails,business_email_validation_status,business_email_last_seen,direct_number,professional_address,professional_address_2,professional_city,professional_state,professional_zip,professional_zip4,company_name,company_domain,company_phone,company_sic,company_naics,company_address,company_city,company_state,company_zip,company_country,company_revenue,company_employee_count,primary_industry,company_last_updated,last_updated';
+
+function sharedAudienceCsv(overrides = {}) {
+    const columns = SHARED_CSV_HEADER.split(',');
+    const defaults = {
+        first_name: 'Avery',
+        last_name: 'Stone',
+        personal_emails: 'avery.stone@example.test',
+        personal_phone: '+12025550101',
+        mobile_phone: '+12025550102',
+        additional_personal_emails: 'avery.alt@example.test',
+        personal_emails_validation_status: 'Valid',
+        personal_emails_last_seen: '2026-01-15 19:00:00',
+        linkedin_url: 'https://linkedin.example.test/in/avery-stone',
+        personal_address: '101 Cedar Ave',
+        personal_city: 'Springfield',
+        personal_state: 'IL',
+        personal_zip: '62704',
+        contact_country: 'US',
+        gender: 'X',
+        age_range: '35-44',
+        married: 'N',
+        homeowner: 'Y',
+        job_title: 'Founder',
+        job_title_normalized: 'founder',
+        job_title_last_updated: '2026-01-10 08:00:00',
+        seniority_level: 'Cxo',
+        seniority_level_2: 'owner',
+        department: 'Operations',
+        department_2: 'Leadership',
+        business_email: 'avery@work.example.test',
+        programmatic_business_emails: '\\N',
+        business_email_validation_status: 'Valid',
+        business_email_last_seen: '2026-01-15 19:00:00',
+        direct_number: '+12025550103',
+        professional_address: '200 Market St',
+        professional_city: 'Chicago',
+        professional_state: 'IL',
+        professional_zip: '60601',
+        company_name: 'Example Company',
+        company_domain: 'example.test',
+        company_phone: '+12025550999',
+        company_sic: '7372',
+        company_naics: '541511',
+        company_address: '200 Market St',
+        company_city: 'Chicago',
+        company_state: 'IL',
+        company_zip: '60601',
+        company_country: 'US',
+        company_revenue: '5000000',
+        company_employee_count: '25',
+        primary_industry: 'Software',
+        company_last_updated: '2026-01-12 10:00:00',
+        last_updated: '2026-01-15 19:00:00'
+    };
+
+    const row = columns.map(column => overrides[column] ?? defaults[column] ?? '');
+    return [SHARED_CSV_HEADER, row.join(',')].join('\n');
+}
+
+function googleAdsSchema(mappings) {
+    return { ADD: mappings };
+}
+
+const BASIC_EMAIL_SCHEMA = googleAdsSchema([
+    { csvHeader: 'email', googleAdsType: 'email' }
+]);
+
+module.exports = {
+    BASIC_EMAIL_SCHEMA,
+    SHARED_CSV_HEADER,
+    csvStream,
+    emailCsv,
+    googleAdsSchema,
+    sharedAudienceCsv
+};

--- a/src/appmixer/googleAds/bundle.json
+++ b/src/appmixer/googleAds/bundle.json
@@ -1,12 +1,12 @@
 {
     "name": "appmixer.googleAds",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial Google Ads release with user list and Customer Match workflow components."
         ],
-        "1.1.0": [
-            "Added support for uploading and removing users to Google Ads user lists from CSV files via two new components."
+        "1.2.0": [
+            "Added support for uploading and removing users to Google Ads user lists from CSV files via two new components using explicit schema mapping."
         ]
     }
 }

--- a/src/appmixer/googleAds/bundle.json
+++ b/src/appmixer/googleAds/bundle.json
@@ -5,8 +5,11 @@
         "1.0.0": [
             "Initial Google Ads release with user list and Customer Match workflow components."
         ],
+        "1.1.0": [
+            "Added support for uploading and removing users to Google Ads user lists from CSV files via two new components."
+        ],
         "1.2.0": [
-            "Added support for uploading and removing users to Google Ads user lists from CSV files via two new components using explicit schema mapping."
+            "Added explicit schema mapping for CSV uploads."
         ]
     }
 }

--- a/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList.js
+++ b/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList.js
@@ -39,85 +39,13 @@ const PROGRESS_INTERVAL_MS = 5000;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Hash a string with SHA-256 (lower-cased, trimmed).
- * Re-uses the helper already present in lib.js.
- */
-const sha256 = lib.hashSha256;
-
-/**
- * Normalise a customer ID to digits only.
- */
 const normId = lib.normalizeCustomerId;
-
-/**
- * Build a UserIdentifier object for the Google Ads API from a CSV row.
- * The row is expected to contain at least one of:
- *   email, phone, (first_name + last_name + country_code), mobile_id, third_party_user_id
- *
- * Column-name matching is case-insensitive and allows common aliases.
- */
-function buildUserIdentifiers(row) {
-    const get = (...keys) => {
-        for (const k of keys) {
-            const found = Object.keys(row).find(
-                rk => rk.toLowerCase() === k.toLowerCase()
-            );
-            if (found !== undefined && row[found] !== '') {
-                return row[found];
-            }
-        }
-        return null;
-    };
-
-    const identifiers = [];
-
-    const email = get('email', 'email_address', 'emailaddress');
-    if (email) {
-        identifiers.push({ hashedEmail: sha256(email.trim().toLowerCase()) });
-    }
-
-    const phone = get('phone', 'phone_number', 'phonenumber');
-    if (phone) {
-        const normalised = phone.replace(/[^0-9+]/g, '').toLowerCase();
-        identifiers.push({ hashedPhoneNumber: sha256(normalised) });
-    }
-
-    const firstName = get('first_name', 'firstname', 'given_name');
-    const lastName = get('last_name', 'lastname', 'family_name', 'surname');
-    const countryCode = get('country_code', 'countrycode', 'country');
-
-    if (firstName && lastName && countryCode) {
-        const addressInfo = {
-            hashedFirstName: sha256(firstName.trim().toLowerCase()),
-            hashedLastName: sha256(lastName.trim().toLowerCase()),
-            countryCode: countryCode.trim().toUpperCase()
-        };
-        const postalCode = get('postal_code', 'postalcode', 'zip', 'zip_code');
-        if (postalCode) {
-            addressInfo.postalCode = postalCode.trim();
-        }
-        identifiers.push({ addressInfo });
-    }
-
-    const mobileId = get('mobile_id', 'mobileid', 'idfa', 'gaid');
-    if (mobileId) {
-        identifiers.push({ mobileId: mobileId.trim() });
-    }
-
-    const thirdPartyUserId = get('third_party_user_id', 'thirdpartyuserid', 'user_id', 'userid');
-    if (thirdPartyUserId) {
-        identifiers.push({ thirdPartyUserId: thirdPartyUserId.trim() });
-    }
-
-    return identifiers;
-}
 
 /**
  * Build an OfflineUserDataJobOperation for the Google Ads API.
  */
-function buildOperation(row, uploadMode, adPersonalization, adUserData) {
-    const userIdentifiers = buildUserIdentifiers(row);
+function buildOperation(row, schemaConfig, adPersonalization, adUserData) {
+    const userIdentifiers = lib.buildUserIdentifiersFromCsvRow(row, schemaConfig);
     if (userIdentifiers.length === 0) {
         return null; // row has no usable identifier – skip
     }
@@ -261,6 +189,7 @@ module.exports = {
             lib.ensureRequired(input.developerToken, 'Developer Token is required!', context);
             lib.ensureRequired(input.fileId, 'File is required!', context);
             lib.ensureRequired(input.userListId, 'User List ID is required!', context);
+            lib.ensureRequired(input.schema, 'Schema is required!', context);
 
             const normCustomerId = normId(input.customerId);
             const normUserListId = String(input.userListId || '').replace(/[^0-9]/g, '');
@@ -273,6 +202,7 @@ module.exports = {
                 loginCustomerId: input.loginCustomerId || null,
                 userListResourceName,
                 uploadMode: input.uploadMode || 'ADD',
+                schema: input.schema || null,
                 batchSize: getBatchSize(context),
                 columnSeparator: input.columnSeparator || ',',
                 adPersonalization: input.adPersonalization || null,
@@ -299,6 +229,7 @@ module.exports = {
 
         const batchSize = state.batchSize;
         const delimiter = state.columnSeparator;
+        const schemaConfig = lib.buildCsvSchemaConfig(state.schema);
 
         if (state.totalRows === null) {
             const countStream = await context.getFileReadStream(state.fileId);
@@ -364,7 +295,7 @@ module.exports = {
             let skippedInChunk = 0;
 
             for (const row of rows) {
-                const op = buildOperation(row, state.uploadMode, state.adPersonalization, state.adUserData);
+                const op = buildOperation(row, schemaConfig, state.adPersonalization, state.adUserData);
                 if (op) {
                     operations.push(op);
                 } else {

--- a/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList.js
+++ b/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList.js
@@ -229,7 +229,7 @@ module.exports = {
 
         const batchSize = state.batchSize;
         const delimiter = state.columnSeparator;
-        const schemaConfig = lib.buildCsvSchemaConfig(state.schema);
+        const schemaConfig = lib.buildCsvSchemaConfig(state.schema, context);
 
         if (state.totalRows === null) {
             const countStream = await context.getFileReadStream(state.fileId);

--- a/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/component.json
+++ b/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/component.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.googleAds.core.AddUsersFromCSVToUserList",
-    "description": "Upload a CSV file of users to a Google Ads Customer Match user list via the Offline User Data Job API. Supports large files by processing them in batches across multiple continuations. Each row must contain at least one identifier: email, phone, first_name+last_name+country_code, mobile_id, or third_party_user_id. Column names are matched case-insensitively.",
+    "description": "Upload a CSV file of users to a Google Ads Customer Match user list via the Offline User Data Job API. Supports large files by processing them in batches across multiple continuations. Provide a schema mapping for each upload so different CSV headers can be mapped explicitly.",
     "author": "Appmixer <info@appmixer.com>",
     "version": "1.0.0",
     "auth": {
@@ -37,6 +37,9 @@
                     "uploadMode": {
                         "type": "string"
                     },
+                    "schema": {
+                        "type": "object"
+                    },
                     "columnSeparator": {
                         "type": "string"
                     },
@@ -51,7 +54,8 @@
                     "fileId",
                     "customerId",
                     "developerToken",
-                    "userListId"
+                    "userListId",
+                    "schema"
                 ]
             },
             "inspector": {
@@ -59,7 +63,7 @@
                     "fileId": {
                         "type": "filepicker",
                         "label": "CSV File",
-                        "tooltip": "A CSV file containing user data. The header row must name the identifier columns (e.g. email, phone, first_name, last_name, country_code, mobile_id, third_party_user_id). Each data row must have at least one usable identifier.",
+                        "tooltip": "A CSV file containing user data. Use the Schema field below to map each CSV header to the Google Ads identifier it represents.",
                         "index": 1
                     },
                     "customerId": {
@@ -97,18 +101,47 @@
                             { "label": "Replace (overwrite)", "value": "REPLACE" }
                         ]
                     },
+                    "schema": {
+                        "type": "expression",
+                        "levels": ["ADD"],
+                        "index": 7,
+                        "label": "Schema",
+                        "tooltip": "Required mapping between CSV headers and Google Ads identifiers. This component does not infer identifiers from header names.",
+                        "fields": {
+                            "csvHeader": {
+                                "type": "text",
+                                "label": "CSV Header",
+                                "tooltip": "The header name in the CSV file. Matching is case-insensitive."
+                            },
+                            "googleAdsType": {
+                                "type": "select",
+                                "label": "Google Ads Type",
+                                "tooltip": "The Google Ads identifier type represented by this CSV column.",
+                                "options": [
+                                    { "value": "email", "label": "Email" },
+                                    { "value": "phoneNumber", "label": "Phone Number" },
+                                    { "value": "firstName", "label": "First Name" },
+                                    { "value": "lastName", "label": "Last Name" },
+                                    { "value": "countryCode", "label": "Country Code" },
+                                    { "value": "postalCode", "label": "Postal Code" },
+                                    { "value": "mobileId", "label": "Mobile Device ID" },
+                                    { "value": "thirdPartyUserId", "label": "Third Party User ID" }
+                                ]
+                            }
+                        }
+                    },
                     "columnSeparator": {
                         "type": "text",
                         "label": "Column Separator",
                         "tooltip": "Character used to separate columns in the CSV file. Default is a comma (,).",
-                        "index": 7,
+                        "index": 8,
                         "defaultValue": ","
                     },
                     "adPersonalization": {
                         "type": "select",
                         "label": "Ad Personalization Consent",
                         "tooltip": "Consent status for ad personalization. Required by EU User Consent Policy.",
-                        "index": 8,
+                        "index": 9,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },
@@ -119,7 +152,7 @@
                         "type": "select",
                         "label": "Ad User Data Consent",
                         "tooltip": "Consent status for use of user data for ads. Required by EU User Consent Policy.",
-                        "index": 9,
+                        "index": 10,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },

--- a/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList.js
+++ b/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList.js
@@ -221,7 +221,7 @@ module.exports = {
 
         const batchSize = state.batchSize;
         const delimiter = state.columnSeparator;
-        const schemaConfig = lib.buildCsvSchemaConfig(state.schema);
+        const schemaConfig = lib.buildCsvSchemaConfig(state.schema, context);
 
         if (state.totalRows === null) {
             const countStream = await context.getFileReadStream(state.fileId);

--- a/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList.js
+++ b/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList.js
@@ -39,84 +39,13 @@ const PROGRESS_INTERVAL_MS = 5000;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Hash a string with SHA-256 (lower-cased, trimmed).
- */
-const sha256 = lib.hashSha256;
-
-/**
- * Normalise a customer ID to digits only.
- */
 const normId = lib.normalizeCustomerId;
-
-/**
- * Build a UserIdentifier object for the Google Ads API from a CSV row.
- * The row is expected to contain at least one of:
- *   email, phone, (first_name + last_name + country_code), mobile_id, third_party_user_id
- *
- * Column-name matching is case-insensitive and allows common aliases.
- */
-function buildUserIdentifiers(row) {
-    const get = (...keys) => {
-        for (const k of keys) {
-            const found = Object.keys(row).find(
-                rk => rk.toLowerCase() === k.toLowerCase()
-            );
-            if (found !== undefined && row[found] !== '') {
-                return row[found];
-            }
-        }
-        return null;
-    };
-
-    const identifiers = [];
-
-    const email = get('email', 'email_address', 'emailaddress');
-    if (email) {
-        identifiers.push({ hashedEmail: sha256(email.trim().toLowerCase()) });
-    }
-
-    const phone = get('phone', 'phone_number', 'phonenumber');
-    if (phone) {
-        const normalised = phone.replace(/[^0-9+]/g, '').toLowerCase();
-        identifiers.push({ hashedPhoneNumber: sha256(normalised) });
-    }
-
-    const firstName = get('first_name', 'firstname', 'given_name');
-    const lastName = get('last_name', 'lastname', 'family_name', 'surname');
-    const countryCode = get('country_code', 'countrycode', 'country');
-
-    if (firstName && lastName && countryCode) {
-        const addressInfo = {
-            hashedFirstName: sha256(firstName.trim().toLowerCase()),
-            hashedLastName: sha256(lastName.trim().toLowerCase()),
-            countryCode: countryCode.trim().toUpperCase()
-        };
-        const postalCode = get('postal_code', 'postalcode', 'zip', 'zip_code');
-        if (postalCode) {
-            addressInfo.postalCode = postalCode.trim();
-        }
-        identifiers.push({ addressInfo });
-    }
-
-    const mobileId = get('mobile_id', 'mobileid', 'idfa', 'gaid');
-    if (mobileId) {
-        identifiers.push({ mobileId: mobileId.trim() });
-    }
-
-    const thirdPartyUserId = get('third_party_user_id', 'thirdpartyuserid', 'user_id', 'userid');
-    if (thirdPartyUserId) {
-        identifiers.push({ thirdPartyUserId: thirdPartyUserId.trim() });
-    }
-
-    return identifiers;
-}
 
 /**
  * Build a remove OfflineUserDataJobOperation for the Google Ads API.
  */
-function buildOperation(row, adPersonalization, adUserData) {
-    const userIdentifiers = buildUserIdentifiers(row);
+function buildOperation(row, schemaConfig, adPersonalization, adUserData) {
+    const userIdentifiers = lib.buildUserIdentifiersFromCsvRow(row, schemaConfig);
     if (userIdentifiers.length === 0) {
         return null; // row has no usable identifier – skip
     }
@@ -254,6 +183,7 @@ module.exports = {
             lib.ensureRequired(input.developerToken, 'Developer Token is required!', context);
             lib.ensureRequired(input.fileId, 'File is required!', context);
             lib.ensureRequired(input.userListId, 'User List ID is required!', context);
+            lib.ensureRequired(input.schema, 'Schema is required!', context);
 
             const normCustomerId = normId(input.customerId);
             const normUserListId = String(input.userListId || '').replace(/[^0-9]/g, '');
@@ -265,6 +195,7 @@ module.exports = {
                 developerToken: input.developerToken,
                 loginCustomerId: input.loginCustomerId || null,
                 userListResourceName,
+                schema: input.schema || null,
                 batchSize: getBatchSize(context),
                 columnSeparator: input.columnSeparator || ',',
                 adPersonalization: input.adPersonalization || null,
@@ -290,6 +221,7 @@ module.exports = {
 
         const batchSize = state.batchSize;
         const delimiter = state.columnSeparator;
+        const schemaConfig = lib.buildCsvSchemaConfig(state.schema);
 
         if (state.totalRows === null) {
             const countStream = await context.getFileReadStream(state.fileId);
@@ -355,7 +287,7 @@ module.exports = {
             let skippedInChunk = 0;
 
             for (const row of rows) {
-                const op = buildOperation(row, state.adPersonalization, state.adUserData);
+                const op = buildOperation(row, schemaConfig, state.adPersonalization, state.adUserData);
                 if (op) {
                     operations.push(op);
                 } else {

--- a/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/component.json
+++ b/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/component.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.googleAds.core.RemoveUsersInCSVFromUserList",
-    "description": "Remove users listed in a CSV file from a Google Ads Customer Match user list via the Offline User Data Job API. Supports large files by processing them in batches across multiple continuations. Each row must contain at least one identifier: email, phone, first_name+last_name+country_code, mobile_id, or third_party_user_id. Column names are matched case-insensitively.",
+    "description": "Remove users listed in a CSV file from a Google Ads Customer Match user list via the Offline User Data Job API. Supports large files by processing them in batches across multiple continuations. Provide a schema mapping for each upload so different CSV headers can be mapped explicitly.",
     "author": "Appmixer <info@appmixer.com>",
     "version": "1.0.0",
     "auth": {
@@ -34,6 +34,9 @@
                     "userListId": {
                         "type": "string"
                     },
+                    "schema": {
+                        "type": "object"
+                    },
                     "columnSeparator": {
                         "type": "string"
                     },
@@ -48,7 +51,8 @@
                     "fileId",
                     "customerId",
                     "developerToken",
-                    "userListId"
+                    "userListId",
+                    "schema"
                 ]
             },
             "inspector": {
@@ -56,7 +60,7 @@
                     "fileId": {
                         "type": "filepicker",
                         "label": "CSV File",
-                        "tooltip": "A CSV file containing user data. The header row must name the identifier columns (e.g. email, phone, first_name, last_name, country_code, mobile_id, third_party_user_id). Each data row must have at least one usable identifier.",
+                        "tooltip": "A CSV file containing user data. Use the Schema field below to map each CSV header to the Google Ads identifier it represents.",
                         "index": 1
                     },
                     "customerId": {
@@ -83,18 +87,47 @@
                         "tooltip": "Numeric ID of the Customer Match user list to remove users from.",
                         "index": 5
                     },
+                    "schema": {
+                        "type": "expression",
+                        "levels": ["ADD"],
+                        "index": 6,
+                        "label": "Schema",
+                        "tooltip": "Required mapping between CSV headers and Google Ads identifiers. This component does not infer identifiers from header names.",
+                        "fields": {
+                            "csvHeader": {
+                                "type": "text",
+                                "label": "CSV Header",
+                                "tooltip": "The header name in the CSV file. Matching is case-insensitive."
+                            },
+                            "googleAdsType": {
+                                "type": "select",
+                                "label": "Google Ads Type",
+                                "tooltip": "The Google Ads identifier type represented by this CSV column.",
+                                "options": [
+                                    { "value": "email", "label": "Email" },
+                                    { "value": "phoneNumber", "label": "Phone Number" },
+                                    { "value": "firstName", "label": "First Name" },
+                                    { "value": "lastName", "label": "Last Name" },
+                                    { "value": "countryCode", "label": "Country Code" },
+                                    { "value": "postalCode", "label": "Postal Code" },
+                                    { "value": "mobileId", "label": "Mobile Device ID" },
+                                    { "value": "thirdPartyUserId", "label": "Third Party User ID" }
+                                ]
+                            }
+                        }
+                    },
                     "columnSeparator": {
                         "type": "text",
                         "label": "Column Separator",
                         "tooltip": "Character used to separate columns in the CSV file. Default is a comma (,).",
-                        "index": 6,
+                        "index": 7,
                         "defaultValue": ","
                     },
                     "adPersonalization": {
                         "type": "select",
                         "label": "Ad Personalization Consent",
                         "tooltip": "Consent status for ad personalization. Required by EU User Consent Policy.",
-                        "index": 7,
+                        "index": 8,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },
@@ -105,7 +138,7 @@
                         "type": "select",
                         "label": "Ad User Data Consent",
                         "tooltip": "Consent status for use of user data for ads. Required by EU User Consent Policy.",
-                        "index": 8,
+                        "index": 9,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },

--- a/src/appmixer/googleAds/lib.js
+++ b/src/appmixer/googleAds/lib.js
@@ -17,6 +17,7 @@ const CSV_MAPPING_TYPES = {
     mobileId: 'mobileId',
     thirdPartyUserId: 'thirdPartyUserId'
 };
+const VALID_CSV_MAPPING_TYPES = new Set(Object.values(CSV_MAPPING_TYPES));
 
 function ensureRequired(value, message, context) {
     if (value === undefined || value === null || value === '') {
@@ -83,7 +84,7 @@ function normalizeRowKey(value) {
     return String(value || '').trim().toLowerCase();
 }
 
-function buildCsvSchemaConfig(schema) {
+function buildCsvSchemaConfig(schema, context) {
     const config = {};
     const mappings = Array.isArray(schema?.ADD) ? schema.ADD : [];
 
@@ -93,6 +94,10 @@ function buildCsvSchemaConfig(schema) {
 
         if (!header || !googleAdsType) {
             continue;
+        }
+
+        if (!VALID_CSV_MAPPING_TYPES.has(googleAdsType)) {
+            throw new context.CancelError(`Unsupported Google Ads Type: ${googleAdsType}`);
         }
 
         if (!config[header]) {

--- a/src/appmixer/googleAds/lib.js
+++ b/src/appmixer/googleAds/lib.js
@@ -160,7 +160,8 @@ function buildUserIdentifiersFromCsvRow(row, schemaConfig = {}) {
         userIdentifiers.push({ hashedEmail: hashSha256(email) });
     }
 
-    const phoneNumbers = getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.phoneNumber, { splitMultiValue: true });
+    const phoneNumbers =
+        getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.phoneNumber, { splitMultiValue: true });
 
     for (const phoneNumber of phoneNumbers) {
         const normalizedPhone = phoneNumber.replace(/[^0-9+]/g, '');
@@ -194,7 +195,8 @@ function buildUserIdentifiersFromCsvRow(row, schemaConfig = {}) {
         userIdentifiers.push({ mobileId });
     }
 
-    const thirdPartyUserIds = getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.thirdPartyUserId, { splitMultiValue: true });
+    const thirdPartyUserIds =
+        getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.thirdPartyUserId, { splitMultiValue: true });
 
     for (const thirdPartyUserId of thirdPartyUserIds) {
         userIdentifiers.push({ thirdPartyUserId });

--- a/src/appmixer/googleAds/lib.js
+++ b/src/appmixer/googleAds/lib.js
@@ -5,6 +5,18 @@ const pathModule = require('path');
 
 const API_BASE_URL = 'https://googleads.googleapis.com/v23';
 const DEFAULT_PREFIX = 'googleads-objects-export';
+const CSV_NULL_TOKENS = new Set(['', '\\N', 'NULL', 'null']);
+
+const CSV_MAPPING_TYPES = {
+    email: 'email',
+    phoneNumber: 'phoneNumber',
+    firstName: 'firstName',
+    lastName: 'lastName',
+    countryCode: 'countryCode',
+    postalCode: 'postalCode',
+    mobileId: 'mobileId',
+    thirdPartyUserId: 'thirdPartyUserId'
+};
 
 function ensureRequired(value, message, context) {
     if (value === undefined || value === null || value === '') {
@@ -59,6 +71,136 @@ function hashSha256(value) {
         .createHash('sha256')
         .update(String(value || '').trim().toLowerCase(), 'utf8')
         .digest('hex');
+}
+
+function normalizeCsvValue(value) {
+    const normalized = String(value ?? '').trim();
+
+    return CSV_NULL_TOKENS.has(normalized) ? null : normalized;
+}
+
+function normalizeRowKey(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function buildCsvSchemaConfig(schema) {
+    const config = {};
+    const mappings = Array.isArray(schema?.ADD) ? schema.ADD : [];
+
+    for (const mapping of mappings) {
+        const header = normalizeRowKey(mapping?.csvHeader);
+        const googleAdsType = String(mapping?.googleAdsType || '').trim();
+
+        if (!header || !googleAdsType) {
+            continue;
+        }
+
+        if (!config[header]) {
+            config[header] = [];
+        }
+
+        if (!config[header].includes(googleAdsType)) {
+            config[header].push(googleAdsType);
+        }
+    }
+
+    return config;
+}
+
+function getRowValues(row, aliases, { splitMultiValue = false } = {}) {
+    const aliasSet = new Set(aliases.map(normalizeRowKey));
+    const values = [];
+
+    for (const [key, rawValue] of Object.entries(row || {})) {
+        if (!aliasSet.has(normalizeRowKey(key))) {
+            continue;
+        }
+
+        const normalized = normalizeCsvValue(rawValue);
+        if (!normalized) {
+            continue;
+        }
+
+        const parts = splitMultiValue
+            ? normalized.split(/[;,]/)
+            : [normalized];
+
+        for (const part of parts) {
+            const value = normalizeCsvValue(part);
+            if (value) {
+                values.push(value);
+            }
+        }
+    }
+
+    return [...new Set(values)];
+}
+
+function getMappedHeaders(schemaConfig, googleAdsType) {
+    return Object.keys(schemaConfig || {}).filter(header => {
+        return Array.isArray(schemaConfig[header]) && schemaConfig[header].includes(googleAdsType);
+    });
+}
+
+function getMappedRowValues(row, schemaConfig, googleAdsType, options = {}) {
+    const headers = getMappedHeaders(schemaConfig, googleAdsType);
+    return getRowValues(row, headers, options);
+}
+
+function getFirstMappedRowValue(row, schemaConfig, googleAdsType) {
+    const [value] = getMappedRowValues(row, schemaConfig, googleAdsType);
+    return value || null;
+}
+
+function buildUserIdentifiersFromCsvRow(row, schemaConfig = {}) {
+    const userIdentifiers = [];
+    const emails = getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.email, { splitMultiValue: true });
+
+    for (const email of emails) {
+        userIdentifiers.push({ hashedEmail: hashSha256(email) });
+    }
+
+    const phoneNumbers = getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.phoneNumber, { splitMultiValue: true });
+
+    for (const phoneNumber of phoneNumbers) {
+        const normalizedPhone = phoneNumber.replace(/[^0-9+]/g, '');
+        if (normalizedPhone) {
+            userIdentifiers.push({ hashedPhoneNumber: hashSha256(normalizedPhone) });
+        }
+    }
+
+    const firstName = getFirstMappedRowValue(row, schemaConfig, CSV_MAPPING_TYPES.firstName);
+    const lastName = getFirstMappedRowValue(row, schemaConfig, CSV_MAPPING_TYPES.lastName);
+    const countryCode = getFirstMappedRowValue(row, schemaConfig, CSV_MAPPING_TYPES.countryCode);
+
+    if (firstName && lastName && countryCode) {
+        const addressInfo = {
+            hashedFirstName: hashSha256(firstName),
+            hashedLastName: hashSha256(lastName),
+            countryCode: countryCode.toUpperCase()
+        };
+        const postalCode = getFirstMappedRowValue(row, schemaConfig, CSV_MAPPING_TYPES.postalCode);
+
+        if (postalCode) {
+            addressInfo.postalCode = postalCode;
+        }
+
+        userIdentifiers.push({ addressInfo });
+    }
+
+    const mobileIds = getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.mobileId, { splitMultiValue: true });
+
+    for (const mobileId of mobileIds) {
+        userIdentifiers.push({ mobileId });
+    }
+
+    const thirdPartyUserIds = getMappedRowValues(row, schemaConfig, CSV_MAPPING_TYPES.thirdPartyUserId, { splitMultiValue: true });
+
+    for (const thirdPartyUserId of thirdPartyUserIds) {
+        userIdentifiers.push({ thirdPartyUserId });
+    }
+
+    return userIdentifiers;
 }
 
 function getOfflineUserDataJobIdFromResourceName(resourceName) {
@@ -174,6 +316,8 @@ module.exports = {
     buildHeaders,
     searchStream,
     hashSha256,
+    buildCsvSchemaConfig,
+    buildUserIdentifiersFromCsvRow,
     getOfflineUserDataJobIdFromResourceName,
     sendArrayOutput,
     getOutputPortOptions,


### PR DESCRIPTION
Use case: user wants to use the same CSV for `facebookbusiness` and `googleAds` connector components that upload CSV files.