### PR TITLE
utils.forms.FormTrigger, FormAction: add support for cutom logo 

### DIFF
--- a/src/appmixer/utils/forms/FormAction/component.json
+++ b/src/appmixer/utils/forms/FormAction/component.json
@@ -17,6 +17,7 @@
             "schema": {
                 "type": "object",
                 "properties": {
+                    "logo": { "type": "string" },
                     "title": { "type": "string" },
                     "description": { "type": "string" },
                     "fields": { "type": "object" },
@@ -29,25 +30,32 @@
             },
             "inspector": {
                 "inputs": {
+                    "logo": {
+                        "type": "text",
+                        "label": "Logo URL",
+                        "tooltip": "URL of a logo image to display in the form header and footer. Defaults to the Appmixer logo.",
+                        "index": 2,
+                        "group": "configuration"
+                    },
                     "title": {
                         "type": "text",
                         "label": "Form Title",
                         "tooltip": "Form Title.",
-                        "index": 2,
+                        "index": 3,
                         "group": "configuration"
                     },
                     "description": {
                         "type": "textarea",
                         "label": "Form Description",
                         "tooltip": "Form Description.",
-                        "index": 3,
+                        "index": 4,
                         "group": "configuration"
                     },
                     "fields": {
                         "type": "expression",
                         "label": "Form Fields",
                         "tooltip": "Define your form fields.",
-                        "index": 4,
+                        "index": 5,
                         "levels": ["ADD"],
                         "fields": {
                             "label": {
@@ -94,7 +102,7 @@
                         "label": "Call To Action",
                         "tooltip": "Label of the call-to-action button.",
                         "defaultValue": "Submit",
-                        "index": 5,
+                        "index": 6,
                         "group": "configuration"
                     },
                     "thanksMessage": {
@@ -102,7 +110,7 @@
                         "label": "Thanks Message",
                         "tooltip": "Message displayed to the user after successful form submission.",
                         "defaultValue": "Thank you!",
-                        "index": 6,
+                        "index": 7,
                         "group": "configuration"
                     },
                     "thanksImage": {
@@ -110,7 +118,7 @@
                         "label": "Thanks Image URL",
                         "tooltip": "Image displayed to the user after successful form submission.",
                         "defaultValue": "",
-                        "index": 7,
+                        "index": 8,
                         "group": "configuration"
                     },
                     "script": {

--- a/src/appmixer/utils/forms/FormTrigger/component.json
+++ b/src/appmixer/utils/forms/FormTrigger/component.json
@@ -23,25 +23,32 @@
                     },
                     "group": "configuration"
                 },
+                "logo": {
+                    "type": "text",
+                    "label": "Logo URL",
+                    "tooltip": "URL of a logo image to display in the form header and footer. Defaults to the Appmixer logo.",
+                    "index": 2,
+                    "group": "configuration"
+                },
                 "title": {
                     "type": "text",
                     "label": "Form Title",
                     "tooltip": "Form Title.",
-                    "index": 2,
+                    "index": 3,
                     "group": "configuration"
                 },
                 "description": {
                     "type": "textarea",
                     "label": "Form Description",
                     "tooltip": "Form Description.",
-                    "index": 3,
+                    "index": 4,
                     "group": "configuration"
                 },
                 "fields": {
                     "type": "expression",
                     "label": "Form Fields",
                     "tooltip": "Define your form fields.",
-                    "index": 4,
+                    "index": 5,
                     "levels": ["ADD"],
                     "fields": {
                         "label": {
@@ -88,7 +95,7 @@
                     "label": "Call To Action",
                     "tooltip": "Label of the call-to-action button.",
                     "defaultValue": "Submit",
-                    "index": 5,
+                    "index": 6,
                     "group": "configuration"
                 },
                 "thanksMessage": {
@@ -96,7 +103,7 @@
                     "label": "Thanks Message",
                     "tooltip": "Message displayed to the user after successful form submission.",
                     "defaultValue": "Thank you!",
-                    "index": 6,
+                    "index": 7,
                     "group": "configuration"
                 },
                 "thanksImage": {
@@ -104,7 +111,7 @@
                     "label": "Thanks Image URL",
                     "tooltip": "Image displayed to the user after successful form submission.",
                     "defaultValue": "",
-                    "index": 7,
+                    "index": 8,
                     "group": "configuration"
                 },
                 "script": {

--- a/src/appmixer/utils/forms/bundle.json
+++ b/src/appmixer/utils/forms/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.forms",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,7 +8,7 @@
         "1.0.2": [
             "Form Trigger: fix the checkbox value propagation."
         ],
-        "1.0.3": [
+        "1.1.0": [
             "Form Trigger and Form Action: expose Logo URL field in inspector."
         ]
     }

--- a/src/appmixer/utils/forms/bundle.json
+++ b/src/appmixer/utils/forms/bundle.json
@@ -1,12 +1,15 @@
 {
     "name": "appmixer.utils.forms",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.0.2": [
             "Form Trigger: fix the checkbox value propagation."
+        ],
+        "1.0.3": [
+            "Form Trigger and Form Action: expose Logo URL field in inspector."
         ]
     }
 }


### PR DESCRIPTION
## Summary

Adds a **Logo URL** input field to both `FormTrigger` and `FormAction` inspector so users can override the default Appmixer logo with their own image or URL.

## Root Cause

The rendering logic in `lib.js` already supported `opt.logo`:
```js
<img class="logo" src="${opt.logo || assets.logo}"/>
```
The field was just never exposed in the inspector.

## Changes

- `FormTrigger/component.json` — added `logo` field (index 2, configuration group); shifted `title`, `description`, `fields`, `cta`, `thanksMessage`, `thanksImage` indices down by 1
- `FormAction/component.json` — same changes + added `logo` to the inPort schema
- `bundle.json` — bumped to `1.1.0`

## Testing

Set a Logo URL in the FormTrigger/FormAction inspector → the custom logo should appear in both the form header and footer instead of the default Appmixer logo.

Fixes Appmixer-ai/appmixer-components#2674