### PR TITLE
hubspot (minor): add optional OAuth2 scopes support

### DIFF
--- a/src/appmixer/hubspot/auth.js
+++ b/src/appmixer/hubspot/auth.js
@@ -43,16 +43,18 @@ module.exports = {
 
         authUrl: context => {
 
+            const { scopeDelimiter, optionalScope } = module.exports.definition;
+
             const params = new URLSearchParams({
                 client_id: context.clientId,
                 redirect_uri: context.callbackUrl,
-                scope: context.scope.join(' '),
+                scope: context.scope.join(scopeDelimiter),
                 state: context.ticket,
                 response_type: 'code'
             });
 
-            if (context.optionalScope && context.optionalScope.length > 0) {
-                params.set('optional_scope', context.optionalScope.join(' '));
+            if (optionalScope && optionalScope.length > 0) {
+                params.set('optional_scope', optionalScope.join(scopeDelimiter));
             }
 
             return 'https://app.hubspot.com/oauth/authorize?' + params.toString();

--- a/src/appmixer/hubspot/auth.js
+++ b/src/appmixer/hubspot/auth.js
@@ -32,9 +32,31 @@ module.exports = {
             'crm.schemas.deals.write',
             'sales-email-read'
         ],
+
+        optionalScope: [
+            'crm.objects.custom.read',
+            'crm.objects.leads.read',
+            'crm.objects.leads.write'
+        ],
+
         scopeDelimiter: ' ',
 
-        authUrl: 'https://app.hubspot.com/oauth/authorize',
+        authUrl: context => {
+
+            const params = new URLSearchParams({
+                client_id: context.clientId,
+                redirect_uri: context.callbackUrl,
+                scope: context.scope.join(' '),
+                state: context.ticket,
+                response_type: 'code'
+            });
+
+            if (context.optionalScope && context.optionalScope.length > 0) {
+                params.set('optional_scope', context.optionalScope.join(' '));
+            }
+
+            return 'https://app.hubspot.com/oauth/authorize?' + params.toString();
+        },
 
         requestAccessToken: 'https://api.hubapi.com/oauth/v1/token',
 


### PR DESCRIPTION
## Summary

Implements optional scope support for the HubSpot OAuth2 connector, as requested in #2676.

### What changed

**`src/appmixer/hubspot/auth.js`**
- Added `optionalScope` array with scopes that HubSpot users can decline without breaking the connection:
  - `crm.objects.custom.read`
  - `crm.objects.leads.read`
  - `crm.objects.leads.write`
- Converted `authUrl` from a static string to a function that builds the authorization URL and appends `optional_scope` as a query parameter (same pattern already used by Airtable and FacebookBusiness connectors).

### How it works

HubSpot's OAuth flow supports two distinct scope params:
- `scope` — required; user must accept all to complete auth
- `optional_scope` — user can decline without blocking the connection

Reference: https://developers.hubspot.com/docs/api/oauth-quickstart-guide

### ⚠️ Breaking change

Existing connected accounts are unaffected. However, any user who **re-authenticates** will see a prompt for the new optional scopes. Components that rely on `crm.objects.custom.read` / `crm.objects.leads.read` / `crm.objects.leads.write` will work only if the user granted those optional scopes during auth.

Closes #2676