### PR TITLE
facebookbusiness (major): remove ads_read scope, bump to v3.0.0

### DIFF
--- a/src/appmixer/facebookbusiness/bundle.json
+++ b/src/appmixer/facebookbusiness/bundle.json
@@ -1,8 +1,10 @@
 {
     "name": "appmixer.facebookbusiness",
-    "version": "2.1.1",
+    "version": "3.0.0",
     "changelog": {
-        "1.0.0": ["Initial version"],
+        "1.0.0": [
+            "Initial version"
+        ],
         "2.0.0": [
             "Support for sessions to upload large number of users.",
             "New: RemoveMembersInCSVFromAudience, ReplaceMembersFromCSVInAudience",
@@ -15,6 +17,9 @@
         "2.1.1": [
             "Fix validateAccessToken in auth.js.",
             "Bump Graph API from v20.0 to v25.0."
+        ],
+        "3.0.0": [
+            "Remove ads_read scope from all components. Only ads_management is required. Breaking change: users need to re-authenticate."
         ]
     }
 }

--- a/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,25 +21,61 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" },
-                    "EMAIL": { "type": "string" },
-                    "PHONE": { "type": "string" },
-                    "GEN": { "type": "string" },
-                    "DOBY": { "type": "string" },
-                    "DOBM": { "type": "string" },
-                    "DOBD": { "type": "string" },
-                    "FN": { "type": "string" },
-                    "LN": { "type": "string" },
-                    "FI": { "type": "string" },
-                    "CT": { "type": "string" },
-                    "ST": { "type": "string" },
-                    "ZIP": { "type": "string" },
-                    "COUNTRY": { "type": "string" },
-                    "MADID": { "type": "string" },
-                    "EXTERN_ID": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    },
+                    "EMAIL": {
+                        "type": "string"
+                    },
+                    "PHONE": {
+                        "type": "string"
+                    },
+                    "GEN": {
+                        "type": "string"
+                    },
+                    "DOBY": {
+                        "type": "string"
+                    },
+                    "DOBM": {
+                        "type": "string"
+                    },
+                    "DOBD": {
+                        "type": "string"
+                    },
+                    "FN": {
+                        "type": "string"
+                    },
+                    "LN": {
+                        "type": "string"
+                    },
+                    "FI": {
+                        "type": "string"
+                    },
+                    "CT": {
+                        "type": "string"
+                    },
+                    "ST": {
+                        "type": "string"
+                    },
+                    "ZIP": {
+                        "type": "string"
+                    },
+                    "COUNTRY": {
+                        "type": "string"
+                    },
+                    "MADID": {
+                        "type": "string"
+                    },
+                    "EXTERN_ID": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId"]
+                "required": [
+                    "audienceId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -86,8 +121,14 @@
                         "index": 5,
                         "label": "Gender",
                         "options": [
-                            { "value": "f", "label": "f" },
-                            { "value": "m", "label": "m" }
+                            {
+                                "value": "f",
+                                "label": "f"
+                            },
+                            {
+                                "value": "m",
+                                "label": "m"
+                            }
                         ]
                     },
                     "DOBY": {
@@ -164,27 +205,38 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [{
-            "value": "audience_id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "session_id",
-            "label": "Session ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "num_received",
-            "label": "Number of Received Users",
-            "schema": { "type": "integer" }
-        }, {
-            "value": "num_invalid_entries",
-            "label": "Number of Invalid Entries",
-            "schema": { "type": "integer" }
-        }]
+            "name": "out",
+            "options": [
+                {
+                    "value": "audience_id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "session_id",
+                    "label": "Session ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "num_received",
+                    "label": "Number of Received Users",
+                    "schema": {
+                        "type": "integer"
+                    }
+                },
+                {
+                    "value": "num_invalid_entries",
+                    "label": "Number of Invalid Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }
-
-

--- a/src/appmixer/facebookbusiness/marketing/AddMembersFromCSVToAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/AddMembersFromCSVToAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,13 +21,26 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" },
-                    "fileId": { "type": "string" },
-                    "schema": { "type": "object" },
-                    "delimiter": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    },
+                    "fileId": {
+                        "type": "string"
+                    },
+                    "schema": {
+                        "type": "object"
+                    },
+                    "delimiter": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId", "fileId"]
+                "required": [
+                    "audienceId",
+                    "fileId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -67,7 +79,9 @@
                     },
                     "schema": {
                         "type": "expression",
-                        "levels": ["ADD"],
+                        "levels": [
+                            "ADD"
+                        ],
                         "index": 3,
                         "label": "Schema",
                         "tooltip": "Specify what type of information you will provide in the CSV file. The order of the columns is not important.",
@@ -82,21 +96,66 @@
                                 "label": "Facebook Type",
                                 "tooltip": "The type of information in the column.",
                                 "options": [
-                                    { "value": "EMAIL", "label": "EMAIL (email address)" },
-                                    { "value": "PHONE", "label": "PHONE (phone number)" },
-                                    { "value": "GEN", "label": "GEN (gender - m|f)" },
-                                    { "value": "DOBY", "label": "DOBY (birth year - YYYY)" },
-                                    { "value": "DOBM", "label": "DOBM (birth month - MM - 01 to 12)" },
-                                    { "value": "DOBD", "label": "DOBD (birthday - DD - 01 to 31)" },
-                                    { "value": "LN", "label": "LN (last name)" },
-                                    { "value": "FN", "label": "FN (first name)" },
-                                    { "value": "FI", "label": "FI (first name initial)" },
-                                    { "value": "CT", "label": "CT (city)" },
-                                    { "value": "ST", "label": "ST (state - US 2-letter, Others lowercase)" },
-                                    { "value": "ZIP", "label": "ZIP (zip code)" },
-                                    { "value": "COUNTRY", "label": "COUNTRY (country code - 2-letter)" },
-                                    { "value": "MADID", "label": "MADID (mobile advertiser ID)" },
-                                    { "value": "EXTERN_ID", "label": "EXTERN_ID (your own ID)" }
+                                    {
+                                        "value": "EMAIL",
+                                        "label": "EMAIL (email address)"
+                                    },
+                                    {
+                                        "value": "PHONE",
+                                        "label": "PHONE (phone number)"
+                                    },
+                                    {
+                                        "value": "GEN",
+                                        "label": "GEN (gender - m|f)"
+                                    },
+                                    {
+                                        "value": "DOBY",
+                                        "label": "DOBY (birth year - YYYY)"
+                                    },
+                                    {
+                                        "value": "DOBM",
+                                        "label": "DOBM (birth month - MM - 01 to 12)"
+                                    },
+                                    {
+                                        "value": "DOBD",
+                                        "label": "DOBD (birthday - DD - 01 to 31)"
+                                    },
+                                    {
+                                        "value": "LN",
+                                        "label": "LN (last name)"
+                                    },
+                                    {
+                                        "value": "FN",
+                                        "label": "FN (first name)"
+                                    },
+                                    {
+                                        "value": "FI",
+                                        "label": "FI (first name initial)"
+                                    },
+                                    {
+                                        "value": "CT",
+                                        "label": "CT (city)"
+                                    },
+                                    {
+                                        "value": "ST",
+                                        "label": "ST (state - US 2-letter, Others lowercase)"
+                                    },
+                                    {
+                                        "value": "ZIP",
+                                        "label": "ZIP (zip code)"
+                                    },
+                                    {
+                                        "value": "COUNTRY",
+                                        "label": "COUNTRY (country code - 2-letter)"
+                                    },
+                                    {
+                                        "value": "MADID",
+                                        "label": "MADID (mobile advertiser ID)"
+                                    },
+                                    {
+                                        "value": "EXTERN_ID",
+                                        "label": "EXTERN_ID (your own ID)"
+                                    }
                                 ]
                             }
                         }
@@ -114,30 +173,45 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [{
-            "value": "audience_id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "account_id",
-            "label": "Account ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "invalid_entry_samples",
-            "label": "Invalid Entry Samples",
-            "schema": { "type": "array" }
-        }, {
-            "value": "num_invalid_entries",
-            "label": "Number of Invalid Entries",
-            "schema": { "type": "integer" }
-        }, {
-            "value": "num_total_entries",
-            "label": "Number of Entries",
-            "schema": { "type": "integer" }
-        }]
+            "name": "out",
+            "options": [
+                {
+                    "value": "audience_id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "account_id",
+                    "label": "Account ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "invalid_entry_samples",
+                    "label": "Invalid Entry Samples",
+                    "schema": {
+                        "type": "array"
+                    }
+                },
+                {
+                    "value": "num_invalid_entries",
+                    "label": "Number of Invalid Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                },
+                {
+                    "value": "num_total_entries",
+                    "label": "Number of Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }
-

--- a/src/appmixer/facebookbusiness/marketing/CreateAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/CreateAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,13 +21,26 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "name": { "type": "string" },
-                    "description": { "type": "string" },
-                    "customer_file_source": { "type": "string" },
-                    "subtype": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "customer_file_source": {
+                        "type": "string"
+                    },
+                    "subtype": {
+                        "type": "string"
+                    }
                 },
-                "required": ["name", "customer_file_source"]
+                "required": [
+                    "name",
+                    "customer_file_source"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -63,9 +75,18 @@
                         "tooltip": "Source of customer information in the uploaded file.",
                         "defaultValue": "USER_PROVIDED_ONLY",
                         "options": [
-                            { "value": "USER_PROVIDED_ONLY", "label": "User Provided Only" },
-                            { "value": "PARTNER_PROVIDED_ONLY", "label": "Partner Provided Only" },
-                            { "value": "BOTH_USER_AND_PARTNER_PROVIDED", "label": "Both User and Partner Provided" }
+                            {
+                                "value": "USER_PROVIDED_ONLY",
+                                "label": "User Provided Only"
+                            },
+                            {
+                                "value": "PARTNER_PROVIDED_ONLY",
+                                "label": "Partner Provided Only"
+                            },
+                            {
+                                "value": "BOTH_USER_AND_PARTNER_PROVIDED",
+                                "label": "Both User and Partner Provided"
+                            }
                         ]
                     },
                     "subtype": {
@@ -75,25 +96,82 @@
                         "tooltip": "Type of custom audience, derived from original data source.",
                         "defaultValue": "CUSTOM",
                         "options": [
-                            { "value": "CUSTOM", "label": "CUSTOM" },
-                            { "value": "PRIMARY", "label": "PRIMARY" },
-                            { "value": "WEBSITE", "label": "WEBSITE" },
-                            { "value": "APP", "label": "APP" },
-                            { "value": "OFFLINE_CONVERSION", "label": "OFFLINE_CONVERSION" },
-                            { "value": "CLAIM", "label": "CLAIM" },
-                            { "value": "MANAGED", "label": "MANAGED" },
-                            { "value": "PARTNER", "label": "PARTNER" },
-                            { "value": "VIDEO", "label": "VIDEO" },
-                            { "value": "LOOKALIKE", "label": "LOOKALIKE" },
-                            { "value": "ENGAGEMENT", "label": "ENGAGEMENT" },
-                            { "value": "BAG_OF_ACCOUNTS", "label": "BAG_OF_ACCOUNTS" },
-                            { "value": "STUDY_RULE_AUDIENCE", "label": "STUDY_RULE_AUDIENCE" },
-                            { "value": "FOX", "label": "FOX" },
-                            { "value": "MEASUREMENT", "label": "MEASUREMENT" },
-                            { "value": "REGULATED_CATEGORIES_AUDIENCE", "label": "REGULATED_CATEGORIES_AUDIENCE" },
-                            { "value": "BIDDING", "label": "BIDDING" },
-                            { "value": "SUBSCRIBER_SEGMENT", "label": "SUBSCRIBER_SEGMENT" },
-                            { "value": "EXCLUSION", "label": "EXCLUSION" }
+                            {
+                                "value": "CUSTOM",
+                                "label": "CUSTOM"
+                            },
+                            {
+                                "value": "PRIMARY",
+                                "label": "PRIMARY"
+                            },
+                            {
+                                "value": "WEBSITE",
+                                "label": "WEBSITE"
+                            },
+                            {
+                                "value": "APP",
+                                "label": "APP"
+                            },
+                            {
+                                "value": "OFFLINE_CONVERSION",
+                                "label": "OFFLINE_CONVERSION"
+                            },
+                            {
+                                "value": "CLAIM",
+                                "label": "CLAIM"
+                            },
+                            {
+                                "value": "MANAGED",
+                                "label": "MANAGED"
+                            },
+                            {
+                                "value": "PARTNER",
+                                "label": "PARTNER"
+                            },
+                            {
+                                "value": "VIDEO",
+                                "label": "VIDEO"
+                            },
+                            {
+                                "value": "LOOKALIKE",
+                                "label": "LOOKALIKE"
+                            },
+                            {
+                                "value": "ENGAGEMENT",
+                                "label": "ENGAGEMENT"
+                            },
+                            {
+                                "value": "BAG_OF_ACCOUNTS",
+                                "label": "BAG_OF_ACCOUNTS"
+                            },
+                            {
+                                "value": "STUDY_RULE_AUDIENCE",
+                                "label": "STUDY_RULE_AUDIENCE"
+                            },
+                            {
+                                "value": "FOX",
+                                "label": "FOX"
+                            },
+                            {
+                                "value": "MEASUREMENT",
+                                "label": "MEASUREMENT"
+                            },
+                            {
+                                "value": "REGULATED_CATEGORIES_AUDIENCE",
+                                "label": "REGULATED_CATEGORIES_AUDIENCE"
+                            },
+                            {
+                                "value": "BIDDING",
+                                "label": "BIDDING"
+                            },
+                            {
+                                "value": "SUBSCRIBER_SEGMENT",
+                                "label": "SUBSCRIBER_SEGMENT"
+                            },
+                            {
+                                "value": "EXCLUSION",
+                                "label": "EXCLUSION"
+                            }
                         ]
                     }
                 }
@@ -102,14 +180,16 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [
-            {
-            "value": "id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }
-        ]
+            "name": "out",
+            "options": [
+                {
+                    "value": "id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="

--- a/src/appmixer/facebookbusiness/marketing/DeleteAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/DeleteAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,10 +21,16 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId"]
+                "required": [
+                    "audienceId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -62,14 +67,16 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [
-            {
-            "value": "id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }
-        ]
+            "name": "out",
+            "options": [
+                {
+                    "value": "id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="

--- a/src/appmixer/facebookbusiness/marketing/GetAdAccounts/component.json
+++ b/src/appmixer/facebookbusiness/marketing/GetAdAccounts/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -18,47 +17,61 @@
     },
     "inPorts": [
         {
-        "name": "in",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "outputType": { "type": "string" }
-            }
-        },
-        "inspector": {
-            "inputs": {
-                "outputType": {
-                    "type": "select",
-                    "label": "Output Type",
-                    "index": 1,
-                    "defaultValue": "array",
-                    "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
-                    "options": [
-                        { "label": "First Item Only", "value": "first" },
-                        { "label": "All items at once", "value": "array" },
-                        { "label": "One item at a time", "value": "object" },
-                        { "label": "Store to CSV file", "value": "file" }
-                    ]
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outputType": {
+                        "type": "string"
+                    }
+                }
+            },
+            "inspector": {
+                "inputs": {
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 1,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            {
+                                "label": "First Item Only",
+                                "value": "first"
+                            },
+                            {
+                                "label": "All items at once",
+                                "value": "array"
+                            },
+                            {
+                                "label": "One item at a time",
+                                "value": "object"
+                            },
+                            {
+                                "label": "Store to CSV file",
+                                "value": "file"
+                            }
+                        ]
+                    }
                 }
             }
         }
-    }
     ],
     "outPorts": [
         {
-        "name": "out",
-        "source": {
-            "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
-            "data": {
-                "properties": {
-                    "generateOutputPortOptions": true
-                },
-                "messages": {
-                    "in/outputType": "inputs/in/outputType"
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/outputType": "inputs/in/outputType"
+                    }
                 }
             }
         }
-    }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }

--- a/src/appmixer/facebookbusiness/marketing/GetCampaigns/component.json
+++ b/src/appmixer/facebookbusiness/marketing/GetCampaigns/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,10 +21,16 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "outputType": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "outputType": {
+                        "type": "string"
+                    }
                 },
