### PR TITLE
googleAds: move developerToken to backoffice, keep loginCustomerId as user input

### DIFF
--- a/src/appmixer/googleAds/artifacts/google-ads-api-design-documentation.md
+++ b/src/appmixer/googleAds/artifacts/google-ads-api-design-documentation.md
@@ -1,0 +1,91 @@
+# Appmixer – Google Ads Integration Design Documentation
+
+## 1. Company Overview
+
+Appmixer is a white-labeled embedded iPaaS (Integration Platform as a Service) with a workflow automation engine and no-code workflow designer. It enables businesses to automate workflows by connecting various cloud services. Appmixer provides a JavaScript SDK, drag-and-drop flow builder, and 100+ pre-built connectors.
+
+More info: https://docs.appmixer.com
+
+## 2. Google Ads Integration Overview
+
+The Appmixer Google Ads connector enables customers to manage **Customer Match audience lists** (user lists) through automated workflows. It uses the **Google Ads API v23** (REST).
+
+The connector does **not** create or manage campaigns, ads, keywords, or budgets. It focuses exclusively on audience list management for Customer Match workflows.
+
+## 3. Authentication
+
+The connector uses **OAuth 2.0** authorization code flow:
+
+1. User clicks "Connect Google Ads" in the Appmixer UI
+2. User is redirected to Google's consent screen
+3. User grants access to their Google Ads account
+4. Appmixer receives an authorization code and exchanges it for access/refresh tokens
+5. Tokens are securely stored and automatically refreshed
+
+**Scopes requested:** `profile`, `email`, plus Google Ads API access.
+
+Each API request includes:
+- `Authorization: Bearer <access_token>` — identifies the user
+- `developer-token` header — identifies the Appmixer application
+- `login-customer-id` header — identifies the manager account (when applicable)
+
+## 4. Components / Features
+
+The connector provides the following components, all operating on Google Ads **User Lists** (Customer Match audiences):
+
+| Component | Description | API Endpoint |
+|-----------|-------------|--------------|
+| **ListAccessibleCustomers** | Lists all Google Ads customer accounts accessible to the authenticated user | `GET /customers:listAccessibleCustomers` |
+| **CreateUserList** | Creates a new CRM-based user list | `POST /customers/{customerId}/userLists:mutate` |
+| **GetUserList** | Retrieves a single user list by resource name | `POST /customers/{customerId}/googleAds:searchStream` |
+| **FindUserLists** | Searches for user lists with optional filters | `POST /customers/{customerId}/googleAds:searchStream` |
+| **UpdateUserList** | Updates user list name, description, or membership lifespan | `POST /customers/{customerId}/userLists:mutate` |
+| **DeleteUserList** | Removes a user list | `POST /customers/{customerId}/userLists:mutate` |
+| **AddUserToUserList** | Adds a single user (by email, phone, name, etc.) to a user list via OfflineUserDataJob | `POST /customers/{customerId}/offlineUserDataJobs` |
+| **RemoveUserFromUserList** | Removes a single user from a user list via OfflineUserDataJob | `POST /customers/{customerId}/offlineUserDataJobs` |
+| **AddUsersFromCSVToUserList** | Bulk adds users from a CSV file to a user list | `POST /customers/{customerId}/offlineUserDataJobs` |
+| **RemoveUsersInCSVFromUserList** | Bulk removes users listed in a CSV file from a user list | `POST /customers/{customerId}/offlineUserDataJobs` |
+
+## 5. Architecture
+
+```
+┌─────────────────────┐
+│   End User Browser   │
+│  (Appmixer Flow UI)  │
+└──────────┬──────────┘
+           │ HTTPS
+           ▼
+┌─────────────────────┐
+│   Appmixer Engine    │
+│  (Workflow Runtime)  │
+└──────────┬──────────┘
+           │ HTTPS (REST)
+           ▼
+┌─────────────────────┐
+│  Google Ads API v23  │
+│  googleads.googleapis│
+│        .com          │
+└─────────────────────┘
+```
+
+1. User builds an automation workflow in the Appmixer drag-and-drop designer
+2. The workflow triggers component execution in the Appmixer engine
+3. Each component makes authenticated REST API calls to Google Ads API v23
+4. Results are returned to the workflow for further processing or output
+
+## 6. Data Handling
+
+- **User identifiers** (emails, phone numbers) are **SHA-256 hashed** before being sent to Google Ads API, in compliance with Customer Match requirements
+- CSV files with user data are processed server-side and streamed in batches
+- No Google Ads data is stored permanently — it is processed within the workflow execution context
+- OAuth tokens are stored encrypted on the Appmixer platform
+
+## 7. API Usage Summary
+
+The connector exclusively uses:
+- **Customer Service** — `listAccessibleCustomers`
+- **GoogleAdsService** — `searchStream` (GAQL queries for user lists)
+- **UserListService** — `mutate` (create, update, remove)
+- **OfflineUserDataJobService** — `create`, `addOperations`, `run` (Customer Match uploads)
+
+No campaign, ad group, ad, keyword, billing, or reporting endpoints are used.

--- a/src/appmixer/googleAds/artifacts/test-flows/test-flow-userlist-crud.json
+++ b/src/appmixer/googleAds/artifacts/test-flows/test-flow-userlist-crud.json
@@ -50,12 +50,6 @@
                                             },
                                             {
                                                 "type": "text",
-                                                "name": "developerToken",
-                                                "toggle": false,
-                                                "text": "TODO"
-                                            },
-                                            {
-                                                "type": "text",
                                                 "name": "userListName",
                                                 "text": "E2E Test Audience - {{{4923f55b-3b3a-4007-95bc-f91cf4030e82}}}"
                                             },
@@ -99,12 +93,6 @@
                                             "functions": []
                                         }
                                     },
-                                    "developerToken": {
-                                        "var-developer-token": {
-                                            "variable": "$.set-variables.out.developerToken",
-                                            "functions": []
-                                        }
-                                    },
                                     "name": {
                                         "var-user-list-name": {
                                             "variable": "$.set-variables.out.userListName",
@@ -116,7 +104,6 @@
                                 },
                                 "lambda": {
                                     "customerId": "{{{var-customer-id}}}",
-                                    "developerToken": "{{{var-developer-token}}}",
                                     "name": "{{{var-user-list-name}}}",
                                     "description": "E2E test user list - safe to delete",
                                     "membershipLifeSpan": 30
@@ -194,12 +181,6 @@
                                             "functions": []
                                         }
                                     },
-                                    "developerToken": {
-                                        "var-developer-token-find": {
-                                            "variable": "$.set-variables.out.developerToken",
-                                            "functions": []
-                                        }
-                                    },
                                     "searchQuery": {
                                         "a8e06f05-08ee-4e59-8796-60bdd45ea9ad": {
                                             "variable": "$.set-variables.out.userListName",
@@ -210,7 +191,6 @@
                                 },
                                 "lambda": {
                                     "customerId": "{{{var-customer-id-find}}}",
-                                    "developerToken": "{{{var-developer-token-find}}}",
                                     "searchQuery": "SELECT user_list.id, user_list.name, user_list.resource_name FROM user_list WHERE user_list.name = '{{{a8e06f05-08ee-4e59-8796-60bdd45ea9ad}}}'",
                                     "outputType": "first"
                                 }
@@ -288,12 +268,6 @@
                                             "functions": []
                                         }
                                     },
-                                    "developerToken": {
-                                        "var-developer-token-get": {
-                                            "variable": "$.set-variables.out.developerToken",
-                                            "functions": []
-                                        }
-                                    },
                                     "userListId": {
                                         "var-user-list-id-get": {
                                             "variable": "$.find-user-lists.out.id",
@@ -303,7 +277,6 @@
                                 },
                                 "lambda": {
                                     "customerId": "{{{var-customer-id-get}}}",
-                                    "developerToken": "{{{var-developer-token-get}}}",
                                     "userListId": "{{{var-user-list-id-get}}}"
                                 }
                             }
@@ -380,12 +353,6 @@
                                             "functions": []
                                         }
                                     },
