### PR TITLE
Jira (patch): fix createmeta endpoint response parsing — required fields not appearing in inspector

### DIFF
--- a/src/appmixer/jira/artifacts/test-flows/test-flow-createissue-fields.json
+++ b/src/appmixer/jira/artifacts/test-flows/test-flow-createissue-fields.json
@@ -1,357 +1,238 @@
 {
-    "name": "E2E Jira - CreateIssue required fields",
-    "description": "Tests that IssueMetadata returns required fields (e.g. summary) for CreateIssue inspector, and that CreateIssue works with summary field.",
     "flow": {
-        "on-start": {
-            "type": "appmixer.utils.controls.OnStart",
-            "x": 100,
-            "y": 300,
-            "source": {},
-            "version": "1.0.0",
-            "config": {}
-        },
-        "set-variables": {
-            "type": "appmixer.utils.controls.SetVariable",
-            "x": 240,
-            "y": 300,
-            "source": {
-                "in": {
-                    "on-start": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {
-                "transform": {
-                    "in": {
-                        "on-start": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "variables": {}
-                                },
-                                "lambda": {
-                                    "variables": {
-                                        "ADD": [
-                                            {
-                                                "type": "text",
-                                                "name": "projectId",
-                                                "text": "10000"
-                                            },
-                                            {
-                                                "type": "text",
-                                                "name": "issueTypeId",
-                                                "text": "10001"
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 380,
-            "y": 300,
-            "source": {
-                "in": {
-                    "set-variables": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {}
-        },
-        "get-field-metadata": {
-            "type": "appmixer.jira.issues.IssueMetadata",
-            "x": 520,
-            "y": 200,
-            "source": {
-                "in": {
-                    "before-all": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {
-                "transform": {
-                    "in": {
-                        "before-all": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "project": {
-                                        "var-project": {
-                                            "variable": "$.set-variables.out.projectId",
-                                            "functions": []
-                                        }
-                                    },
-                                    "issueType": {
-                                        "var-issue-type": {
-                                            "variable": "$.set-variables.out.issueTypeId",
-                                            "functions": []
-                                        }
-                                    }
-                                },
-                                "lambda": {
-                                    "project": "{{{var-project}}}",
-                                    "issueType": "{{{var-issue-type}}}"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "check-metadata": {
-            "type": "appmixer.utils.controls.CodeBlock",
-            "x": 660,
-            "y": 200,
-            "source": {
-                "in": {
-                    "get-field-metadata": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {
-                "transform": {
-                    "in": {
-                        "get-field-metadata": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "code": {
-                                        "metadata-var": {
-                                            "variable": "$.get-field-metadata.out",
-                                            "functions": [{"name": "g_stringify"}]
-                                        }
-                                    }
-                                },
-                                "lambda": {
-                                    "code": "(() => { const meta = JSON.parse('{{{metadata-var}}}'); const keys = Object.keys(meta); const hasSummary = keys.includes('summary'); const fieldCount = keys.length; return hasSummary ? 'PASS:summary_found:' + fieldCount + '_fields' : 'FAIL:summary_missing:fields=' + keys.join(','); })()"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "assert-fields-returned": {
-            "type": "appmixer.utils.test.Assert",
-            "x": 800,
-            "y": 200,
-            "source": {
-                "in": {
-                    "check-metadata": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {
-                "transform": {
-                    "in": {
-                        "check-metadata": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "expression": {
-                                        "result-check": {
-                                            "variable": "$.check-metadata.out.result",
-                                            "functions": []
-                                        }
-                                    }
-                                },
-                                "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "field": "{{{result-check}}}",
-                                                "assertion": "contains",
-                                                "value": "PASS:summary_found",
-                                                "label": "IssueMetadata should return summary field in metadata"
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "create-issue": {
-            "type": "appmixer.jira.issues.CreateIssue",
-            "x": 520,
-            "y": 400,
-            "source": {
-                "in": {
-                    "before-all": ["out"]
-                }
-            },
-            "version": "1.0.1",
-            "config": {
-                "properties": {
-                    "project": "10000",
-                    "issueType": "10001"
-                },
-                "transform": {
-                    "in": {
-                        "before-all": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "summary": {
-                                        "ts-var": {
-                                            "variable": "$.on-start.out.started",
-                                            "functions": [{"name": "g_timestamp"}]
-                                        }
-                                    }
-                                },
-                                "lambda": {
-                                    "summary": "E2E-CreateIssue-Fields-Test-{{{ts-var}}}"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "assert-create-issue": {
-            "type": "appmixer.utils.test.Assert",
-            "x": 660,
-            "y": 400,
-            "source": {
-                "in": {
-                    "create-issue": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {
-                "transform": {
-                    "in": {
-                        "create-issue": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "expression": {
-                                        "issue-id": {
-                                            "variable": "$.create-issue.out.id",
-                                            "functions": []
-                                        },
-                                        "issue-key": {
-                                            "variable": "$.create-issue.out.key",
-                                            "functions": []
-                                        }
-                                    }
-                                },
-                                "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "field": "{{{issue-id}}}",
-                                                "assertion": "notEmpty",
-                                                "label": "Created issue should have an ID"
-                                            },
-                                            {
-                                                "field": "{{{issue-key}}}",
-                                                "assertion": "notEmpty",
-                                                "label": "Created issue should have a key"
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "delete-issue": {
-            "type": "appmixer.jira.issues.DeleteIssue",
-            "x": 800,
-            "y": 400,
-            "source": {
-                "in": {
-                    "create-issue": ["out"]
-                }
-            },
-            "version": "1.0.0",
-            "config": {
-                "transform": {
-                    "in": {
-                        "create-issue": {
-                            "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "id": {
-                                        "var-issue-id": {
-                                            "variable": "$.create-issue.out.id",
-                                            "functions": []
-                                        }
-                                    }
-                                },
-                                "lambda": {
-                                    "id": "{{{var-issue-id}}}"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "after-all": {
-            "type": "appmixer.utils.test.AfterAll",
-            "x": 940,
-            "y": 300,
-            "source": {
-                "in": {
-                    "assert-fields-returned": ["out"],
-                    "assert-create-issue": ["out"]
-                }
-            },
-            "version": "1.0.0",
             "config": {
                 "properties": {
                     "timeout": 30
                 }
-            }
-        },
-        "process-results": {
-            "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 1080,
-            "y": 300,
+            },
             "source": {
                 "in": {
-                    "after-all": ["out"]
+                    "assert-create-issue": [
+                        "out"
+                    ]
                 }
             },
-            "version": "1.0.1",
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1100,
+            "y": 304
+        },
+        "assert-create-issue": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "delete-issue": {
+                            "deleted": {
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{issue-id}}}",
+                                                "label": "Created issue should have an ID"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{issue-key}}}",
+                                                "label": "Created issue should have a key"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "modifiers": {
+                                    "expression": {
+                                        "issue-id": {
+                                            "functions": [],
+                                            "variable": "$.create-issue.out.id"
+                                        },
+                                        "issue-key": {
+                                            "functions": [],
+                                            "variable": "$.create-issue.out.key"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "source": {
+                "in": {
+                    "delete-issue": [
+                        "deleted"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.Assert",
+            "x": 880,
+            "y": 304
+        },
+        "create-issue": {
+            "config": {
+                "properties": {
+                    "issueType": "10001",
+                    "project": "10000"
+                },
+                "transform": {
+                    "in": {
+                        "set-variables": {
+                            "out": {
+                                "lambda": {
+                                    "customfield_10076": "asdfdsf",
+                                    "reporter": "5eafb639ddd45f0b94215fa9",
+                                    "summary": "asdfasdf"
+                                },
+                                "modifiers": {
+                                    "customfield_10076": {},
+                                    "reporter": {},
+                                    "summary": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "source": {
+                "in": {
+                    "set-variables": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.jira.issues.CreateIssue",
+            "x": 416,
+            "y": 304
+        },
+        "delete-issue": {
+            "config": {
+                "properties": {
+                    "account": "698df646f513883a8203c88e"
+                },
+                "transform": {
+                    "in": {
+                        "create-issue": {
+                            "out": {
+                                "lambda": {
+                                    "id": "{{{var-issue-id}}}"
+                                },
+                                "modifiers": {
+                                    "id": {
+                                        "var-issue-id": {
+                                            "functions": [],
+                                            "variable": "$.create-issue.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "source": {
+                "in": {
+                    "create-issue": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.jira.issues.DeleteIssue",
+            "x": 656,
+            "y": 304
+        },
+        "on-start": {
+            "config": {},
+            "source": {},
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 0,
+            "y": 304
+        },
+        "process-results": {
             "config": {
                 "properties": {},
                 "transform": {
                     "in": {
                         "after-all": {
                             "out": {
-                                "type": "json2new",
-                                "modifiers": {
-                                    "recipients": {},
-                                    "testCase": {},
-                                    "result": {
-                                        "result-var": {
-                                            "variable": "$.after-all.out",
-                                            "functions": []
-                                        }
-                                    }
-                                },
                                 "lambda": {
                                     "recipients": "test@appmixer.ai",
-                                    "testCase": "E2E Jira - CreateIssue required fields",
-                                    "result": "{{{result-var}}}"
-                                }
+                                    "result": "{{{result-var}}}",
+                                    "testCase": "Jira CreateIssue E2E"
+                                },
+                                "modifiers": {
+                                    "recipients": {},
+                                    "result": {
+                                        "result-var": {
+                                            "functions": [],
+                                            "variable": "$.after-all.out"
+                                        }
+                                    },
+                                    "testCase": {}
+                                },
+                                "type": "json2new"
                             }
                         }
                     }
                 }
-            }
+            },
+            "source": {
+                "in": {
+                    "after-all": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1300,
+            "y": 304
+        },
+        "set-variables": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "on-start": {
+                            "out": {
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "name": "projectId",
+                                                "text": "10000",
+                                                "type": "text"
+                                            },
+                                            {
+                                                "name": "issueTypeId",
+                                                "text": "10001",
+                                                "type": "text"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "source": {
+                "in": {
+                    "on-start": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 176,
+            "y": 304
         }
+    },
+    "name": "E2E Jira - CreateIssue required fields",
+    "notes": {},
+    "wizard": {
+        "fields": []
     }
 }

--- a/src/appmixer/jira/artifacts/test-flows/test-flow-createissue-fields.json
+++ b/src/appmixer/jira/artifacts/test-flows/test-flow-createissue-fields.json
@@ -1,0 +1,357 @@
+{
+    "name": "E2E Jira - CreateIssue required fields",
+    "description": "Tests that IssueMetadata returns required fields (e.g. summary) for CreateIssue inspector, and that CreateIssue works with summary field.",
+    "flow": {
+        "on-start": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 100,
+            "y": 300,
+            "source": {},
+            "version": "1.0.0",
+            "config": {}
+        },
+        "set-variables": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 240,
+            "y": 300,
+            "source": {
+                "in": {
+                    "on-start": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "on-start": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "projectId",
+                                                "text": "10000"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "issueTypeId",
+                                                "text": "10001"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "before-all": {
+            "type": "appmixer.utils.test.BeforeAll",
+            "x": 380,
+            "y": 300,
+            "source": {
+                "in": {
+                    "set-variables": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {}
+        },
+        "get-field-metadata": {
+            "type": "appmixer.jira.issues.IssueMetadata",
+            "x": 520,
+            "y": 200,
+            "source": {
+                "in": {
+                    "before-all": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "before-all": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "project": {
+                                        "var-project": {
+                                            "variable": "$.set-variables.out.projectId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "issueType": {
+                                        "var-issue-type": {
+                                            "variable": "$.set-variables.out.issueTypeId",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "project": "{{{var-project}}}",
+                                    "issueType": "{{{var-issue-type}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "check-metadata": {
+            "type": "appmixer.utils.controls.CodeBlock",
+            "x": 660,
+            "y": 200,
+            "source": {
+                "in": {
+                    "get-field-metadata": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "get-field-metadata": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "code": {
+                                        "metadata-var": {
+                                            "variable": "$.get-field-metadata.out",
+                                            "functions": [{"name": "g_stringify"}]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "code": "(() => { const meta = JSON.parse('{{{metadata-var}}}'); const keys = Object.keys(meta); const hasSummary = keys.includes('summary'); const fieldCount = keys.length; return hasSummary ? 'PASS:summary_found:' + fieldCount + '_fields' : 'FAIL:summary_missing:fields=' + keys.join(','); })()"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-fields-returned": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 800,
+            "y": 200,
+            "source": {
+                "in": {
+                    "check-metadata": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "check-metadata": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "result-check": {
+                                            "variable": "$.check-metadata.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{result-check}}}",
+                                                "assertion": "contains",
+                                                "value": "PASS:summary_found",
+                                                "label": "IssueMetadata should return summary field in metadata"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "create-issue": {
+            "type": "appmixer.jira.issues.CreateIssue",
+            "x": 520,
+            "y": 400,
+            "source": {
+                "in": {
+                    "before-all": ["out"]
+                }
+            },
+            "version": "1.0.1",
+            "config": {
+                "properties": {
+                    "project": "10000",
+                    "issueType": "10001"
+                },
+                "transform": {
+                    "in": {
+                        "before-all": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "summary": {
+                                        "ts-var": {
+                                            "variable": "$.on-start.out.started",
+                                            "functions": [{"name": "g_timestamp"}]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "summary": "E2E-CreateIssue-Fields-Test-{{{ts-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-create-issue": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 660,
+            "y": 400,
+            "source": {
+                "in": {
+                    "create-issue": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-issue": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "issue-id": {
+                                            "variable": "$.create-issue.out.id",
+                                            "functions": []
+                                        },
+                                        "issue-key": {
+                                            "variable": "$.create-issue.out.key",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{issue-id}}}",
+                                                "assertion": "notEmpty",
+                                                "label": "Created issue should have an ID"
+                                            },
+                                            {
+                                                "field": "{{{issue-key}}}",
+                                                "assertion": "notEmpty",
+                                                "label": "Created issue should have a key"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "delete-issue": {
+            "type": "appmixer.jira.issues.DeleteIssue",
+            "x": 800,
+            "y": 400,
+            "source": {
+                "in": {
+                    "create-issue": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-issue": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "id": {
+                                        "var-issue-id": {
+                                            "variable": "$.create-issue.out.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "id": "{{{var-issue-id}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "after-all": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 940,
+            "y": 300,
+            "source": {
+                "in": {
+                    "assert-fields-returned": ["out"],
+                    "assert-create-issue": ["out"]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 30
+                }
+            }
+        },
+        "process-results": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1080,
+            "y": 300,
+            "source": {
+                "in": {
+                    "after-all": ["out"]
+                }
+            },
+            "version": "1.0.1",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "after-all": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "result-var": {
+                                            "variable": "$.after-all.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "E2E Jira - CreateIssue required fields",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/appmixer/jira/bundle.json
+++ b/src/appmixer/jira/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jira",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -51,6 +51,9 @@
         ],
         "2.0.2": [
             "Create Issue, Update Issue: fix support for custom fields."
+        ],
+        "2.0.3": [
+            "CreateIssue, IssueMetadata: add pagination support for createmeta endpoints — required fields (e.g. Summary) were missing in inspector when projects had more fields than the default page size (50)."
         ]
     }
 }

--- a/src/appmixer/jira/issues/CreateIssue/CreateIssue.js
+++ b/src/appmixer/jira/issues/CreateIssue/CreateIssue.js
@@ -85,11 +85,13 @@ module.exports = {
         const hasCustomFields = Object.keys(issue).some(key => key.startsWith('customfield_'));
         if (hasCustomFields) {
             try {
-                const { fields } = await commons.get(
-                    `${apiUrl}issue/createmeta/${project}/issuetypes/${issueType}`,
-                    auth
-                );
-                if (fields) {
+                const fields = await commons.pager({
+                    endpoint: `${apiUrl}issue/createmeta/${project}/issuetypes/${issueType}`,
+                    credentials: auth,
+                    key: 'fields',
+                    params: { maxResults: 100 }
+                });
+                if (fields && fields.length > 0) {
                     const fieldMeta = fields.reduce((acc, field) => {
                         acc[field.fieldId] = field;
                         return acc;

--- a/src/appmixer/jira/issues/IssueMetadata/IssueMetadata.js
+++ b/src/appmixer/jira/issues/IssueMetadata/IssueMetadata.js
@@ -65,20 +65,24 @@ module.exports = {
         }
 
         if (!issueType) {
-            const { issueTypes } = await commons.get(
-                `${apiUrl}issue/createmeta/${project}/issuetypes`,
-                auth
-            );
+            const issueTypes = await commons.pager({
+                endpoint: `${apiUrl}issue/createmeta/${project}/issuetypes`,
+                credentials: auth,
+                key: 'issueTypes',
+                params: { maxResults: 100 }
+            });
 
             return context.sendJson(issueTypes || [], 'out');
         }
 
-        const { fields } = await commons.get(
-            `${apiUrl}issue/createmeta/${project}/issuetypes/${issueType}`,
-            auth
-        );
+        const fields = await commons.pager({
+            endpoint: `${apiUrl}issue/createmeta/${project}/issuetypes/${issueType}`,
+            credentials: auth,
+            key: 'fields',
+            params: { maxResults: 100 }
+        });
 
-        if (!fields) {
+        if (!fields || fields.length === 0) {
             return context.sendJson([], 'out');
         }
 


### PR DESCRIPTION
https://appmixer.freshdesk.com/a/tickets/9555

>Hello,
>
> I am a Technical Support Engineer at Salt Security reporting an issue with the CreateIssue Jira component/connector.
>
> In both our internal labs and customer deployments of Jira workflows with the CreateIssue component, we have had consistent issues getting fields that are marked as required in Jira from appearing in the connector edit panel. We have tested with both scoped service accounts (that have permissions to only access certain Projects and Issue Types) and admin-level accounts; neither have gotten all required fields to show consistently.
>
> To be able to assist our customers that are currently blocked from implementing said workflows, we are requesting assistance with what permissions are necessary for a non-admin service account to be able to see the required fields (i.e. Summary). As a security standard, it is ill-advised to give service accounts administrator-level permissions such as Manage Project.
>
> For example:
Customers have asked why a service account would need "manage" permissions scoped if they already have browse-project, read/write, and create issue permissions in a project?
>
> Via our investigation, we have also verified that the required fields are included in a response when querying the Atlassian API, and they are included in the Create screen for the Project/Issue Type that customers are using. 
>
> Unless we are mistaken, this points to an issue in the core function of the CreateIssue component.
>
> Any assistance in remediating this issue would be greatly appreciated!

## Problem

The Jira `CreateIssue` component fails to display required fields (e.g. Summary) in the edit panel/inspector. This affects all users regardless of permission level.

## Root Cause

Jira's /issue/createmeta API endpoints return paginated results (default maxResults=50). Our CreateIssue and IssueMetadata components were only fetching the first page of results. For projects with many custom fields, required fields like Summary could fall outside the first page and therefore not appear in the component's field inspector.
This explains why the fields were visible when querying the Jira API directly (full pagination) but missing in the Appmixer connector (first page only).