### PR TITLE
facebookbusiness: cache dynamic input calls, suppress errors for isSource

### DIFF
--- a/src/appmixer/facebookbusiness/bundle.json
+++ b/src/appmixer/facebookbusiness/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.facebookbusiness",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -18,7 +18,7 @@
             "Fix validateAccessToken in auth.js.",
             "Bump Graph API from v20.0 to v25.0."
         ],
-        "3.0.0": [
+        "3.0.1": [
             "Remove ads_read scope from all components. Only ads_management is required. Breaking change: users need to re-authenticate."
         ]
     }

--- a/src/appmixer/facebookbusiness/lib.js
+++ b/src/appmixer/facebookbusiness/lib.js
@@ -4,7 +4,39 @@ const workerpool = require('workerpool');
 
 const pool = workerpool.pool(__dirname + '/prepareMembers.js');
 
+function getCacheKey(obj) {
+    return crypto.createHash('sha256').update(JSON.stringify(obj)).digest('hex');
+}
+
+async function callEndpointCached(context, url) {
+
+    let lock;
+    try {
+        const key = getCacheKey({ url, token: context.auth.accessToken });
+        lock = await context.lock(key);
+
+        const cached = await context.staticCache.get(key);
+        if (cached) {
+            return { data: cached };
+        }
+
+        const { data } = await context.httpRequest.get(url);
+
+        await context.staticCache.set(
+            key,
+            data,
+            context.config.listCacheTTL || (2 * 60 * 1000) // 120s
+        );
+
+        return { data };
+    } finally {
+        lock?.unlock();
+    }
+}
+
 module.exports = {
+
+    callEndpointCached,
 
     async sendCSVAudienceToFacebook(context, method, operation) {
 

--- a/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/AddMemberToAudience/component.json
@@ -87,6 +87,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -99,6 +100,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"

--- a/src/appmixer/facebookbusiness/marketing/AddMembersFromCSVToAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/AddMembersFromCSVToAudience/component.json
@@ -52,6 +52,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -64,6 +65,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"

--- a/src/appmixer/facebookbusiness/marketing/CreateAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/CreateAudience/component.json
@@ -52,6 +52,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }

--- a/src/appmixer/facebookbusiness/marketing/DeleteAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/DeleteAudience/component.json
@@ -42,6 +42,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -54,6 +55,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"

--- a/src/appmixer/facebookbusiness/marketing/GetAdAccounts/GetAdAccounts.js
+++ b/src/appmixer/facebookbusiness/marketing/GetAdAccounts/GetAdAccounts.js
@@ -1,3 +1,5 @@
+const { callEndpointCached } = require('../../lib');
+
 module.exports = {
 
     async receive(context) {
@@ -8,10 +10,19 @@ module.exports = {
             return this.getOutputPortOptions(context, outputType);
         }
 
-        const accessToken = context.auth.accessToken;
-        const url = `https://graph.facebook.com/v25.0/me/adaccounts?access_token=${accessToken}&fields=id,account_id,name,account_status`;
-        const { data } = await context.httpRequest.get(url);
-        return context.sendJson({ accounts: data.data }, 'out');
+        try {
+            const accessToken = context.auth.accessToken;
+            const url = `https://graph.facebook.com/v25.0/me/adaccounts?access_token=${accessToken}&fields=id,account_id,name,account_status`;
+            const { data } = context.properties.isSource
+                ? await callEndpointCached(context, url)
+                : await context.httpRequest.get(url);
+            return context.sendJson({ accounts: data.data }, 'out');
+        } catch (err) {
+            if (context.properties.isSource) {
+                return context.sendJson({ accounts: [] }, 'out');
+            }
+            throw err;
+        }
     },
 
     toSelectArray(out) {

--- a/src/appmixer/facebookbusiness/marketing/GetCampaigns/component.json
+++ b/src/appmixer/facebookbusiness/marketing/GetCampaigns/component.json
@@ -42,6 +42,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }

--- a/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/GetCustomAudiences.js
+++ b/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/GetCustomAudiences.js
@@ -1,3 +1,5 @@
+const { callEndpointCached } = require('../../lib');
+
 module.exports = {
 
     async receive(context) {
@@ -8,10 +10,19 @@ module.exports = {
             return this.getOutputPortOptions(context, outputType);
         }
 
-        const accessToken = context.auth.accessToken;
-        const url = `https://graph.facebook.com/v25.0/act_${accountId}/customaudiences?access_token=${accessToken}&fields=id,name,description`;
-        const { data } = await context.httpRequest.get(url);
-        return context.sendJson({ customAudiences: data.data }, 'out');
+        try {
+            const accessToken = context.auth.accessToken;
+            const url = `https://graph.facebook.com/v25.0/act_${accountId}/customaudiences?access_token=${accessToken}&fields=id,name,description`;
+            const { data } = context.properties.isSource
+                ? await callEndpointCached(context, url)
+                : await context.httpRequest.get(url);
+            return context.sendJson({ customAudiences: data.data }, 'out');
+        } catch (err) {
+            if (context.properties.isSource) {
+                return context.sendJson({ customAudiences: [] }, 'out');
+            }
+            throw err;
+        }
     },
 
     toSelectArray(out) {

--- a/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/component.json
+++ b/src/appmixer/facebookbusiness/marketing/GetCustomAudiences/component.json
@@ -44,6 +44,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }

--- a/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/RemoveMemberFromAudience/component.json
@@ -87,6 +87,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -99,6 +100,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"

--- a/src/appmixer/facebookbusiness/marketing/RemoveMembersInCSVFromAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/RemoveMembersInCSVFromAudience/component.json
@@ -52,6 +52,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -64,6 +65,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"

--- a/src/appmixer/facebookbusiness/marketing/ReplaceMembersFromCSVInAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/ReplaceMembersFromCSVInAudience/component.json
@@ -52,6 +52,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -64,6 +65,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"

--- a/src/appmixer/facebookbusiness/marketing/UpdateAudience/component.json
+++ b/src/appmixer/facebookbusiness/marketing/UpdateAudience/component.json
@@ -48,6 +48,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetAdAccounts?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetAdAccounts#toSelectArray"
                             }
                         }
@@ -60,6 +61,7 @@
                         "source": {
                             "url": "/component/appmixer/facebookbusiness/marketing/GetCustomAudiences?outPort=out",
                             "data": {
+                                "properties": { "isSource": true },
                                 "transform": "./GetCustomAudiences#toSelectArray",
                                 "messages": {
                                     "in/accountId": "inputs/in/accountId"


### PR DESCRIPTION
## Summary

- Adds `callEndpointCached()` to `lib.js` — SHA-256 cache key (URL + access token), `context.lock` + `context.staticCache`, configurable TTL via `config.listCacheTTL` (default 120s)
- `GetAdAccounts` and `GetCustomAudiences` use the cache only when called as a dynamic source (`isSource: true`) — normal flow calls bypass cache
- Errors during `isSource` calls return an empty array instead of propagating to the UI (no irrelevant error popups)
- All `source` definitions referencing `GetAdAccounts#toSelectArray` and `GetCustomAudiences#toSelectArray` updated with `"properties": { "isSource": true }`

## Note

This uses `isSource` (same as monday connector). The `copilot-instructions.md` documents both `variableFetch` and `isSource` — see PR #1062.

## Test plan
- [ ] Open inspector for CreateAudience / AddMemberToAudience — dropdown populates correctly
- [ ] Verify repeated dropdown opens do not trigger repeated API calls (cache hit)
- [ ] Revoke token / invalid auth — dropdown returns empty silently, no UI error
- [ ] Normal flow execution (no isSource) — errors propagate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)