### PR TITLE
utils.chat, ai/OpenAi: replace direct Redis pub/sub with context pubSub methods

### DIFF
--- a/src/appmixer/ai/openai/AIAgent/AIAgent.js
+++ b/src/appmixer/ai/openai/AIAgent/AIAgent.js
@@ -213,7 +213,7 @@ module.exports = {
 
     publishChatProgressEvent: function(context, step, content) {
 
-        return lib.publish(`stream:agent:events:${context.messages.in.content.threadId}`, {
+        return context.pubSubPublish(`stream:agent:events:${context.messages.in.content.threadId}`, {
             type: 'progress',
             data: {
                 id: uuid.v6(), // UUID v6 is time ordered
@@ -229,7 +229,7 @@ module.exports = {
 
     publishChatDeltaEvent: async function(context, completionId, content) {
 
-        return lib.publish(`stream:agent:events:${context.messages.in.content.threadId}`, {
+        return context.pubSubPublish(`stream:agent:events:${context.messages.in.content.threadId}`, {
             type: 'delta',
             data: {
                 id: uuid.v6(), // UUID v6 is time ordered

--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,5 +1,6 @@
 {
     "name": "appmixer.ai.openai",
+    "engine": ">=6.4",
     "version": "1.3.3",
     "changelog": {
         "1.0.0": [

--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ai.openai",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "changelog": {
         "1.0.0": [
             "First version."
@@ -49,6 +49,9 @@
         ],
         "1.3.2": [
             "Fixed ioredis sentinel connection configuration to properly parse sentinel hosts and handle password authentication."
+        ],
+        "1.3.3": [
+            "Replaced direct Redis pub/sub with tenant-isolated context pubSubPublish method."
         ]
     }
 }

--- a/src/appmixer/ai/openai/lib.js
+++ b/src/appmixer/ai/openai/lib.js
@@ -64,6 +64,6 @@ module.exports = {
         const i = Math.floor(Math.log(bytes) / Math.log(k));
 
         return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
-    },
+    }
 
 };

--- a/src/appmixer/ai/openai/lib.js
+++ b/src/appmixer/ai/openai/lib.js
@@ -1,6 +1,4 @@
 const OpenAI = require('openai');
-const Redis = require('ioredis');
-const fs = require('fs').promises;
 
 module.exports = {
 
@@ -68,61 +66,4 @@ module.exports = {
         return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
     },
 
-    publish: async function(channel, event) {
-
-        let redisPub = process.CONNECTOR_STREAM_PUB_CLIENT;
-        if (!redisPub) {
-            redisPub = process.CONNECTOR_STREAM_PUB_CLIENT = await this.connectRedis();
-        }
-        return redisPub.publish(channel, JSON.stringify(event));
-    },
-
-    connectRedis: async function() {
-
-        const connection = {
-            uri: process.env.REDIS_URI,
-            mode: process.env.REDIS_MODE || 'standalone',
-            sentinels: process.env.REDIS_SENTINELS,
-            sentinelMasterName: process.env.REDIS_SENTINEL_MASTER_NAME,
-            password: process.env.REDIS_PASSWORD,
-            sentinelRedisPassword: process.env.REDIS_SENTINEL_PASSWORD,
-            enableTLSForSentinelMode: process.env.REDIS_SENTINEL_ENABLE_TLS,
-            caPath: process.env.REDIS_CA_PATH,
-            useSSL: process.env.REDIS_USE_SSL === 'true' || parseInt(process.env.REDIS_USE_SSL) > 0
-        };
-
-        const options = {};
-        if (connection.useSSL) {
-            options.tls = {
-                ca: connection.caPath ? await fs.readFile(connection.caPath) : undefined
-            };
-        }
-
-        let client;
-
-        if (connection.mode === 'replica' && connection.sentinels) {
-
-            const sentinelsArray = connection.sentinels.split(',').map(sentinel => {
-                const [host, port] = sentinel.trim().split(':');
-                return { host, port: port ? parseInt(port) : 26379 };
-            });
-
-            const redisPassword = connection.password || connection.sentinelRedisPassword;
-            const sentinelPassword = connection.sentinelRedisPassword || connection.password;
-
-            client = new Redis({
-                sentinels: sentinelsArray,
-                name: connection.sentinelMasterName,
-                ...(redisPassword ? { password: redisPassword } : {}),
-                ...(sentinelPassword ? { sentinelPassword: sentinelPassword } : {}),
-                ...(connection.enableTLSForSentinelMode ?
-                    { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {}),
-                ...options
-            });
-        } else {
-            client = connection.uri ? new Redis(connection.uri, options) : new Redis();
-        }
-
-        return client;
-    }
 };

--- a/src/appmixer/utils/ai/bundle.json
+++ b/src/appmixer/utils/ai/bundle.json
@@ -1,5 +1,6 @@
 {
     "name": "appmixer.utils.ai",
+    "engine": ">=6.4",
     "version": "1.1.2",
     "changelog": {
         "1.0.0": [

--- a/src/appmixer/utils/chat/bundle.json
+++ b/src/appmixer/utils/chat/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.chat",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -18,6 +18,9 @@
         ],
         "2.0.1": [
             "Fixed ioredis sentinel connection configuration to properly parse sentinel hosts and handle password authentication."
+        ],
+        "2.0.2": [
+            "Replaced direct Redis pub/sub with tenant-isolated context pubSub methods. SSE clients now subscribe to exact channels per connection, removing the need for psubscribe ACL permissions."
         ]
     }
 }

--- a/src/appmixer/utils/chat/bundle.json
+++ b/src/appmixer/utils/chat/bundle.json
@@ -1,5 +1,6 @@
 {
     "name": "appmixer.utils.chat",
+    "engine": ">=6.4",
     "version": "2.0.2",
     "changelog": {
         "1.0.0": [

--- a/src/appmixer/utils/chat/lib.js
+++ b/src/appmixer/utils/chat/lib.js
@@ -28,6 +28,6 @@ module.exports = {
         const parsedUrl = new URL(endpoint);
         const baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
         return page(baseUrl, endpoint);
-    },
+    }
 
 };

--- a/src/appmixer/utils/chat/lib.js
+++ b/src/appmixer/utils/chat/lib.js
@@ -1,6 +1,4 @@
 const { URL } = require('url');
-const fs = require('fs').promises;
-const Redis = require('ioredis');
 
 const page = (baseUrl, endpoint) => {
     return `
@@ -32,55 +30,4 @@ module.exports = {
         return page(baseUrl, endpoint);
     },
 
-    connectRedis: async function() {
-
-        const connection = {
-            uri: process.env.REDIS_URI,
-            mode: process.env.REDIS_MODE || 'standalone',
-            sentinels: process.env.REDIS_SENTINELS,
-            sentinelMasterName: process.env.REDIS_SENTINEL_MASTER_NAME,
-            password: process.env.REDIS_PASSWORD,
-            sentinelRedisPassword: process.env.REDIS_SENTINEL_PASSWORD,
-            enableTLSForSentinelMode: process.env.REDIS_SENTINEL_ENABLE_TLS,
-            caPath: process.env.REDIS_CA_PATH,
-            useSSL: process.env.REDIS_USE_SSL === 'true' || parseInt(process.env.REDIS_USE_SSL) > 0
-        };
-
-        const options = {};
-        if (connection.useSSL) {
-            options.tls = {
-                ca: connection.caPath ? await fs.readFile(connection.caPath) : undefined
-            };
-        }
-
-        let client;
-
-        if (connection.mode === 'replica' && connection.sentinels) {
-
-            const sentinelsArray = connection.sentinels.split(',').map(sentinel => {
-                const [host, port] = sentinel.trim().split(':');
-                return { host, port: port ? parseInt(port) : 26379 };
-            });
-
-            // Determine passwords for Redis master and Sentinel nodes
-            // Priority: use specific password if available, otherwise use the general password,
-            // then fall back to sentinelRedisPassword
-            const redisPassword = connection.password || connection.sentinelRedisPassword;
-            const sentinelPassword = connection.sentinelRedisPassword || connection.password;
-
-            client = new Redis({
-                ...options,
-                sentinels: sentinelsArray,
-                name: connection.sentinelMasterName,
-                ...(redisPassword ? { password: redisPassword } : {}),
-                ...(sentinelPassword ? { sentinelPassword } : {}),
-                ...(connection.enableTLSForSentinelMode ?
-                    { enableTLSForSentinelMode: connection.enableTLSForSentinelMode } : {})
-            });
-        } else {
-            client = connection.uri ? new Redis(connection.uri, options) : new Redis();
-        }
-
-        return client;
-    }
 };

--- a/src/appmixer/utils/chat/plugin.js
+++ b/src/appmixer/utils/chat/plugin.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const lib = require('./lib');
-
 module.exports = async context => {
 
     context.log('info', '[UTILS.CHAT] Initializing CHAT plugin.');
@@ -12,24 +10,6 @@ module.exports = async context => {
         await require('./ChatSessionModel')(context).createIndex({ id: 1 });
     } finally {
         lock.unlock();
-    }
-
-    // Keep a connection to Redis for publish/subscribe that we use to deliver
-    // new chat messages to clients in real-time.
-    if (!process.CONNECTOR_STREAM_PUB_CLIENT) {
-        context.log('info', '[UTILS.CHAT] Connecting Redis Publisher client.');
-        process.CONNECTOR_STREAM_PUB_CLIENT = await lib.connectRedis();
-        context.log('info', '[UTILS.CHAT] Redis Publisher client connected.');
-    }
-    if (!process.CONNECTOR_STREAM_SUB_CLIENT) {
-        context.log('info', '[UTILS.CHAT] Connecting Redis Subscriber client.');
-        process.CONNECTOR_STREAM_SUB_CLIENT = await lib.connectRedis();
-        context.log('info', '[UTILS.CHAT] Redis Subscriber client connected.');
-    } else {
-        // Make sure listeners are removed so that the ones registered in routes.js
-        // will not introduce duplicate message handlers.
-        // TODO: only listenrs that are registered by this plugin should be removed.
-        process.CONNECTOR_STREAM_SUB_CLIENT.removeAllListeners();
     }
 
     require('./routes')(context);

--- a/src/appmixer/utils/chat/routes.js
+++ b/src/appmixer/utils/chat/routes.js
@@ -20,39 +20,12 @@ const { PassThrough } = require('stream');
 
 const chatBundleJs = fs.readFileSync(__dirname + '/chat.bundle.js', 'utf8');
 
-// In-memory map of connected clients per threadId.
-const chatClients = new Map();
-
-async function publish(channel, event) {
-
-    const redisPub = process.CONNECTOR_STREAM_PUB_CLIENT;
-    if (redisPub) {
-        return redisPub.publish(channel, JSON.stringify(event));
-    }
-}
-
 module.exports = (context) => {
 
     const ChatMessage = require('./ChatMessageModel')(context);
     const ChatSession = require('./ChatSessionModel')(context);
     const ChatAgent = require('./ChatAgentModel')(context);
     const ChatThread = require('./ChatThreadModel')(context);
-
-    // assert(Redis clients have been connected in plugin.js).
-    process.CONNECTOR_STREAM_SUB_CLIENT.psubscribe('stream:agent:events:*');
-    process.CONNECTOR_STREAM_SUB_CLIENT.psubscribe('stream:chat:events:*');
-    process.CONNECTOR_STREAM_SUB_CLIENT.on('pmessage', (pattern, channel, payload) => {
-        const [, , ,threadId] = channel.split(':'); // e.g., 'stream:chat:events:123'
-        const data = JSON.parse(payload);
-
-        if (chatClients.has(threadId)) {
-            for (const stream of chatClients.get(threadId)) {
-                if (!stream.writableEnded) {
-                    stream.write(`data: ${JSON.stringify(data)}\n\n`);
-                }
-            }
-        }
-    });
 
     // ASSETS
 
@@ -86,7 +59,7 @@ module.exports = (context) => {
                 message.threadId = threadId;
                 message.createdAt = new Date;
                 message.userId = userId;
-                await publish(`stream:chat:events:${threadId}`, {
+                await context.pubSubPublish(`stream:chat:events:${threadId}`, {
                     type: 'message',
                     data: message
                 });
@@ -149,7 +122,7 @@ module.exports = (context) => {
             cors: {
                 origin: ['*']
             },
-            handler: (request, h) => {
+            handler: async (request, h) => {
                 const { threadId } = request.params;
 
                 const stream = new PassThrough();
@@ -164,9 +137,16 @@ module.exports = (context) => {
                 response.header('Content-Encoding', 'identity');
                 stream.write(': init\n\n'); // Send SSE comment to kickstart stream.
 
-                // Track connection.
-                if (!chatClients.has(threadId)) chatClients.set(threadId, new Set());
-                chatClients.get(threadId).add(stream);
+                const sendEvent = (data) => {
+                    if (!stream.writableEnded) {
+                        stream.write(`data: ${JSON.stringify(data)}\n\n`);
+                    }
+                };
+
+                // Subscribe to the exact channels for this thread.
+                // Using exact-channel subscribe avoids the need for psubscribe ACL permission.
+                const subChat = await context.pubSubSubscribe(`stream:chat:events:${threadId}`, sendEvent);
+                const subAgent = await context.pubSubSubscribe(`stream:agent:events:${threadId}`, sendEvent);
 
                 // Necessary to keep the connection alive. Otherwise it closes after
                 // a timeout interval set on the load balancer/proxy (typically 1 minute).
@@ -177,10 +157,10 @@ module.exports = (context) => {
                 }, context.config.SSE_HEARTBEAT_INTERVAL || 15000);
 
                 // Cleanup on disconnect.
-                request.raw.req.on('close', () => {
+                request.raw.req.on('close', async () => {
                     clearInterval(heartbeat);
-                    chatClients.get(threadId).delete(stream);
-                    if (chatClients.get(threadId).size === 0) chatClients.delete(threadId);
+                    await subChat.unsubscribe();
+                    await subAgent.unsubscribe();
                     stream.end();
                 });
 
@@ -374,4 +354,5 @@ module.exports = (context) => {
             }
         }
     });
+
 };

--- a/src/appmixer/utils/chat/routes.js
+++ b/src/appmixer/utils/chat/routes.js
@@ -143,10 +143,11 @@ module.exports = (context) => {
                     }
                 };
 
-                // Subscribe to the exact channels for this thread.
-                // Using exact-channel subscribe avoids the need for psubscribe ACL permission.
-                const subChat = await context.pubSubSubscribe(`stream:chat:events:${threadId}`, sendEvent);
-                const subAgent = await context.pubSubSubscribe(`stream:agent:events:${threadId}`, sendEvent);
+                // Track subscriptions and state so the close handler can clean them
+                // up even if the client disconnects during the subscribe awaits.
+                let subChat = null;
+                let subAgent = null;
+                let closed = false;
 
                 // Necessary to keep the connection alive. Otherwise it closes after
                 // a timeout interval set on the load balancer/proxy (typically 1 minute).
@@ -156,13 +157,35 @@ module.exports = (context) => {
                     }
                 }, context.config.SSE_HEARTBEAT_INTERVAL || 15000);
 
-                // Cleanup on disconnect.
-                request.raw.req.on('close', async () => {
+                // Attach the close handler BEFORE awaiting subscriptions to avoid a
+                // race where the client disconnects during the subscribe call and the
+                // cleanup never runs.
+                request.raw.req.on('close', () => {
+                    closed = true;
                     clearInterval(heartbeat);
-                    await subChat.unsubscribe();
-                    await subAgent.unsubscribe();
-                    stream.end();
+                    // Use Promise.allSettled so both unsubscribes always run, even if
+                    // one rejects, and always end the stream in finally.
+                    Promise.allSettled([
+                        subChat ? subChat.unsubscribe() : Promise.resolve(),
+                        subAgent ? subAgent.unsubscribe() : Promise.resolve()
+                    ]).finally(() => {
+                        if (!stream.writableEnded) {
+                            stream.end();
+                        }
+                    });
                 });
+
+                // Subscribe to the exact channels for this thread.
+                // Using exact-channel subscribe avoids the need for psubscribe ACL permission.
+                subChat = await context.pubSubSubscribe(`stream:chat:events:${threadId}`, sendEvent);
+                subAgent = await context.pubSubSubscribe(`stream:agent:events:${threadId}`, sendEvent);
+
+                // If the client already disconnected during the subscribe calls, clean up immediately.
+                if (closed) {
+                    await Promise.allSettled([subChat.unsubscribe(), subAgent.unsubscribe()]);
+                    if (!stream.writableEnded) stream.end();
+                    return response;
+                }
 
                 return response;
             }


### PR DESCRIPTION
## Summary

- Replace `connectRedis` (direct ioredis connection) in `lib.js` with the new tenant-isolated `context.pubSubPublish` / `context.pubSubSubscribe` context methods
- Remove global `psubscribe` pattern subscriptions and the `chatClients` Map from `plugin.js` and `routes.js` — these required `psubscribe` ACL permission which is not available to connector Redis users
- SSE clients now subscribe to exact channels (`stream:chat:events:{threadId}`, `stream:agent:events:{threadId}`) at connection time and unsubscribe on disconnect, using `context.pubSubSubscribe` (Redis `subscribe` command)

## Test plan

- [ ] Open chat SSE endpoint `/events/{threadId}` and verify SSE stream receives events
- [ ] Send a message via POST `/messages/{threadId}` and verify it appears in the SSE stream
- [ ] Disconnect SSE client and verify subscriptions are cleaned up (no Redis subscription leak)
- [ ] Restart/reload the plugin and verify no duplicate handlers or errors on re-init

🤖 Generated with [Claude Code](https://claude.com/claude-code)