-                                    "developerToken": {
-                                        "var-developer-token-add": {
-                                            "variable": "$.set-variables.out.developerToken",
-                                            "functions": []
-                                        }
-                                    },
                                     "userListId": {
                                         "var-user-list-id-add": {
                                             "variable": "$.find-user-lists.out.id",
@@ -404,7 +371,6 @@
                                 },
                                 "lambda": {
                                     "customerId": "{{{var-customer-id-add}}}",
-                                    "developerToken": "{{{var-developer-token-add}}}",
                                     "userListId": "{{{var-user-list-id-add}}}",
                                     "email": "{{{var-test-email}}}",
                                     "operation": "create",
@@ -511,12 +477,6 @@
                                             "functions": []
                                         }
                                     },
-                                    "developerToken": {
-                                        "var-developer-token-del": {
-                                            "variable": "$.set-variables.out.developerToken",
-                                            "functions": []
-                                        }
-                                    },
                                     "userListId": {
                                         "var-user-list-id-del": {
                                             "variable": "$.find-user-lists.out.id",
@@ -526,7 +486,6 @@
                                 },
                                 "lambda": {
                                     "customerId": "{{{var-customer-id-del}}}",
-                                    "developerToken": "{{{var-developer-token-del}}}",
                                     "userListId": "{{{var-user-list-id-del}}}"
                                 }
                             }

