### PR TITLE
Utils/Chat (patch): Fix ioredis sentinel connection configuration

### DIFF
--- a/src/appmixer/utils/chat/bundle.json
+++ b/src/appmixer/utils/chat/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.chat",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -15,6 +15,9 @@
             "Breaking Change - Updated configuration of ChatTrigger: added 'agentIntro', 'agentDescription' (previously 'chatTheme'), 'agentPromptPlaceholder', removed 'agentMessage'.",
             "Completely redesigned Chat UI (appmixer-chatbot v1.1.0)",
             "Added support for file attachments in chat messages."
+        ],
+        "2.0.1": [
+            "Fixed ioredis sentinel connection configuration to properly parse sentinel hosts and handle password authentication."
         ]
     }
 }

--- a/src/appmixer/utils/chat/lib.js
+++ b/src/appmixer/utils/chat/lib.js
@@ -40,7 +40,7 @@ module.exports = {
             sentinels: process.env.REDIS_SENTINELS,
             sentinelMasterName: process.env.REDIS_SENTINEL_MASTER_NAME,
             password: process.env.REDIS_PASSWORD,
-            sentinelPassword: process.env.REDIS_SENTINEL_PASSWORD,
+            sentinelRedisPassword: process.env.REDIS_SENTINEL_PASSWORD,
             enableTLSForSentinelMode: process.env.REDIS_SENTINEL_ENABLE_TLS,
             caPath: process.env.REDIS_CA_PATH,
             useSSL: process.env.REDIS_USE_SSL === 'true' || parseInt(process.env.REDIS_USE_SSL) > 0
@@ -62,12 +62,18 @@ module.exports = {
                 return { host, port: port ? parseInt(port) : 26379 };
             });
 
+            // Determine passwords for Redis master and Sentinel nodes
+            // Priority: use specific password if available, otherwise use the general password,
+            // then fall back to sentinelRedisPassword
+            const redisPassword = connection.password || connection.sentinelRedisPassword;
+            const sentinelPassword = connection.sentinelRedisPassword || connection.password;
+
             client = new Redis({
                 ...options,
                 sentinels: sentinelsArray,
                 name: connection.sentinelMasterName,
-                ...(connection.password ? { password: connection.password } : {}),
-                ...(connection.sentinelPassword ? { sentinelPassword: connection.sentinelPassword } : {}),
+                ...(redisPassword ? { password: redisPassword } : {}),
+                ...(sentinelPassword ? { sentinelPassword } : {}),
                 ...(connection.enableTLSForSentinelMode ?
                     { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {})
             });

--- a/src/appmixer/utils/chat/lib.js
+++ b/src/appmixer/utils/chat/lib.js
@@ -39,7 +39,8 @@ module.exports = {
             mode: process.env.REDIS_MODE || 'standalone',
             sentinels: process.env.REDIS_SENTINELS,
             sentinelMasterName: process.env.REDIS_SENTINEL_MASTER_NAME,
-            sentinelRedisPassword: process.env.REDIS_SENTINEL_PASSWORD,
+            password: process.env.REDIS_PASSWORD,
+            sentinelPassword: process.env.REDIS_SENTINEL_PASSWORD,
             enableTLSForSentinelMode: process.env.REDIS_SENTINEL_ENABLE_TLS,
             caPath: process.env.REDIS_CA_PATH,
             useSSL: process.env.REDIS_USE_SSL === 'true' || parseInt(process.env.REDIS_USE_SSL) > 0
@@ -56,12 +57,17 @@ module.exports = {
 
         if (connection.mode === 'replica' && connection.sentinels) {
 
-            const sentinelsArray = connection.sentinels.split(',');
+            const sentinelsArray = connection.sentinels.split(',').map(sentinel => {
+                const [host, port] = sentinel.trim().split(':');
+                return { host, port: port ? parseInt(port) : 26379 };
+            });
 
             client = new Redis({
+                ...options,
                 sentinels: sentinelsArray,
                 name: connection.sentinelMasterName,
-                ...(connection.sentinelRedisPassword ? { password: connection.sentinelRedisPassword } : {}),
+                ...(connection.password ? { password: connection.password } : {}),
+                ...(connection.sentinelPassword ? { sentinelPassword: connection.sentinelPassword } : {}),
                 ...(connection.enableTLSForSentinelMode ?
                     { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {})
             });


### PR DESCRIPTION
## Summary
- Parse sentinel hosts from `"host:port"` string format to object array `[{host, port}]`
- Add support for `REDIS_PASSWORD` environment variable
- Properly separate `password` (Redis auth) and `sentinelPassword` (Sentinel auth)
- Include TLS options in sentinel mode configuration
- Add `.trim()` and default port 26379 for robustness

## Context
Same fix as PR #1020 (openai/lib.js), applied to `src/appmixer/utils/chat/lib.js` which had the identical issue.

## Changes
The `connectRedis` function in `src/appmixer/utils/chat/lib.js` now:
1. Properly parses the comma-separated sentinel string into an array of `{host, port}` objects with `.trim()` and default port 26379
2. Uses `REDIS_PASSWORD` for Redis authentication
3. Uses `REDIS_SENTINEL_PASSWORD` for Sentinel authentication
4. Applies TLS configuration (`...options`) to sentinel connections

## Test plan
- [ ] Test Redis connection in sentinel mode with password authentication
- [ ] Test Redis connection in sentinel mode with TLS enabled
- [ ] Verify backward compatibility with standalone Redis mode