-                "required": ["accountId"]
+                "required": [
+                    "accountId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -48,10 +53,22 @@
                         "defaultValue": "array",
                         "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
                         "options": [
-                            { "label": "First Item Only", "value": "first" },
-                            { "label": "All items at once", "value": "array" },
-                            { "label": "One item at a time", "value": "object" },
-                            { "label": "Store to CSV file", "value": "file" }
+                            {
+                                "label": "First Item Only",
+                                "value": "first"
+                            },
+                            {
+                                "label": "All items at once",
+                                "value": "array"
+                            },
+                            {
+                                "label": "One item at a time",
+                                "value": "object"
+                            },
+                            {
+                                "label": "Store to CSV file",
+                                "value": "file"
+                            }
                         ]
                     }
                 }
@@ -60,20 +77,20 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "source": {
-            "url": "/component/appmixer/facebookbusiness/marketing/GetCampaigns?outPort=out",
-            "data": {
-                "properties": {
-                    "generateOutputPortOptions": true
-                },
-                "messages": {
-                    "in/accountId": "dummy",
-                    "in/outputType": "inputs/in/outputType"
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/facebookbusiness/marketing/GetCampaigns?outPort=out",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/accountId": "dummy",
+                        "in/outputType": "inputs/in/outputType"
+                    }
                 }
             }
         }