--- a/src/appmixer/googleAds/artifacts/test/AddUserToUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/AddUserToUserList.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const AddUserToUserList = require('../../core/AddUserToUserList/AddUserToUserList');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('AddUserToUserList', () => {
 
@@ -11,6 +12,7 @@ describe('AddUserToUserList', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
     describe('Required inputs validation', () => {
@@ -27,15 +29,16 @@ describe('AddUserToUserList', () => {
             });
         });
 
-        it('throws when developerToken is missing', async () => {
+        it('throws when developer token is missing in backoffice config', async () => {
             context.messages.in.content = {
                 customerId: '7107133715',
                 userListId: '12345',
                 email: 'test@example.com'
             };
+            context.config = {};
 
             await assert.rejects(() => AddUserToUserList.receive(context), {
-                message: 'Developer Token is required!'
+                message: 'Developer Token is required in backoffice config!'
             });
         });
 

--- a/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
@@ -95,9 +95,13 @@ describe('AddUsersFromCSVToUserList', () => {
             context.messages.in.content = {
                 fileId: 'file-abc',
                 customerId: '7123133715',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.config = {};
+
+            // Stub file read so CSV parsing succeeds before buildHeaders is called
+            context.getFileReadStream = sinon.stub().resolves(csvStream(emailCsv([{ email: 'a@b.com' }])));
 
             await assert.rejects(() => AddUsersFromCSVToUserList.receive(context), {
                 message: 'Developer Token is required in backoffice config!'
@@ -215,8 +219,8 @@ describe('AddUsersFromCSVToUserList', () => {
             assert.strictEqual(headers['developer-token'], 'dev-token');
         });
 
-        it('sets login-customer-id header from backoffice config', async () => {
-            context.config.loginCustomerId = '999-888-7777';
+        it('sets login-customer-id header from user input', async () => {
+            context.messages.in.content.loginCustomerId = '999-888-7777';
 
             await AddUsersFromCSVToUserList.receive(context);
 
@@ -226,12 +230,15 @@ describe('AddUsersFromCSVToUserList', () => {
             assert.strictEqual(createJobCall.args[0].headers['login-customer-id'], '9998887777');
         });
 
-        it('throws when loginCustomerId is missing in backoffice config', async () => {
-            delete context.config.loginCustomerId;
+        it('omits login-customer-id header when not provided', async () => {
+            delete context.messages.in.content.loginCustomerId;
 
-            await assert.rejects(() => AddUsersFromCSVToUserList.receive(context), {
-                message: 'Login Customer ID is required in backoffice config!'
-            });
+            await AddUsersFromCSVToUserList.receive(context);
+
+            const createJobCall = context.httpRequest.getCalls()
+                .find(c => c.args[0].url.includes('offlineUserDataJobs') && !c.args[0].url.includes(':addOperations') && !c.args[0].url.includes(':run'));
+
+            assert.strictEqual(createJobCall.args[0].headers['login-customer-id'], undefined);
         });
     });
 

--- a/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/AddUsersFromCSVToUserList.test.js
@@ -6,6 +6,7 @@ const testUtils = require('../../../../../test/utils');
 const AddUsersFromCSVToUserList = require('../../core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList');
 const {
     BASIC_EMAIL_SCHEMA,
+    applyGoogleAdsConfig,
     csvStream,
     emailCsv,
     googleAdsSchema,
@@ -56,7 +57,7 @@ describe('AddUsersFromCSVToUserList', () => {
         context.messages = { in: { content: {} } };
         context.clearTimeout = sinon.stub().resolves();
         context.auth = { accessToken: 'test-access-token' };
-        context.config = {};
+        applyGoogleAdsConfig(context);
         context.setTimeout = sinon.stub().resolves('timeout-id-1');
     });
 
@@ -90,15 +91,16 @@ describe('AddUsersFromCSVToUserList', () => {
             });
         });
 
-        it('throws when developerToken is missing', async () => {
+        it('throws when developer token is missing in backoffice config', async () => {
             context.messages.in.content = {
                 fileId: 'file-abc',
                 customerId: '7123133715',
                 userListId: '9329730810'
             };
+            context.config = {};
 
             await assert.rejects(() => AddUsersFromCSVToUserList.receive(context), {
-                message: 'Developer Token is required!'
+                message: 'Developer Token is required in backoffice config!'
             });
         });
 
@@ -213,8 +215,8 @@ describe('AddUsersFromCSVToUserList', () => {
             assert.strictEqual(headers['developer-token'], 'dev-token');
         });
 
-        it('sets login-customer-id header when loginCustomerId is provided', async () => {
-            context.messages.in.content.loginCustomerId = '999-888-7777';
+        it('sets login-customer-id header from backoffice config', async () => {
+            context.config.loginCustomerId = '999-888-7777';
 
             await AddUsersFromCSVToUserList.receive(context);
 
@@ -224,13 +226,12 @@ describe('AddUsersFromCSVToUserList', () => {
             assert.strictEqual(createJobCall.args[0].headers['login-customer-id'], '9998887777');
         });
 
-        it('does not set login-customer-id header when loginCustomerId is absent', async () => {
-            await AddUsersFromCSVToUserList.receive(context);
+        it('throws when loginCustomerId is missing in backoffice config', async () => {
+            delete context.config.loginCustomerId;
 
-            const createJobCall = context.httpRequest.getCalls()
-                .find(c => c.args[0].url.includes('offlineUserDataJobs') && !c.args[0].url.includes(':addOperations') && !c.args[0].url.includes(':run'));
-
-            assert.ok(!('login-customer-id' in createJobCall.args[0].headers));
+            await assert.rejects(() => AddUsersFromCSVToUserList.receive(context), {
+                message: 'Login Customer ID is required in backoffice config!'
+            });
         });
     });
 

--- a/src/appmixer/googleAds/artifacts/test/CreateUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/CreateUserList.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const CreateUserList = require('../../core/CreateUserList/CreateUserList');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('CreateUserList', () => {
 
@@ -9,6 +10,7 @@ describe('CreateUserList', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
     it('throws when name is missing', async () => {

--- a/src/appmixer/googleAds/artifacts/test/DeleteUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/DeleteUserList.test.js
@@ -27,7 +27,8 @@ describe('DeleteUserList', () => {
 
     it('should require developer token in backoffice config', async () => {
         context.messages.in.content = {
-            customerId: '123'
+            customerId: '123',
+            userListId: '456'
         };
         context.config = {};
 
@@ -94,12 +95,12 @@ describe('DeleteUserList', () => {
         assert.strictEqual(context.sendJson.getCall(0).args[0].success, true);
     });
 
-    it('should use loginCustomerId from backoffice config', async () => {
+    it('should use loginCustomerId from user input', async () => {
         context.messages.in.content = {
             customerId: '7107133715',
+            loginCustomerId: '5338559342',
             userListId: '123456'
         };
-        context.config.loginCustomerId = '5338559342';
 
         context.httpRequest.resolves({
             data: { results: [] }

--- a/src/appmixer/googleAds/artifacts/test/DeleteUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/DeleteUserList.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const DeleteUserList = require('../../core/DeleteUserList/DeleteUserList.js');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('DeleteUserList', () => {
 
@@ -11,6 +12,7 @@ describe('DeleteUserList', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
     it('should require Customer ID', async () => {
@@ -23,13 +25,14 @@ describe('DeleteUserList', () => {
         });
     });
 
-    it('should require Developer Token', async () => {
+    it('should require developer token in backoffice config', async () => {
         context.messages.in.content = {
             customerId: '123'
         };
+        context.config = {};
 
         await assert.rejects(() => DeleteUserList.receive(context), {
-            message: 'Developer Token is required!'
+            message: 'Developer Token is required in backoffice config!'
         });
     });
 
@@ -91,13 +94,12 @@ describe('DeleteUserList', () => {
         assert.strictEqual(context.sendJson.getCall(0).args[0].success, true);
     });
 
-    it('should accept loginCustomerId parameter', async () => {
+    it('should use loginCustomerId from backoffice config', async () => {
         context.messages.in.content = {
             customerId: '7107133715',
-            developerToken: 'test-token',
-            loginCustomerId: '5338559342',
             userListId: '123456'
         };
+        context.config.loginCustomerId = '5338559342';
 
         context.httpRequest.resolves({
             data: { results: [] }

--- a/src/appmixer/googleAds/artifacts/test/FindUserLists.test.js
+++ b/src/appmixer/googleAds/artifacts/test/FindUserLists.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const FindUserLists = require('../../core/FindUserLists/FindUserLists');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('FindUserLists', () => {
 
@@ -13,21 +14,23 @@ describe('FindUserLists', () => {
         beforeEach(() => {
             context = testUtils.createMockContext();
             context.messages = { in: { content: {} } };
+            applyGoogleAdsConfig(context);
         });
 
         it('throws when customerId is missing', async () => {
-            context.messages.in.content = { developerToken: 'dev-token' };
+            context.messages.in.content = {};
 
             await assert.rejects(() => FindUserLists.receive(context), {
                 message: 'Customer ID is required!'
             });
         });
 
-        it('throws when developerToken is missing', async () => {
+        it('throws when developer token is missing in backoffice config', async () => {
             context.messages.in.content = { customerId: '123-456-7890' };
+            context.config = {};
 
             await assert.rejects(() => FindUserLists.receive(context), {
-                message: 'Developer Token is required!'
+                message: 'Developer Token is required in backoffice config!'
             });
         });
     });
@@ -39,6 +42,7 @@ describe('FindUserLists', () => {
         beforeEach(() => {
             context = testUtils.createMockContext();
             context.messages = { in: { content: {} } };
+            applyGoogleAdsConfig(context);
         });
 
         it('returns notFound when no user lists match (outputType=array)', async () => {
@@ -187,6 +191,7 @@ describe('FindUserLists', () => {
         beforeEach(() => {
             context = testUtils.createMockContext();
             context.messages = { in: { content: {} } };
+            applyGoogleAdsConfig(context);
         });
 
         it('uses default query when searchQuery is empty', async () => {
@@ -231,13 +236,12 @@ describe('FindUserLists', () => {
             assert.strictEqual(result.result[0].name, 'My Audience');
         });
 
-        it('supports loginCustomerId for cross-account access', async () => {
+        it('supports loginCustomerId from backoffice config for cross-account access', async () => {
             context.messages.in.content = {
                 customerId: '123-456-7890',
-                developerToken: 'dev-token',
-                loginCustomerId: '9999999999',
                 outputType: 'array'
             };
+            context.config.loginCustomerId = '9999999999';
             context.httpRequest.resolves({
                 data: [{
                     results: [
@@ -266,6 +270,7 @@ describe('FindUserLists', () => {
             context = testUtils.createMockContext();
             context.messages = { in: { content: { outputType: 'array' } } };
             context.properties = { generateOutputPortOptions: true };
+            applyGoogleAdsConfig(context);
         });
 
         it('generates output port options', async () => {

--- a/src/appmixer/googleAds/artifacts/test/GetUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/GetUserList.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const GetUserList = require('../../core/GetUserList/GetUserList');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('GetUserList', () => {
 
@@ -9,6 +10,7 @@ describe('GetUserList', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
     it('throws when userListId is missing', async () => {

--- a/src/appmixer/googleAds/artifacts/test/ListAccessibleCustomers.test.js
+++ b/src/appmixer/googleAds/artifacts/test/ListAccessibleCustomers.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const ListAccessibleCustomers = require('../../core/ListAccessibleCustomers/ListAccessibleCustomers');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('ListAccessibleCustomers', () => {
 
@@ -9,11 +10,14 @@ describe('ListAccessibleCustomers', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
-    it('throws when developerToken is missing', async () => {
+    it('throws when developer token is missing in backoffice config', async () => {
+        context.config = {};
+
         await assert.rejects(() => ListAccessibleCustomers.receive(context), {
-            message: 'Developer Token is required!'
+            message: 'Developer Token is required in backoffice config!'
         });
     });
 

--- a/src/appmixer/googleAds/artifacts/test/RemoveUserFromUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/RemoveUserFromUserList.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const RemoveUserFromUserList = require('../../core/RemoveUserFromUserList/RemoveUserFromUserList');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('RemoveUserFromUserList', () => {
 
@@ -11,6 +12,7 @@ describe('RemoveUserFromUserList', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
     describe('Required inputs validation', () => {
@@ -27,15 +29,16 @@ describe('RemoveUserFromUserList', () => {
             });
         });
 
-        it('throws when developerToken is missing', async () => {
+        it('throws when developer token is missing in backoffice config', async () => {
             context.messages.in.content = {
                 customerId: '7107133715',
                 userListId: '12345',
                 email: 'test@example.com'
             };
+            context.config = {};
 
             await assert.rejects(() => RemoveUserFromUserList.receive(context), {
-                message: 'Developer Token is required!'
+                message: 'Developer Token is required in backoffice config!'
             });
         });
 

--- a/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
@@ -6,6 +6,7 @@ const testUtils = require('../../../../../test/utils');
 const RemoveUsersInCSVFromUserList = require('../../core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList');
 const {
     BASIC_EMAIL_SCHEMA,
+    applyGoogleAdsConfig,
     csvStream,
     emailCsv,
     googleAdsSchema,
@@ -53,7 +54,7 @@ describe('RemoveUsersInCSVFromUserList', () => {
         context.messages = { in: { content: {} } };
         context.clearTimeout = sinon.stub().resolves();
         context.auth = { accessToken: 'test-access-token' };
-        context.config = {};
+        applyGoogleAdsConfig(context);
         context.setTimeout = sinon.stub().resolves('timeout-id-1');
     });
 
@@ -87,15 +88,16 @@ describe('RemoveUsersInCSVFromUserList', () => {
             });
         });
 
-        it('throws when developerToken is missing', async () => {
+        it('throws when developer token is missing in backoffice config', async () => {
             context.messages.in.content = {
                 fileId: 'file-abc',
                 customerId: '7122133715',
                 userListId: '9329730810'
             };
+            context.config = {};
 
             await assert.rejects(() => RemoveUsersInCSVFromUserList.receive(context), {
-                message: 'Developer Token is required!'
+                message: 'Developer Token is required in backoffice config!'
             });
         });
 
@@ -208,8 +210,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
             assert.strictEqual(headers['developer-token'], 'dev-token');
         });
 
-        it('sets login-customer-id header when loginCustomerId is provided', async () => {
-            context.messages.in.content.loginCustomerId = '999-888-7777';
+        it('sets login-customer-id header from backoffice config', async () => {
+            context.config.loginCustomerId = '999-888-7777';
 
             await RemoveUsersInCSVFromUserList.receive(context);
 
@@ -219,13 +221,12 @@ describe('RemoveUsersInCSVFromUserList', () => {
             assert.strictEqual(createJobCall.args[0].headers['login-customer-id'], '9998887777');
         });
 
-        it('does not set login-customer-id header when loginCustomerId is absent', async () => {
-            await RemoveUsersInCSVFromUserList.receive(context);
+        it('throws when loginCustomerId is missing in backoffice config', async () => {
+            delete context.config.loginCustomerId;
 
-            const createJobCall = context.httpRequest.getCalls()
-                .find(c => c.args[0].url.includes('offlineUserDataJobs') && !c.args[0].url.includes(':addOperations') && !c.args[0].url.includes(':run'));
-
-            assert.ok(!('login-customer-id' in createJobCall.args[0].headers));
+            await assert.rejects(() => RemoveUsersInCSVFromUserList.receive(context), {
+                message: 'Login Customer ID is required in backoffice config!'
+            });
         });
     });
 

--- a/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/RemoveUsersInCSVFromUserList.test.js
@@ -92,9 +92,13 @@ describe('RemoveUsersInCSVFromUserList', () => {
             context.messages.in.content = {
                 fileId: 'file-abc',
                 customerId: '7122133715',
-                userListId: '9329730810'
+                userListId: '9329730810',
+                schema: BASIC_EMAIL_SCHEMA
             };
             context.config = {};
+
+            // Stub file read so CSV parsing succeeds before buildHeaders is called
+            context.getFileReadStream = sinon.stub().resolves(csvStream(emailCsv([{ email: 'a@b.com' }])));
 
             await assert.rejects(() => RemoveUsersInCSVFromUserList.receive(context), {
                 message: 'Developer Token is required in backoffice config!'
@@ -210,8 +214,8 @@ describe('RemoveUsersInCSVFromUserList', () => {
             assert.strictEqual(headers['developer-token'], 'dev-token');
         });
 
-        it('sets login-customer-id header from backoffice config', async () => {
-            context.config.loginCustomerId = '999-888-7777';
+        it('sets login-customer-id header from user input', async () => {
+            context.messages.in.content.loginCustomerId = '999-888-7777';
 
             await RemoveUsersInCSVFromUserList.receive(context);
 
@@ -221,12 +225,15 @@ describe('RemoveUsersInCSVFromUserList', () => {
             assert.strictEqual(createJobCall.args[0].headers['login-customer-id'], '9998887777');
         });
 
-        it('throws when loginCustomerId is missing in backoffice config', async () => {
-            delete context.config.loginCustomerId;
+        it('omits login-customer-id header when not provided', async () => {
+            delete context.messages.in.content.loginCustomerId;
 
-            await assert.rejects(() => RemoveUsersInCSVFromUserList.receive(context), {
-                message: 'Login Customer ID is required in backoffice config!'
-            });
+            await RemoveUsersInCSVFromUserList.receive(context);
+
+            const createJobCall = context.httpRequest.getCalls()
+                .find(c => c.args[0].url.includes('offlineUserDataJobs') && !c.args[0].url.includes(':addOperations') && !c.args[0].url.includes(':run'));
+
+            assert.strictEqual(createJobCall.args[0].headers['login-customer-id'], undefined);
         });
     });
 

--- a/src/appmixer/googleAds/artifacts/test/UpdateUserList.test.js
+++ b/src/appmixer/googleAds/artifacts/test/UpdateUserList.test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const testUtils = require('../../../../../test/utils');
 const UpdateUserList = require('../../core/UpdateUserList/UpdateUserList');
+const { applyGoogleAdsConfig } = require('./helpers');
 
 describe('UpdateUserList', () => {
 
@@ -11,6 +12,7 @@ describe('UpdateUserList', () => {
     beforeEach(() => {
         context = testUtils.createMockContext();
         context.messages = { in: { content: {} } };
+        applyGoogleAdsConfig(context);
     });
 
     describe('Required inputs validation', () => {
@@ -27,15 +29,16 @@ describe('UpdateUserList', () => {
             });
         });
 
-        it('throws when developerToken is missing', async () => {
+        it('throws when developer token is missing in backoffice config', async () => {
             context.messages.in.content = {
                 customerId: '7107133715',
                 userListId: '12345',
                 name: 'Updated Name'
             };
+            context.config = {};
 
             await assert.rejects(() => UpdateUserList.receive(context), {
-                message: 'Developer Token is required!'
+                message: 'Developer Token is required in backoffice config!'
             });
         });
 

--- a/src/appmixer/googleAds/artifacts/test/helpers.js
+++ b/src/appmixer/googleAds/artifacts/test/helpers.js
@@ -87,7 +87,6 @@ function applyGoogleAdsConfig(context, overrides = {}) {
     context.config = {
         ...(context.config || {}),
         developerToken: 'dev-token',
-        loginCustomerId: '9999999999',
         ...overrides
     };
 

--- a/src/appmixer/googleAds/artifacts/test/helpers.js
+++ b/src/appmixer/googleAds/artifacts/test/helpers.js
@@ -83,9 +83,21 @@ const BASIC_EMAIL_SCHEMA = googleAdsSchema([
     { csvHeader: 'email', googleAdsType: 'email' }
 ]);
 
+function applyGoogleAdsConfig(context, overrides = {}) {
+    context.config = {
+        ...(context.config || {}),
+        developerToken: 'dev-token',
+        loginCustomerId: '9999999999',
+        ...overrides
+    };
+
+    return context;
+}
+
 module.exports = {
     BASIC_EMAIL_SCHEMA,
     SHARED_CSV_HEADER,
+    applyGoogleAdsConfig,
     csvStream,
     emailCsv,
     googleAdsSchema,

--- a/src/appmixer/googleAds/bundle.json
+++ b/src/appmixer/googleAds/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.googleAds",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "changelog": {
         "1.0.0": [
             "Initial Google Ads release with user list and Customer Match workflow components."
@@ -10,6 +10,9 @@
         ],
         "1.2.0": [
             "Added explicit schema mapping for CSV uploads."
+        ],
+        "1.2.1": [
+            "Move Developer Token from individual components to backoffice config. Add tooltip for Login Customer ID."
         ]
     }
 }

--- a/src/appmixer/googleAds/core/AddUserToUserList/AddUserToUserList.js
+++ b/src/appmixer/googleAds/core/AddUserToUserList/AddUserToUserList.js
@@ -8,7 +8,6 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             userListId,
             userListResourceName,
@@ -26,7 +25,6 @@ module.exports = {
         } = context.messages.in.content;
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
 
         // Resolve user list resource name from either explicit resource name or numeric ID
         const normalizedCustomerId = lib.normalizeCustomerId(customerId);
@@ -116,7 +114,7 @@ module.exports = {
         const { data } = await context.httpRequest({
             method: 'POST',
             url: `${lib.API_BASE_URL}/customers/${normalizedCustomerId}:uploadUserData`,
-            headers: lib.buildHeaders(context, { developerToken, loginCustomerId }),
+            headers: lib.buildHeaders(context, { loginCustomerId }),
             data: requestBody
         });
 

--- a/src/appmixer/googleAds/core/AddUserToUserList/component.json
+++ b/src/appmixer/googleAds/core/AddUserToUserList/component.json
@@ -79,7 +79,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/core/AddUserToUserList/component.json
+++ b/src/appmixer/googleAds/core/AddUserToUserList/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -69,8 +66,7 @@
                     }
                 },
                 "required": [
-                    "customerId",
-                    "developerToken"
+                    "customerId"
                 ]
             },
             "inspector": {
@@ -80,82 +76,77 @@
                         "label": "Customer ID",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Required when authenticating via a manager (MCC) account.",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
                         "tooltip": "Numeric ID of the Customer Match user list. Use either User List ID or User List Resource Name.",
-                        "index": 4
+                        "index": 3
                     },
                     "userListResourceName": {
                         "type": "text",
                         "label": "User List Resource Name",
                         "tooltip": "Full resource name, e.g. customers/123/userLists/456. Use either this or User List ID.",
-                        "index": 5
+                        "index": 4
                     },
                     "email": {
                         "type": "text",
                         "label": "Email",
                         "tooltip": "Email address of the user. Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 6
+                        "index": 5
                     },
                     "phoneNumber": {
                         "type": "text",
                         "label": "Phone Number",
                         "tooltip": "Phone number in E.164 format (e.g., +1234567890). Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 7
+                        "index": 6
                     },
                     "firstName": {
                         "type": "text",
                         "label": "First Name",
                         "tooltip": "First name. Use with lastName and countryCode for address-based matching.",
-                        "index": 8
+                        "index": 7
                     },
                     "lastName": {
                         "type": "text",
                         "label": "Last Name",
                         "tooltip": "Last name. Use with firstName and countryCode for address-based matching.",
-                        "index": 9
+                        "index": 8
                     },
                     "countryCode": {
                         "type": "text",
                         "label": "Country Code",
                         "tooltip": "2-letter ISO-3166-1 alpha-2 country code (e.g., US, CA, GB). Use with firstName and lastName for address-based matching.",
-                        "index": 10
+                        "index": 9
                     },
                     "postalCode": {
                         "type": "text",
                         "label": "Postal Code",
                         "tooltip": "Postal/ZIP code. Optional with address-based matching.",
-                        "index": 11
+                        "index": 10
                     },
                     "mobileId": {
                         "type": "text",
                         "label": "Mobile Device ID",
                         "tooltip": "Mobile device ID (IDFA for iOS or Google Advertising ID for Android). Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 12
+                        "index": 11
                     },
                     "thirdPartyUserId": {
                         "type": "text",
                         "label": "Third Party User ID",
                         "tooltip": "Advertiser-assigned user ID. Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 13
+                        "index": 12
                     },
                     "operation": {
                         "type": "select",
                         "label": "Operation",
                         "tooltip": "Whether to add (create) or remove the user from the list.",
-                        "index": 14,
+                        "index": 13,
                         "defaultValue": "create",
                         "options": [
                             { "label": "Add (create)", "value": "create" },
@@ -166,7 +157,7 @@
                         "type": "select",
                         "label": "Ad User Data Consent",
                         "tooltip": "Consent status for use of user data for ads. Required for 'Add' operations.",
-                        "index": 15,
+                        "index": 14,
                         "options": [
                             { "label": "Unspecified", "value": "UNSPECIFIED" },
                             { "label": "Unknown", "value": "UNKNOWN" },
@@ -178,7 +169,7 @@
                         "type": "select",
                         "label": "Ad Personalization Consent",
                         "tooltip": "Consent status for ad personalization. Required for 'Add' operations.",
-                        "index": 16,
+                        "index": 15,
                         "options": [
                             { "label": "Unspecified", "value": "UNSPECIFIED" },
                             { "label": "Unknown", "value": "UNKNOWN" },

--- a/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList.js
+++ b/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/AddUsersFromCSVToUserList.js
@@ -73,10 +73,10 @@ function buildOperation(row, schemaConfig, adPersonalization, adUserData) {
 // ---------------------------------------------------------------------------
 
 async function createOfflineUserDataJob(context, {
-    customerId, developerToken, loginCustomerId, userListResourceName, uploadMode
+    customerId, loginCustomerId, userListResourceName, uploadMode
 }) {
     const normCustomerId = normId(customerId);
-    const headers = lib.buildHeaders(context, { developerToken, loginCustomerId });
+    const headers = lib.buildHeaders(context, { loginCustomerId });
 
     const jobBody = {
         job: {
@@ -101,9 +101,9 @@ async function createOfflineUserDataJob(context, {
     return data.resourceName; // e.g. "customers/123/offlineUserDataJobs/456"
 }
 
-async function addOperations(context, { customerId, developerToken, loginCustomerId, jobResourceName, operations }) {
+async function addOperations(context, { customerId, loginCustomerId, jobResourceName, operations }) {
 
-    const headers = lib.buildHeaders(context, { developerToken, loginCustomerId });
+    const headers = lib.buildHeaders(context, { loginCustomerId });
 
     const { data } = await context.httpRequest({
         method: 'POST',
@@ -118,8 +118,8 @@ async function addOperations(context, { customerId, developerToken, loginCustome
     return data;
 }
 
-async function runOfflineUserDataJob(context, { customerId, developerToken, loginCustomerId, jobResourceName }) {
-    const headers = lib.buildHeaders(context, { developerToken, loginCustomerId });
+async function runOfflineUserDataJob(context, { customerId, loginCustomerId, jobResourceName }) {
+    const headers = lib.buildHeaders(context, { loginCustomerId });
 
     const { data } = await context.httpRequest({
         method: 'POST',
@@ -186,7 +186,6 @@ module.exports = {
             const input = context.messages.in.content;
 
             lib.ensureRequired(input.customerId, 'Customer ID is required!', context);
-            lib.ensureRequired(input.developerToken, 'Developer Token is required!', context);
             lib.ensureRequired(input.fileId, 'File is required!', context);
             lib.ensureRequired(input.userListId, 'User List ID is required!', context);
             lib.ensureRequired(input.schema, 'Schema is required!', context);
@@ -198,7 +197,6 @@ module.exports = {
             state = {
                 fileId: input.fileId,
                 customerId: input.customerId,
-                developerToken: input.developerToken,
                 loginCustomerId: input.loginCustomerId || null,
                 userListResourceName,
                 uploadMode: input.uploadMode || 'ADD',
@@ -252,7 +250,6 @@ module.exports = {
         if (!jobResourceName) {
             jobResourceName = await createOfflineUserDataJob(context, {
                 customerId: state.customerId,
-                developerToken: state.developerToken,
                 loginCustomerId: state.loginCustomerId,
                 userListResourceName: state.userListResourceName,
                 uploadMode: state.uploadMode
@@ -307,7 +304,6 @@ module.exports = {
             if (operations.length > 0) {
                 const result = await addOperations(context, {
                     customerId: state.customerId,
-                    developerToken: state.developerToken,
                     loginCustomerId: state.loginCustomerId,
                     jobResourceName,
                     operations
@@ -377,7 +373,6 @@ module.exports = {
             try {
                 runResult = await runOfflineUserDataJob(context, {
                     customerId: state.customerId,
-                    developerToken: state.developerToken,
                     loginCustomerId: state.loginCustomerId,
                     jobResourceName
                 });

--- a/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/component.json
+++ b/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/component.json
@@ -71,7 +71,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 3
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/component.json
+++ b/src/appmixer/googleAds/core/AddUsersFromCSVToUserList/component.json
@@ -25,9 +25,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -53,7 +50,6 @@
                 "required": [
                     "fileId",
                     "customerId",
-                    "developerToken",
                     "userListId",
                     "schema"
                 ]
@@ -72,29 +68,23 @@
                         "tooltip": "Google Ads customer ID (digits only, e.g. 1234567890). Hyphens are ignored.",
                         "index": 2
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "tooltip": "Your Google Ads API developer token.",
-                        "index": 3
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Required when authenticating via a manager (MCC) account. Leave blank if you are using the customer account directly.",
-                        "index": 4
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 3
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
                         "tooltip": "Numeric ID of the Customer Match user list to upload users into.",
-                        "index": 5
+                        "index": 4
                     },
                     "uploadMode": {
                         "type": "select",
                         "label": "Upload Mode",
                         "tooltip": "ADD appends users to the list. REPLACE removes all existing users and replaces them with this upload.",
-                        "index": 6,
+                        "index": 5,
                         "defaultValue": "ADD",
                         "options": [
                             { "label": "Add (append)", "value": "ADD" },
@@ -104,7 +94,7 @@
                     "schema": {
                         "type": "expression",
                         "levels": ["ADD"],
-                        "index": 7,
+                        "index": 6,
                         "label": "Schema",
                         "tooltip": "Required mapping between CSV headers and Google Ads identifiers. This component does not infer identifiers from header names.",
                         "fields": {
@@ -134,14 +124,14 @@
                         "type": "text",
                         "label": "Column Separator",
                         "tooltip": "Character used to separate columns in the CSV file. Default is a comma (,).",
-                        "index": 8,
+                        "index": 7,
                         "defaultValue": ","
                     },
                     "adPersonalization": {
                         "type": "select",
                         "label": "Ad Personalization Consent",
                         "tooltip": "Consent status for ad personalization. Required by EU User Consent Policy.",
-                        "index": 9,
+                        "index": 8,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },
@@ -152,7 +142,7 @@
                         "type": "select",
                         "label": "Ad User Data Consent",
                         "tooltip": "Consent status for use of user data for ads. Required by EU User Consent Policy.",
-                        "index": 10,
+                        "index": 9,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },

--- a/src/appmixer/googleAds/core/CreateUserList/CreateUserList.js
+++ b/src/appmixer/googleAds/core/CreateUserList/CreateUserList.js
@@ -8,7 +8,6 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             name,
             description,
@@ -16,7 +15,6 @@ module.exports = {
         } = context.messages.in.content;
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
         lib.ensureRequired(name, 'Name is required!', context);
 
         const create = {
@@ -37,7 +35,7 @@ module.exports = {
         const { data } = await context.httpRequest({
             method: 'POST',
             url: `${lib.API_BASE_URL}/customers/${lib.normalizeCustomerId(customerId)}/userLists:mutate`,
-            headers: lib.buildHeaders(context, { developerToken, loginCustomerId }),
+            headers: lib.buildHeaders(context, { loginCustomerId }),
             data: {
                 operations: [
                     { create }

--- a/src/appmixer/googleAds/core/CreateUserList/component.json
+++ b/src/appmixer/googleAds/core/CreateUserList/component.json
@@ -50,7 +50,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "name": {

--- a/src/appmixer/googleAds/core/CreateUserList/component.json
+++ b/src/appmixer/googleAds/core/CreateUserList/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -40,7 +37,6 @@
                 },
                 "required": [
                     "customerId",
-                    "developerToken",
                     "name"
                 ]
             },
@@ -51,31 +47,27 @@
                         "label": "Customer ID",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "name": {
                         "type": "text",
                         "label": "User List Name",
-                        "index": 4
+                        "index": 3
                     },
                     "description": {
                         "type": "textarea",
                         "label": "Description",
-                        "index": 5
+                        "index": 4
                     },
                     "membershipLifeSpan": {
                         "type": "number",
                         "label": "Membership Life Span",
                         "tooltip": "Optional membership duration in days.",
-                        "index": 6
+                        "index": 5
                     }
                 }
             }

--- a/src/appmixer/googleAds/core/DeleteUserList/DeleteUserList.js
+++ b/src/appmixer/googleAds/core/DeleteUserList/DeleteUserList.js
@@ -8,14 +8,12 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             userListId,
             userListResourceName
         } = context.messages.in.content;
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
 
         // Resolve resource name from either userListId or userListResourceName
         let resourceName = userListResourceName;
@@ -28,7 +26,7 @@ module.exports = {
         const { data } = await context.httpRequest({
             method: 'POST',
             url: `${lib.API_BASE_URL}/customers/${lib.normalizeCustomerId(customerId)}/userLists:mutate`,
-            headers: lib.buildHeaders(context, { developerToken, loginCustomerId }),
+            headers: lib.buildHeaders(context, { loginCustomerId }),
             data: {
                 operations: [
                     { remove: resourceName }

--- a/src/appmixer/googleAds/core/DeleteUserList/component.json
+++ b/src/appmixer/googleAds/core/DeleteUserList/component.json
@@ -46,7 +46,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/core/DeleteUserList/component.json
+++ b/src/appmixer/googleAds/core/DeleteUserList/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -36,8 +33,7 @@
                     }
                 },
                 "required": [
-                    "customerId",
-                    "developerToken"
+                    "customerId"
                 ]
             },
             "inspector": {
@@ -47,27 +43,23 @@
                         "label": "Customer ID",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
-                        "tooltip": "The user list ID. Can alternatively provide userListResourceName.",
-                        "index": 4
+                        "tooltip": "Numeric user list ID. Can alternatively provide User List Resource Name.",
+                        "index": 3
                     },
                     "userListResourceName": {
                         "type": "text",
                         "label": "User List Resource Name",
                         "tooltip": "The full resource name (e.g., 'customers/7107133715/userLists/123'). Can alternatively provide userListId.",
-                        "index": 5
+                        "index": 4
                     }
                 }
             }

--- a/src/appmixer/googleAds/core/FindUserLists/FindUserLists.js
+++ b/src/appmixer/googleAds/core/FindUserLists/FindUserLists.js
@@ -34,7 +34,6 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             searchQuery,
             outputType = 'array'
@@ -48,11 +47,9 @@ module.exports = {
         }
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
 
         const rows = await lib.searchStream(context, {
             customerId,
-            developerToken,
             loginCustomerId,
             query: searchQuery || DEFAULT_QUERY
         });

--- a/src/appmixer/googleAds/core/FindUserLists/component.json
+++ b/src/appmixer/googleAds/core/FindUserLists/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -37,8 +34,7 @@
                     }
                 },
                 "required": [
-                    "customerId",
-                    "developerToken"
+                    "customerId"
                 ]
             },
             "inspector": {
@@ -49,28 +45,22 @@
                         "tooltip": "Google Ads customer ID, with or without dashes.",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "tooltip": "Google Ads API developer token.",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Optional manager account customer ID, with or without dashes.",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "searchQuery": {
                         "type": "textarea",
                         "label": "GAQL Query",
                         "tooltip": "Optional GAQL query override. Leave empty to use the default user list query. Example: WHERE user_list.name = 'My Audience'",
-                        "index": 4
+                        "index": 3
                     },
                     "outputType": {
                         "type": "select",
                         "label": "Output Type",
-                        "index": 5,
+                        "index": 4,
                         "defaultValue": "array",
                         "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
                         "options": [
@@ -94,9 +84,7 @@
                         "generateOutputPortOptions": true
                     },
                     "messages": {
-                        "in/outputType": "inputs/in/outputType",
-                        "in/customerId": "any",
-                        "in/developerToken": "any"
+                        "in/outputType": "inputs/in/outputType"
                     }
                 }
             }

--- a/src/appmixer/googleAds/core/FindUserLists/component.json
+++ b/src/appmixer/googleAds/core/FindUserLists/component.json
@@ -48,7 +48,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "searchQuery": {

--- a/src/appmixer/googleAds/core/GetUserList/GetUserList.js
+++ b/src/appmixer/googleAds/core/GetUserList/GetUserList.js
@@ -8,13 +8,11 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             userListId
         } = context.messages.in.content;
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
         lib.ensureRequired(userListId, 'User List ID is required!', context);
 
         const query = [
@@ -34,7 +32,6 @@ module.exports = {
 
         const rows = await lib.searchStream(context, {
             customerId,
-            developerToken,
             loginCustomerId,
             query
         });

--- a/src/appmixer/googleAds/core/GetUserList/component.json
+++ b/src/appmixer/googleAds/core/GetUserList/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -34,7 +31,6 @@
                 },
                 "required": [
                     "customerId",
-                    "developerToken",
                     "userListId"
                 ]
             },
@@ -45,20 +41,16 @@
                         "label": "Customer ID",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
-                        "index": 4
+                        "index": 3
                     }
                 }
             }
@@ -76,10 +68,10 @@
                     }
                 },
                 {
-                    "label": "Id",
+                    "label": "ID",
                     "value": "id",
                     "schema": {
-                        "type": "integer"
+                        "type": "string"
                     }
                 },
                 {

--- a/src/appmixer/googleAds/core/GetUserList/component.json
+++ b/src/appmixer/googleAds/core/GetUserList/component.json
@@ -44,7 +44,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/core/ListAccessibleCustomers/ListAccessibleCustomers.js
+++ b/src/appmixer/googleAds/core/ListAccessibleCustomers/ListAccessibleCustomers.js
@@ -6,14 +6,12 @@ module.exports = {
 
     async receive(context) {
 
-        const { developerToken, loginCustomerId } = context.messages.in.content;
-
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
+        const { loginCustomerId } = context.messages.in.content;
 
         const { data } = await context.httpRequest({
             method: 'GET',
             url: `${lib.API_BASE_URL}/customers:listAccessibleCustomers`,
-            headers: lib.buildHeaders(context, { developerToken, loginCustomerId })
+            headers: lib.buildHeaders(context, { loginCustomerId })
         });
 
         const resourceNames = data.resourceNames || [];

--- a/src/appmixer/googleAds/core/ListAccessibleCustomers/component.json
+++ b/src/appmixer/googleAds/core/ListAccessibleCustomers/component.json
@@ -19,30 +19,18 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     }
-                },
-                "required": [
-                    "developerToken"
-                ]
+                }
             },
             "inspector": {
                 "inputs": {
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "tooltip": "Google Ads API developer token.",
-                        "index": 1
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Optional manager account customer ID, with or without dashes.",
-                        "index": 2
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 1
                     }
                 }
             }

--- a/src/appmixer/googleAds/core/ListAccessibleCustomers/component.json
+++ b/src/appmixer/googleAds/core/ListAccessibleCustomers/component.json
@@ -29,7 +29,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 1
                     }
                 }

--- a/src/appmixer/googleAds/core/RemoveUserFromUserList/RemoveUserFromUserList.js
+++ b/src/appmixer/googleAds/core/RemoveUserFromUserList/RemoveUserFromUserList.js
@@ -8,7 +8,6 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             userListId,
             userListResourceName,
@@ -25,7 +24,6 @@ module.exports = {
         } = context.messages.in.content;
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
 
         // Resolve user list resource name from either explicit resource name or numeric ID
         const normalizedCustomerId = lib.normalizeCustomerId(customerId);
@@ -115,7 +113,7 @@ module.exports = {
         const { data } = await context.httpRequest({
             method: 'POST',
             url: `${lib.API_BASE_URL}/customers/${normalizedCustomerId}:uploadUserData`,
-            headers: lib.buildHeaders(context, { developerToken, loginCustomerId }),
+            headers: lib.buildHeaders(context, { loginCustomerId }),
             data: requestBody
         });
 

--- a/src/appmixer/googleAds/core/RemoveUserFromUserList/component.json
+++ b/src/appmixer/googleAds/core/RemoveUserFromUserList/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -66,8 +63,7 @@
                     }
                 },
                 "required": [
-                    "customerId",
-                    "developerToken"
+                    "customerId"
                 ]
             },
             "inspector": {
@@ -77,82 +73,77 @@
                         "label": "Customer ID",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Required when authenticating via a manager (MCC) account.",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
                         "tooltip": "Numeric ID of the Customer Match user list. Use either User List ID or User List Resource Name.",
-                        "index": 4
+                        "index": 3
                     },
                     "userListResourceName": {
                         "type": "text",
                         "label": "User List Resource Name",
                         "tooltip": "Full resource name, e.g. customers/123/userLists/456. Use either this or User List ID.",
-                        "index": 5
+                        "index": 4
                     },
                     "email": {
                         "type": "text",
                         "label": "Email",
                         "tooltip": "Email address of the user. Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 6
+                        "index": 5
                     },
                     "phoneNumber": {
                         "type": "text",
                         "label": "Phone Number",
                         "tooltip": "Phone number in E.164 format (e.g., +1234567890). Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 7
+                        "index": 6
                     },
                     "firstName": {
                         "type": "text",
                         "label": "First Name",
                         "tooltip": "First name. Use with lastName and countryCode for address-based matching.",
-                        "index": 8
+                        "index": 7
                     },
                     "lastName": {
                         "type": "text",
                         "label": "Last Name",
                         "tooltip": "Last name. Use with firstName and countryCode for address-based matching.",
-                        "index": 9
+                        "index": 8
                     },
                     "countryCode": {
                         "type": "text",
                         "label": "Country Code",
                         "tooltip": "2-letter ISO-3166-1 alpha-2 country code (e.g., US, CA, GB). Use with firstName and lastName for address-based matching.",
-                        "index": 10
+                        "index": 9
                     },
                     "postalCode": {
                         "type": "text",
                         "label": "Postal Code",
                         "tooltip": "Postal/ZIP code. Optional with address-based matching.",
-                        "index": 11
+                        "index": 10
                     },
                     "mobileId": {
                         "type": "text",
                         "label": "Mobile Device ID",
                         "tooltip": "Mobile device ID (IDFA for iOS or Google Advertising ID for Android). Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 12
+                        "index": 11
                     },
                     "thirdPartyUserId": {
                         "type": "text",
                         "label": "Third Party User ID",
                         "tooltip": "Advertiser-assigned user ID. Provide either email OR phone OR (firstName + lastName + countryCode) OR mobileId OR thirdPartyUserId.",
-                        "index": 13
+                        "index": 12
                     },
                     "adUserDataConsent": {
                         "type": "select",
                         "label": "Ad User Data Consent",
                         "tooltip": "User consent status for ad user data. Optional.",
-                        "index": 14,
+                        "index": 13,
                         "options": [
                             {
                                 "label": "Unspecified",
@@ -176,7 +167,7 @@
                         "type": "select",
                         "label": "Ad Personalization Consent",
                         "tooltip": "User consent status for ad personalization. Optional.",
-                        "index": 15,
+                        "index": 14,
                         "options": [
                             {
                                 "label": "Unspecified",

--- a/src/appmixer/googleAds/core/RemoveUserFromUserList/component.json
+++ b/src/appmixer/googleAds/core/RemoveUserFromUserList/component.json
@@ -76,7 +76,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList.js
+++ b/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/RemoveUsersInCSVFromUserList.js
@@ -71,10 +71,10 @@ function buildOperation(row, schemaConfig, adPersonalization, adUserData) {
 // ---------------------------------------------------------------------------
 
 async function createOfflineUserDataJob(context, {
-    customerId, developerToken, loginCustomerId, userListResourceName
+    customerId, loginCustomerId, userListResourceName
 }) {
     const normCustomerId = normId(customerId);
-    const headers = lib.buildHeaders(context, { developerToken, loginCustomerId });
+    const headers = lib.buildHeaders(context, { loginCustomerId });
 
     const jobBody = {
         job: {
@@ -95,9 +95,9 @@ async function createOfflineUserDataJob(context, {
     return data.resourceName; // e.g. "customers/123/offlineUserDataJobs/456"
 }
 
-async function addOperations(context, { customerId, developerToken, loginCustomerId, jobResourceName, operations }) {
+async function addOperations(context, { customerId, loginCustomerId, jobResourceName, operations }) {
 
-    const headers = lib.buildHeaders(context, { developerToken, loginCustomerId });
+    const headers = lib.buildHeaders(context, { loginCustomerId });
 
     const { data } = await context.httpRequest({
         method: 'POST',
@@ -112,8 +112,8 @@ async function addOperations(context, { customerId, developerToken, loginCustome
     return data;
 }
 
-async function runOfflineUserDataJob(context, { customerId, developerToken, loginCustomerId, jobResourceName }) {
-    const headers = lib.buildHeaders(context, { developerToken, loginCustomerId });
+async function runOfflineUserDataJob(context, { customerId, loginCustomerId, jobResourceName }) {
+    const headers = lib.buildHeaders(context, { loginCustomerId });
 
     const { data } = await context.httpRequest({
         method: 'POST',
@@ -180,7 +180,6 @@ module.exports = {
             const input = context.messages.in.content;
 
             lib.ensureRequired(input.customerId, 'Customer ID is required!', context);
-            lib.ensureRequired(input.developerToken, 'Developer Token is required!', context);
             lib.ensureRequired(input.fileId, 'File is required!', context);
             lib.ensureRequired(input.userListId, 'User List ID is required!', context);
             lib.ensureRequired(input.schema, 'Schema is required!', context);
@@ -192,7 +191,6 @@ module.exports = {
             state = {
                 fileId: input.fileId,
                 customerId: input.customerId,
-                developerToken: input.developerToken,
                 loginCustomerId: input.loginCustomerId || null,
                 userListResourceName,
                 schema: input.schema || null,
@@ -243,7 +241,6 @@ module.exports = {
         if (!jobResourceName) {
             jobResourceName = await createOfflineUserDataJob(context, {
                 customerId: state.customerId,
-                developerToken: state.developerToken,
                 loginCustomerId: state.loginCustomerId,
                 userListResourceName: state.userListResourceName
             });
@@ -299,7 +296,6 @@ module.exports = {
             if (operations.length > 0) {
                 const result = await addOperations(context, {
                     customerId: state.customerId,
-                    developerToken: state.developerToken,
                     loginCustomerId: state.loginCustomerId,
                     jobResourceName,
                     operations
@@ -369,7 +365,6 @@ module.exports = {
             try {
                 runResult = await runOfflineUserDataJob(context, {
                     customerId: state.customerId,
-                    developerToken: state.developerToken,
                     loginCustomerId: state.loginCustomerId,
                     jobResourceName
                 });

--- a/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/component.json
+++ b/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/component.json
@@ -68,7 +68,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 3
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/component.json
+++ b/src/appmixer/googleAds/core/RemoveUsersInCSVFromUserList/component.json
@@ -25,9 +25,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -50,7 +47,6 @@
                 "required": [
                     "fileId",
                     "customerId",
-                    "developerToken",
                     "userListId",
                     "schema"
                 ]
@@ -69,28 +65,22 @@
                         "tooltip": "Google Ads customer ID (digits only, e.g. 1234567890). Hyphens are ignored.",
                         "index": 2
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "tooltip": "Your Google Ads API developer token.",
-                        "index": 3
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Required when authenticating via a manager (MCC) account. Leave blank if you are using the customer account directly.",
-                        "index": 4
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 3
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
                         "tooltip": "Numeric ID of the Customer Match user list to remove users from.",
-                        "index": 5
+                        "index": 4
                     },
                     "schema": {
                         "type": "expression",
                         "levels": ["ADD"],
-                        "index": 6,
+                        "index": 5,
                         "label": "Schema",
                         "tooltip": "Required mapping between CSV headers and Google Ads identifiers. This component does not infer identifiers from header names.",
                         "fields": {
@@ -120,14 +110,14 @@
                         "type": "text",
                         "label": "Column Separator",
                         "tooltip": "Character used to separate columns in the CSV file. Default is a comma (,).",
-                        "index": 7,
+                        "index": 6,
                         "defaultValue": ","
                     },
                     "adPersonalization": {
                         "type": "select",
                         "label": "Ad Personalization Consent",
                         "tooltip": "Consent status for ad personalization. Required by EU User Consent Policy.",
-                        "index": 8,
+                        "index": 7,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },
@@ -138,7 +128,7 @@
                         "type": "select",
                         "label": "Ad User Data Consent",
                         "tooltip": "Consent status for use of user data for ads. Required by EU User Consent Policy.",
-                        "index": 9,
+                        "index": 8,
                         "options": [
                             { "label": "Unspecified", "value": "" },
                             { "label": "Granted", "value": "GRANTED" },

--- a/src/appmixer/googleAds/core/UpdateUserList/UpdateUserList.js
+++ b/src/appmixer/googleAds/core/UpdateUserList/UpdateUserList.js
@@ -8,7 +8,6 @@ module.exports = {
 
         const {
             customerId,
-            developerToken,
             loginCustomerId,
             userListId,
             userListResourceName,
@@ -19,7 +18,6 @@ module.exports = {
         } = context.messages.in.content;
 
         lib.ensureRequired(customerId, 'Customer ID is required!', context);
-        lib.ensureRequired(developerToken, 'Developer Token is required!', context);
 
         // Resolve user list resource name from either explicit resource name or numeric ID
         const normalizedCustomerId = lib.normalizeCustomerId(customerId);
@@ -74,7 +72,7 @@ module.exports = {
         const { data } = await context.httpRequest({
             method: 'POST',
             url: `${lib.API_BASE_URL}/customers/${normalizedCustomerId}/userLists:mutate`,
-            headers: lib.buildHeaders(context, { developerToken, loginCustomerId }),
+            headers: lib.buildHeaders(context, { loginCustomerId }),
             data: {
                 operations: [
                     {

--- a/src/appmixer/googleAds/core/UpdateUserList/component.json
+++ b/src/appmixer/googleAds/core/UpdateUserList/component.json
@@ -22,9 +22,6 @@
                     "customerId": {
                         "type": "string"
                     },
-                    "developerToken": {
-                        "type": "string"
-                    },
                     "loginCustomerId": {
                         "type": "string"
                     },
@@ -48,8 +45,7 @@
                     }
                 },
                 "required": [
-                    "customerId",
-                    "developerToken"
+                    "customerId"
                 ]
             },
             "inspector": {
@@ -59,52 +55,47 @@
                         "label": "Customer ID",
                         "index": 1
                     },
-                    "developerToken": {
-                        "type": "text",
-                        "label": "Developer Token",
-                        "index": 2
-                    },
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "Required when authenticating via a manager (MCC) account.",
-                        "index": 3
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "index": 2
                     },
                     "userListId": {
                         "type": "text",
                         "label": "User List ID",
                         "tooltip": "Numeric ID of the Customer Match user list. Use either User List ID or User List Resource Name.",
-                        "index": 4
+                        "index": 3
                     },
                     "userListResourceName": {
                         "type": "text",
                         "label": "User List Resource Name",
                         "tooltip": "Full resource name, e.g. customers/123/userLists/456. Use either this or User List ID.",
-                        "index": 5
+                        "index": 4
                     },
                     "name": {
                         "type": "text",
                         "label": "Name",
                         "tooltip": "New name for the user list. Must be unique per customer.",
-                        "index": 6
+                        "index": 5
                     },
                     "description": {
                         "type": "textarea",
                         "label": "Description",
                         "tooltip": "New description for the user list.",
-                        "index": 7
+                        "index": 6
                     },
                     "membershipLifeSpan": {
                         "type": "number",
                         "label": "Membership Life Span (days)",
                         "tooltip": "Number of days a user's cookie stays on the list (0-540, or 10000 for no expiration for CRM lists).",
-                        "index": 8
+                        "index": 7
                     },
                     "integrationCode": {
                         "type": "text",
                         "label": "Integration Code",
                         "tooltip": "ID from external system for correlation with Google Ads.",
-                        "index": 9
+                        "index": 8
                     }
                 }
             }

--- a/src/appmixer/googleAds/core/UpdateUserList/component.json
+++ b/src/appmixer/googleAds/core/UpdateUserList/component.json
@@ -58,7 +58,7 @@
                     "loginCustomerId": {
                         "type": "text",
                         "label": "Login Customer ID",
-                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890.",
+                        "tooltip": "The Google Ads Manager Account (MCC) ID. Required when accessing accounts managed through an MCC hierarchy. Format: 10-digit number, e.g. 1234567890. See https://developers.google.com/google-ads/api/docs/concepts/call-structure#login-customer-id",
                         "index": 2
                     },
                     "userListId": {

--- a/src/appmixer/googleAds/lib.js
+++ b/src/appmixer/googleAds/lib.js
@@ -29,7 +29,18 @@ function normalizeCustomerId(customerId) {
     return String(customerId || '').replace(/[^0-9]/g, '');
 }
 
-function buildHeaders(context, { developerToken, loginCustomerId }) {
+function getGoogleAdsConfig(context) {
+    const developerToken = context.config?.developerToken;
+
+    ensureRequired(developerToken, 'Developer Token is required in backoffice config!', context);
+
+    return {
+        developerToken
+    };
+}
+
+function buildHeaders(context, { loginCustomerId } = {}) {
+    const { developerToken } = getGoogleAdsConfig(context);
     const headers = {
         'Authorization': `Bearer ${context.auth.accessToken}`,
         'developer-token': developerToken
@@ -44,12 +55,11 @@ function buildHeaders(context, { developerToken, loginCustomerId }) {
 
 async function searchStream(context, {
     customerId,
-    developerToken,
     loginCustomerId,
     query
 }) {
     const normalizedCustomerId = normalizeCustomerId(customerId);
-    const headers = buildHeaders(context, { developerToken, loginCustomerId });
+    const headers = buildHeaders(context, { loginCustomerId });
 
     const { data } = await context.httpRequest({
         method: 'POST',
@@ -319,6 +329,7 @@ function toCsv(array) {
 
 module.exports = {
     ensureRequired,
+    getGoogleAdsConfig,
     normalizeCustomerId,
     buildHeaders,
     searchStream,


### PR DESCRIPTION
## Summary
- Move `developerToken` from individual component inputs to backoffice config (`context.config`) — it identifies the Appmixer application and is shared across all customers
- Keep `loginCustomerId` as a user-facing input on all components — it varies per customer depending on their MCC hierarchy
- Add tooltip with documentation link for `loginCustomerId` on all 10 components
- Add Google Ads API design documentation for developer token access level review
- Version bump to 1.2.1

## Test plan
- [ ] Verify backoffice `developerToken` config is picked up correctly
- [ ] Verify `loginCustomerId` is visible and editable in component inspector
- [ ] Test CreateUserList, FindUserLists, DeleteUserList with both `loginCustomerId` set and empty
- [ ] Test CSV upload/remove components with continuation (loginCustomerId persisted in state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)