### PR TITLE
fix(googleDocs): correct changelog order in bundle.json

### DIFF
--- a/src/appmixer/googleDocs/bundle.json
+++ b/src/appmixer/googleDocs/bundle.json
@@ -1,9 +1,12 @@
 {
     "name": "appmixer.googleDocs",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version with Google Docs operations"
+        ],
+        "1.1.0": [
+            "CreateDocument: added HTML rich text support via contentType selector"
         ]
     }
 }


### PR DESCRIPTION
Fixes changelog entry order in `bundle.json` — latest version (`1.1.0`) must be the last item.

Related to #2651 (https://github.com/Appmixer-ai/appmixer-components/issues/2651)