-    }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }

--- a/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/component.json
+++ b/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -18,68 +17,82 @@
     },
     "inPorts": [
         {
-        "name": "in",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "accountId": {
-                    "type": "string",
-                    "title": "Ad Account ID",
-                    "description": "The ID of the ad account to get custom audiences for."
-                },
-                "outputType": { "type": "string" }
-            },
-            "required": [
-                "accountId"
-            ]
-        },
-        "inspector": {
-            "inputs": {
-                "accountId": {
-                    "type": "select",
-                    "label": "Account ID",
-                    "index": 1,
-                    "tooltip": "Enter your Ad Account ID.",
-                    "source": {
-                        "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
-                        "data": {
-                            "transform": "./GetAdAccounts#toSelectArray"
-                        }
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "accountId": {
+                        "type": "string",
+                        "title": "Ad Account ID",
+                        "description": "The ID of the ad account to get custom audiences for."
+                    },
+                    "outputType": {
+                        "type": "string"
                     }
                 },
-                "outputType": {
-                    "type": "select",
-                    "label": "Output Type",
-                    "index": 2,
-                    "defaultValue": "array",
-                    "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
-                    "options": [
-                        { "label": "First Item Only", "value": "first" },
-                        { "label": "All items at once", "value": "array" },
-                        { "label": "One item at a time", "value": "object" },
-                        { "label": "Store to CSV file", "value": "file" }
-                    ]
+                "required": [
+                    "accountId"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "accountId": {
+                        "type": "select",
+                        "label": "Account ID",
+                        "index": 1,
+                        "tooltip": "Enter your Ad Account ID.",
+                        "source": {
+                            "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
+                            "data": {
+                                "transform": "./GetAdAccounts#toSelectArray"
+                            }
+                        }
+                    },
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 2,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            {
+                                "label": "First Item Only",
+                                "value": "first"
+                            },
+                            {
+                                "label": "All items at once",
+                                "value": "array"
+                            },
+                            {
+                                "label": "One item at a time",
+                                "value": "object"
+                            },
+                            {
+                                "label": "Store to CSV file",
+                                "value": "file"
+                            }
+                        ]
+                    }
                 }
             }
-        }
         }
     ],
     "outPorts": [
         {
-        "name": "out",
-        "source": {
-            "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
-            "data": {
-                "properties": {
-                    "generateOutputPortOptions": true
-                },
-                "messages": {
-                    "in/accountId": "dummy",
-                    "in/outputType": "inputs/in/outputType"
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/accountId": "dummy",
+                        "in/outputType": "inputs/in/outputType"
+                    }
                 }
             }
         }
-    }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }

