### PR TITLE
utils.converters (patch) - Fix crashing XLSX2CSV with invalid file

### DIFF
--- a/src/appmixer/utils/converters/bundle.json
+++ b/src/appmixer/utils/converters/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.converters",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "changelog": {
         "1.1.0": [
             "FileId inputs changed from 'text' to 'filepicker'. Requires Appmixer 4.4.4 or higher."
@@ -20,6 +20,9 @@
         ],
         "1.4.0": [
             "PDF2Text: new component to extract text from a PDF file."
+        ],
+        "1.4.1": [
+            "Added check for valid XLSX file in XLSX2CSV component. Throwing early if the file is not a valid XLSX."
         ]
     }
 }

--- a/src/appmixer/utils/converters/xlsx-helpers.js
+++ b/src/appmixer/utils/converters/xlsx-helpers.js
@@ -1,6 +1,50 @@
 const xlsx = require('xlsx');
 const path = require('path');
 
+const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY_MIN_LENGTH = 22;
+const ZIP_MAX_COMMENT_LENGTH = 0xFFFF;
+
+function createSpreadsheetValidationError(context, message) {
+
+    if (context?.CancelError) {
+        return new context.CancelError(message);
+    }
+
+    return new Error(message);
+}
+
+function assertValidZipArchive(buffer, context) {
+
+    if (buffer.length < ZIP_END_OF_CENTRAL_DIRECTORY_MIN_LENGTH
+        || buffer.readUInt32LE(0) !== ZIP_LOCAL_FILE_HEADER_SIGNATURE) {
+        throw createSpreadsheetValidationError(context, 'Invalid spreadsheet file: expected a ZIP-based workbook.');
+    }
+
+    const minimumOffset = Math.max(0, buffer.length - ZIP_END_OF_CENTRAL_DIRECTORY_MIN_LENGTH - ZIP_MAX_COMMENT_LENGTH);
+    let endOfCentralDirectoryOffset = -1;
+
+    for (let offset = buffer.length - ZIP_END_OF_CENTRAL_DIRECTORY_MIN_LENGTH; offset >= minimumOffset; offset--) {
+        if (buffer.readUInt32LE(offset) === ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+            endOfCentralDirectoryOffset = offset;
+            break;
+        }
+    }
+
+    if (endOfCentralDirectoryOffset === -1) {
+        throw createSpreadsheetValidationError(context, 'Invalid spreadsheet file: missing ZIP footer.');
+    }
+
+    const centralDirectorySize = buffer.readUInt32LE(endOfCentralDirectoryOffset + 12);
+    const centralDirectoryOffset = buffer.readUInt32LE(endOfCentralDirectoryOffset + 16);
+    const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
+
+    if (centralDirectoryEnd > endOfCentralDirectoryOffset) {
+        throw createSpreadsheetValidationError(context, 'Invalid spreadsheet file: truncated ZIP archive.');
+    }
+}
+
 module.exports.JSON2Workbook = async function(readStream) {
 
     return new Promise((resolve, reject) => {
@@ -74,7 +118,7 @@ module.exports.HTML2Workbook = async function(readStream) {
     });
 };
 
-module.exports.XLSX2Workbook = async function(readStream) {
+module.exports.XLSX2Workbook = async function(readStream, context) {
 
     return new Promise((resolve, reject) => {
         const buffers = [];
@@ -85,7 +129,8 @@ module.exports.XLSX2Workbook = async function(readStream) {
         }).on('end', () => {
             try {
                 const buffer = Buffer.concat(buffers);
-                const workbook = xlsx.read(buffer);
+                assertValidZipArchive(buffer, context);
+                const workbook = xlsx.read(buffer, { type: 'buffer' });
                 resolve(workbook);
             } catch (err) {
                 reject(err);
@@ -98,7 +143,7 @@ module.exports.convertFile = async function(context, sourceFileId, converterFunc
 
     const readStream = await context.getFileReadStream(sourceFileId);
     const fileInfo = await context.getFileInfo(sourceFileId);
-    const workbook = await converterFunction(readStream);
+    const workbook = await converterFunction(readStream, context);
     const outputBuffer = xlsx.write(workbook, { type: 'buffer', bookType: bookType });
     const newFileName = path.parse(fileInfo.filename).name + '.' + bookType;
     const savedFile = await context.saveFile(newFileName, mimeType, outputBuffer);
@@ -120,7 +165,7 @@ module.exports.convertFile2JSON = async function(context, sourceFileId, converte
 
     const readStream = await context.getFileReadStream(sourceFileId);
     const fileInfo = await context.getFileInfo(sourceFileId);
-    const workbook = await converterFunction(readStream);
+    const workbook = await converterFunction(readStream, context);
     const firstWorksheet = workbook.Sheets[workbook.SheetNames[0]];
     const json = xlsx.utils.sheet_to_json(firstWorksheet);
     const newFileName = path.parse(fileInfo.filename).name + '.json';


### PR DESCRIPTION
https://appmixer.freshdesk.com/a/tickets/9566
Closes https://github.com/Appmixer-ai/appmixer-components/issues/2663

> The crash was caused by feeding a malformed XLSX container into SheetJS through [xlsx-helpers.js](vscode-file://vscode-app/Users/jirihofman/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). An [.xlsx](vscode-file://vscode-app/Users/jirihofman/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) file is just a ZIP archive with Office XML parts inside; the Boots file was not structurally valid as a ZIP workbook.

**What was wrong with the file:**
> unzip reported that the archive was missing 741111411 bytes and could not seek to the beginning of the ZIP footer. That means the file’s ZIP central directory was broken or truncated. In practice, the workbook data was corrupted, not just “an unusual XLSX”.

**Why that crashed instead of throwing a normal error:**
> With this corrupted archive, the parser did not fail cleanly in this environment and the Node process was killed with exit code 137, which is consistent with the OS terminating it during pathological parsing, typically due to memory pressure or runaway work. The root cause was the invalid file, not the converter logic for valid spreadsheets.

The fix adds a cheap ZIP sanity check before parsing, so corrupted XLSX-like files now fail fast with a clear error instead of reaching SheetJS.