### PR TITLE
ai.openai: Fix ioredis sentinel connection configuration

### DIFF
--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ai.openai",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "changelog": {
         "1.0.0": [
             "First version."
@@ -46,6 +46,9 @@
         ],
         "1.3.1": [
             "Fixed AI Agent mcpCallTool not passing correlationId, causing MCP server tool calls to appear in separate execution logs."
+        ],
+        "1.3.2": [
+            "Fixed ioredis sentinel connection configuration to properly parse sentinel hosts and handle password authentication."
         ]
     }
 }

--- a/src/appmixer/ai/openai/lib.js
+++ b/src/appmixer/ai/openai/lib.js
@@ -84,7 +84,8 @@ module.exports = {
             mode: process.env.REDIS_MODE || 'standalone',
             sentinels: process.env.REDIS_SENTINELS,
             sentinelMasterName: process.env.REDIS_SENTINEL_MASTER_NAME,
-            sentinelRedisPassword: process.env.REDIS_SENTINEL_PASSWORD,
+            password: process.env.REDIS_PASSWORD,
+            sentinelPassword: process.env.REDIS_SENTINEL_PASSWORD,
             enableTLSForSentinelMode: process.env.REDIS_SENTINEL_ENABLE_TLS,
             caPath: process.env.REDIS_CA_PATH,
             useSSL: process.env.REDIS_USE_SSL === 'true' || parseInt(process.env.REDIS_USE_SSL) > 0
@@ -101,14 +102,19 @@ module.exports = {
 
         if (connection.mode === 'replica' && connection.sentinels) {
 
-            const sentinelsArray = connection.sentinels.split(',');
+            const sentinelsArray = connection.sentinels.split(',').map(sentinel => {
+                const [host, port] = sentinel.split(':');
+                return { host, port: parseInt(port) };
+            });
 
             client = new Redis({
                 sentinels: sentinelsArray,
                 name: connection.sentinelMasterName,
-                ...(connection.sentinelRedisPassword ? { password: connection.sentinelRedisPassword } : {}),
+                ...(connection.password ? { password: connection.password } : {}),
+                ...(connection.sentinelPassword ? { sentinelPassword: connection.sentinelPassword } : {}),
                 ...(connection.enableTLSForSentinelMode ?
-                    { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {})
+                    { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {}),
+                ...options
             });
         } else {
             client = connection.uri ? new Redis(connection.uri, options) : new Redis();

--- a/src/appmixer/ai/openai/lib.js
+++ b/src/appmixer/ai/openai/lib.js
@@ -85,7 +85,7 @@ module.exports = {
             sentinels: process.env.REDIS_SENTINELS,
             sentinelMasterName: process.env.REDIS_SENTINEL_MASTER_NAME,
             password: process.env.REDIS_PASSWORD,
-            sentinelPassword: process.env.REDIS_SENTINEL_PASSWORD,
+            sentinelRedisPassword: process.env.REDIS_SENTINEL_PASSWORD,
             enableTLSForSentinelMode: process.env.REDIS_SENTINEL_ENABLE_TLS,
             caPath: process.env.REDIS_CA_PATH,
             useSSL: process.env.REDIS_USE_SSL === 'true' || parseInt(process.env.REDIS_USE_SSL) > 0
@@ -103,15 +103,18 @@ module.exports = {
         if (connection.mode === 'replica' && connection.sentinels) {
 
             const sentinelsArray = connection.sentinels.split(',').map(sentinel => {
-                const [host, port] = sentinel.split(':');
-                return { host, port: parseInt(port) };
+                const [host, port] = sentinel.trim().split(':');
+                return { host, port: port ? parseInt(port) : 26379 };
             });
+
+            const redisPassword = connection.password || connection.sentinelRedisPassword;
+            const sentinelPassword = connection.sentinelRedisPassword || connection.password;
 
             client = new Redis({
                 sentinels: sentinelsArray,
                 name: connection.sentinelMasterName,
-                ...(connection.password ? { password: connection.password } : {}),
-                ...(connection.sentinelPassword ? { sentinelPassword: connection.sentinelPassword } : {}),
+                ...(redisPassword ? { password: redisPassword } : {}),
+                ...(sentinelPassword ? { sentinelPassword: sentinelPassword } : {}),
                 ...(connection.enableTLSForSentinelMode ?
                     { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {}),
                 ...options


### PR DESCRIPTION
## Summary
- Parse sentinel hosts from `"host:port"` string format to object array `[{host, port}]`
- Add support for `REDIS_PASSWORD` environment variable
- Properly separate `password` (Redis auth) and `sentinelPassword` (Sentinel auth)
- Include TLS options in sentinel mode configuration

## Context
This fix aligns with the changes made in appmixer-core PR #3563 to ensure proper connection to Redis in sentinel mode.

## Changes
The `connectRedis` function in `src/appmixer/ai/openai/lib.js` now:
1. Properly parses the comma-separated sentinel string into an array of `{host, port}` objects
2. Uses `REDIS_PASSWORD` for Redis authentication
3. Uses `REDIS_SENTINEL_PASSWORD` for Sentinel authentication  
4. Applies TLS configuration to sentinel connections

## Test plan
- [ ] Test Redis connection in sentinel mode with password authentication
- [ ] Test Redis connection in sentinel mode with TLS enabled
- [ ] Verify backward compatibility with standalone Redis mode

Fixes: https://github.com/Appmixer-ai/appmixer-components/issues/2656

🤖 Generated with [Claude Code](https://claude.com/claude-code)