--- a/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,25 +21,61 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" },
-                    "EMAIL": { "type": "string" },
-                    "PHONE": { "type": "string" },
-                    "GEN": { "type": "string" },
-                    "DOBY": { "type": "string" },
-                    "DOBM": { "type": "string" },
-                    "DOBD": { "type": "string" },
-                    "FN": { "type": "string" },
-                    "LN": { "type": "string" },
-                    "FI": { "type": "string" },
-                    "CT": { "type": "string" },
-                    "ST": { "type": "string" },
-                    "ZIP": { "type": "string" },
-                    "COUNTRY": { "type": "string" },
-                    "MADID": { "type": "string" },
-                    "EXTERN_ID": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    },
+                    "EMAIL": {
+                        "type": "string"
+                    },
+                    "PHONE": {
+                        "type": "string"
+                    },
+                    "GEN": {
+                        "type": "string"
+                    },
+                    "DOBY": {
+                        "type": "string"
+                    },
+                    "DOBM": {
+                        "type": "string"
+                    },
+                    "DOBD": {
+                        "type": "string"
+                    },
+                    "FN": {
+                        "type": "string"
+                    },
+                    "LN": {
+                        "type": "string"
+                    },
+                    "FI": {
+                        "type": "string"
+                    },
+                    "CT": {
+                        "type": "string"
+                    },
+                    "ST": {
+                        "type": "string"
+                    },
+                    "ZIP": {
+                        "type": "string"
+                    },
+                    "COUNTRY": {
+                        "type": "string"
+                    },
+                    "MADID": {
+                        "type": "string"
+                    },
+                    "EXTERN_ID": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId"]
+                "required": [
+                    "audienceId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -86,8 +121,14 @@
                         "index": 5,
                         "label": "Gender",
                         "options": [
-                            { "value": "f", "label": "f" },
-                            { "value": "m", "label": "m" }
+                            {
+                                "value": "f",
+                                "label": "f"
+                            },
+                            {
+                                "value": "m",
+                                "label": "m"
+                            }
                         ]
                     },
                     "DOBY": {
@@ -164,27 +205,38 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [{
-            "value": "audience_id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "session_id",
-            "label": "Session ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "num_received",
-            "label": "Number of Received Users",
-            "schema": { "type": "integer" }
-        }, {
-            "value": "num_invalid_entries",
-            "label": "Number of Invalid Entries",
-            "schema": { "type": "integer" }
-        }]
+            "name": "out",
+            "options": [
+                {
+                    "value": "audience_id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "session_id",
+                    "label": "Session ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "num_received",
+                    "label": "Number of Received Users",
+                    "schema": {
+                        "type": "integer"
+                    }
+                },
+                {
+                    "value": "num_invalid_entries",
+                    "label": "Number of Invalid Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }
-
-

--- a/src/appmixer/facebookbusiness/marketing/RemoveMembersInCSVFromAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/RemoveMembersInCSVFromAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,13 +21,26 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" },
-                    "fileId": { "type": "string" },
-                    "schema": { "type": "object" },
-                    "delimiter": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    },
+                    "fileId": {
+                        "type": "string"
+                    },
+                    "schema": {
+                        "type": "object"
+                    },
+                    "delimiter": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId", "fileId"]
+                "required": [
+                    "audienceId",
+                    "fileId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -67,7 +79,9 @@
                     },
                     "schema": {
                         "type": "expression",
-                        "levels": ["ADD"],
+                        "levels": [
+                            "ADD"
+                        ],
                         "index": 3,
                         "label": "Schema",
                         "tooltip": "Specify what type of information you will provide in the CSV file. The order of the columns is not important.",
@@ -82,21 +96,66 @@
                                 "label": "Facebook Type",
                                 "tooltip": "The type of information in the column.",
                                 "options": [
-                                    { "value": "EMAIL", "label": "EMAIL (email address)" },
-                                    { "value": "PHONE", "label": "PHONE (phone number)" },
-                                    { "value": "GEN", "label": "GEN (gender - m|f)" },
-                                    { "value": "DOBY", "label": "DOBY (birth year - YYYY)" },
-                                    { "value": "DOBM", "label": "DOBM (birth month - MM - 01 to 12)" },
-                                    { "value": "DOBD", "label": "DOBD (birthday - DD - 01 to 31)" },
-                                    { "value": "LN", "label": "LN (last name)" },
-                                    { "value": "FN", "label": "FN (first name)" },
-                                    { "value": "FI", "label": "FI (first name initial)" },
-                                    { "value": "CT", "label": "CT (city)" },
-                                    { "value": "ST", "label": "ST (state - US 2-letter, Others lowercase)" },
-                                    { "value": "ZIP", "label": "ZIP (zip code)" },
-                                    { "value": "COUNTRY", "label": "COUNTRY (country code - 2-letter)" },
-                                    { "value": "MADID", "label": "MADID (mobile advertiser ID)" },
-                                    { "value": "EXTERN_ID", "label": "EXTERN_ID (your own ID)" }
+                                    {
+                                        "value": "EMAIL",
+                                        "label": "EMAIL (email address)"
+                                    },
+                                    {
+                                        "value": "PHONE",
+                                        "label": "PHONE (phone number)"
+                                    },
+                                    {
+                                        "value": "GEN",
+                                        "label": "GEN (gender - m|f)"
+                                    },
+                                    {
+                                        "value": "DOBY",
+                                        "label": "DOBY (birth year - YYYY)"
+                                    },
+                                    {
+                                        "value": "DOBM",
+                                        "label": "DOBM (birth month - MM - 01 to 12)"
+                                    },
+                                    {
+                                        "value": "DOBD",
+                                        "label": "DOBD (birthday - DD - 01 to 31)"
+                                    },
+                                    {
+                                        "value": "LN",
+                                        "label": "LN (last name)"
+                                    },
+                                    {
+                                        "value": "FN",
+                                        "label": "FN (first name)"
+                                    },
+                                    {
+                                        "value": "FI",
+                                        "label": "FI (first name initial)"
+                                    },
+                                    {
+                                        "value": "CT",
+                                        "label": "CT (city)"
+                                    },
+                                    {
+                                        "value": "ST",
+                                        "label": "ST (state - US 2-letter, Others lowercase)"
+                                    },
+                                    {
+                                        "value": "ZIP",
+                                        "label": "ZIP (zip code)"
+                                    },
+                                    {
+                                        "value": "COUNTRY",
+                                        "label": "COUNTRY (country code - 2-letter)"
+                                    },
+                                    {
+                                        "value": "MADID",
+                                        "label": "MADID (mobile advertiser ID)"
+                                    },
+                                    {
+                                        "value": "EXTERN_ID",
+                                        "label": "EXTERN_ID (your own ID)"
+                                    }
                                 ]
                             }
                         }
@@ -114,26 +173,38 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [{
-            "value": "audience_id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "account_id",
-            "label": "Account ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "invalid_entry_samples",
-            "label": "Invalid Entry Samples",
-            "schema": { "type": "array" }
-        }, {
-            "value": "num_invalid_entries",
-            "label": "Number of Invalid Entries",
-            "schema": { "type": "integer" }
-        }]
+            "name": "out",
+            "options": [
+                {
+                    "value": "audience_id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "account_id",
+                    "label": "Account ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "invalid_entry_samples",
+                    "label": "Invalid Entry Samples",
+                    "schema": {
+                        "type": "array"
+                    }
+                },
+                {
+                    "value": "num_invalid_entries",
+                    "label": "Number of Invalid Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }
-

--- a/src/appmixer/facebookbusiness/marketing/ReplaceMembersFromCSVInAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/ReplaceMembersFromCSVInAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,13 +21,26 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" },
-                    "fileId": { "type": "string" },
-                    "schema": { "type": "object" },
-                    "delimiter": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    },
+                    "fileId": {
+                        "type": "string"
+                    },
+                    "schema": {
+                        "type": "object"
+                    },
+                    "delimiter": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId", "fileId"]
+                "required": [
+                    "audienceId",
+                    "fileId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -67,7 +79,9 @@
                     },
                     "schema": {
                         "type": "expression",
-                        "levels": ["ADD"],
+                        "levels": [
+                            "ADD"
+                        ],
                         "index": 3,
                         "label": "Schema",
                         "tooltip": "Specify what type of information you will provide in the CSV file. The order of the columns is not important.",
@@ -82,21 +96,66 @@
                                 "label": "Facebook Type",
                                 "tooltip": "The type of information in the column.",
                                 "options": [
-                                    { "value": "EMAIL", "label": "EMAIL (email address)" },
-                                    { "value": "PHONE", "label": "PHONE (phone number)" },
-                                    { "value": "GEN", "label": "GEN (gender - m|f)" },
-                                    { "value": "DOBY", "label": "DOBY (birth year - YYYY)" },
-                                    { "value": "DOBM", "label": "DOBM (birth month - MM - 01 to 12)" },
-                                    { "value": "DOBD", "label": "DOBD (birthday - DD - 01 to 31)" },
-                                    { "value": "LN", "label": "LN (last name)" },
-                                    { "value": "FN", "label": "FN (first name)" },
-                                    { "value": "FI", "label": "FI (first name initial)" },
-                                    { "value": "CT", "label": "CT (city)" },
-                                    { "value": "ST", "label": "ST (state - US 2-letter, Others lowercase)" },
-                                    { "value": "ZIP", "label": "ZIP (zip code)" },
-                                    { "value": "COUNTRY", "label": "COUNTRY (country code - 2-letter)" },
-                                    { "value": "MADID", "label": "MADID (mobile advertiser ID)" },
-                                    { "value": "EXTERN_ID", "label": "EXTERN_ID (your own ID)" }
+                                    {
+                                        "value": "EMAIL",
+                                        "label": "EMAIL (email address)"
+                                    },
+                                    {
+                                        "value": "PHONE",
+                                        "label": "PHONE (phone number)"
+                                    },
+                                    {
+                                        "value": "GEN",
+                                        "label": "GEN (gender - m|f)"
+                                    },
+                                    {
+                                        "value": "DOBY",
+                                        "label": "DOBY (birth year - YYYY)"
+                                    },
+                                    {
+                                        "value": "DOBM",
+                                        "label": "DOBM (birth month - MM - 01 to 12)"
+                                    },
+                                    {
+                                        "value": "DOBD",
+                                        "label": "DOBD (birthday - DD - 01 to 31)"
+                                    },
+                                    {
+                                        "value": "LN",
+                                        "label": "LN (last name)"
+                                    },
+                                    {
+                                        "value": "FN",
+                                        "label": "FN (first name)"
+                                    },
+                                    {
+                                        "value": "FI",
+                                        "label": "FI (first name initial)"
+                                    },
+                                    {
+                                        "value": "CT",
+                                        "label": "CT (city)"
+                                    },
+                                    {
+                                        "value": "ST",
+                                        "label": "ST (state - US 2-letter, Others lowercase)"
+                                    },
+                                    {
+                                        "value": "ZIP",
+                                        "label": "ZIP (zip code)"
+                                    },
+                                    {
+                                        "value": "COUNTRY",
+                                        "label": "COUNTRY (country code - 2-letter)"
+                                    },
+                                    {
+                                        "value": "MADID",
+                                        "label": "MADID (mobile advertiser ID)"
+                                    },
+                                    {
+                                        "value": "EXTERN_ID",
+                                        "label": "EXTERN_ID (your own ID)"
+                                    }
                                 ]
                             }
                         }
@@ -114,30 +173,45 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [{
-            "value": "audience_id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "account_id",
-            "label": "Account ID",
-            "schema": { "type": "string" }
-        }, {
-            "value": "invalid_entry_samples",
-            "label": "Invalid Entry Samples",
-            "schema": { "type": "array" }
-        }, {
-            "value": "num_invalid_entries",
-            "label": "Number of Invalid Entries",
-            "schema": { "type": "integer" }
-        }, {
-            "value": "num_total_entries",
-            "label": "Number of Entries",
-            "schema": { "type": "integer" }
-        }]
+            "name": "out",
+            "options": [
+                {
+                    "value": "audience_id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "account_id",
+                    "label": "Account ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "value": "invalid_entry_samples",
+                    "label": "Invalid Entry Samples",
+                    "schema": {
+                        "type": "array"
+                    }
+                },
+                {
+                    "value": "num_invalid_entries",
+                    "label": "Number of Invalid Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                },
+                {
+                    "value": "num_total_entries",
+                    "label": "Number of Entries",
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }
-

--- a/src/appmixer/facebookbusiness/marketing/UpdateAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/UpdateAudience/component.json
@@ -5,8 +5,7 @@
     "auth": {
         "service": "appmixer:facebookbusiness",
         "scope": [
-            "ads_management",
-            "ads_read"
+            "ads_management"
         ]
     },
     "quota": {
@@ -22,12 +21,22 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "accountId": { "type": "string" },
-                    "audienceId": { "type": "string" },
-                    "name": { "type": "string" },
-                    "description": { "type": "string" }
+                    "accountId": {
+                        "type": "string"
+                    },
+                    "audienceId": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    }
                 },
-                "required": ["audienceId"]
+                "required": [
+                    "audienceId"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -76,16 +85,17 @@
     ],
     "outPorts": [
         {
-        "name": "out",
-        "options": [
-            {
-            "value": "id",
-            "label": "Audience ID",
-            "schema": { "type": "string" }
-        }
-        ]
+            "name": "out",
+            "options": [
+                {
+                    "value": "id",
+                    "label": "Audience ID",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9IjAgMCAyNjYuODkzIDI2Ni44OTUiPjxwYXRoIGQ9Ik0yNTIuMTY0IDI2Ni44OTVjOC4xMzQgMCAxNC43MjktNi41OTYgMTQuNzI5LTE0LjczVjE0LjczYzAtOC4xMzctNi41OTYtMTQuNzMtMTQuNzI5LTE0LjczSDE0LjczQzYuNTkzIDAgMCA2LjU5NCAwIDE0LjczdjIzNy40MzRjMCA4LjEzNSA2LjU5MyAxNC43MyAxNC43MyAxNC43M2gyMzcuNDM0eiIgZmlsbD0iIzQ4NWE5NiIvPjxwYXRoIGQ9Ik0xODQuMTUyIDI2Ni44OTVWMTYzLjUzOWgzNC42OTJsNS4xOTQtNDAuMjhoLTM5Ljg4N1Y5Ny41NDJjMC0xMS42NjIgMy4yMzgtMTkuNjA5IDE5Ljk2Mi0xOS42MDlsMjEuMzI5LS4wMVY0MS44OTdjLTMuNjg5LS40OS0xNi4zNTEtMS41ODctMzEuMDgtMS41ODctMzAuNzUzIDAtNTEuODA3IDE4Ljc3MS01MS44MDcgNTMuMjQ0djI5LjcwNWgtMzQuNzgxdjQwLjI4aDM0Ljc4MXYxMDMuMzU1aDQxLjU5N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4="
 }
-


### PR DESCRIPTION
## Summary

Removes `ads_read` scope from all 11 facebookbusiness marketing components.

## Reason

Meta App Review rejected the app submission with the message: *"We have determined that your app's use case for the requested permission or feature is invalid or is not needed to support its core functionality."*

`ads_management` is a superset of `ads_read` — it already grants full read+write access to ads objects including custom audiences. `ads_read` is redundant and unnecessary for this connector's use case.

## Changes

- Removed `ads_read` from `auth.scope` in all 11 component.jsons:
  - AddMemberToAudience
  - AddMembersFromCSVToAudience
  - CreateAudience
  - DeleteAudience
  - GetAdAccounts
  - GetCampaigns
  - GetCustomAudiences
  - RemoveMemberFromAudience
  - RemoveMembersInCSVFromAudience
  - ReplaceMembersFromCSVInAudience
  - UpdateAudience
- Bumped `bundle.json` version `2.1.1` → `2.2.0`

## ⚠️ Breaking Change

Changing the OAuth scope requires users to **re-authenticate** to get a new token with the updated scope set.