### PR TITLE
utils.tasks: replace broken external icon URLs with inline SVG data URIs in RequestApprovalEmail

### DIFF
--- a/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
+++ b/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
@@ -26,13 +26,11 @@ const prepareMessage = (context, emailForApproval, data, variables) => {
                 <p style="width: 100%;color: #050505;font-size: 13px;text-align: left;">{{{task_description}}}</p> 
             </div> 
             <div style="margin: 10px 0;"> 
-                <img alt="clock" style="width: 16px; height: 16px; vertical-align: sub;" 
-                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpolyline points='12 6 12 12 16 14'/%3E%3C/svg%3E"> 
+                <span style="font-size: 14px; vertical-align: sub;">&#128336;</span> 
                 <span style="margin-left: 6px; font-size: 12px;">{{task_decision_by}}</span> 
             </div> 
             <div style="margin: 15px 0;"> 
-                <img alt="person" style="width: 14px; height: 14px; vertical-align: sub;" 
-                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'/%3E%3Ccircle cx='12' cy='7' r='4'/%3E%3C/svg%3E"> 
+                <span style="font-size: 14px; vertical-align: sub;">&#128100;</span> 
                 <span style="margin-left: 6px; font-size: 12px;">{{requester_email}}</span> 
             </div> 
             <div style="width: 100%; text-align: center;"> 
@@ -69,13 +67,11 @@ const prepareMessage = (context, emailForApproval, data, variables) => {
                     <p style="width: 100%;color: #050505;font-size: 13px;text-align: left;">{{{task_description}}}</p> 
                 </div> 
                 <div style="margin: 10px 0;"> 
-                    <img alt="clock" style="width: 16px; height: 16px; vertical-align: sub;" 
-                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpolyline points='12 6 12 12 16 14'/%3E%3C/svg%3E"> 
+                    <span style="font-size: 14px; vertical-align: sub;">&#128336;</span> 
                     <span style="margin-left: 6px; font-size: 12px;">{{task_decision_by}}</span> 
                 </div> 
                 <div style="margin: 15px 0;"> 
-                    <img alt="person" style="width: 14px; height: 14px; vertical-align: sub;" 
-                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'/%3E%3Ccircle cx='12' cy='7' r='4'/%3E%3C/svg%3E"> 
+                    <span style="font-size: 14px; vertical-align: sub;">&#128100;</span> 
                     <span style="margin-left: 6px; font-size: 12px;">{{requester_email}}</span> 
                 </div> 
                 <a href="{{task_dashboard_link_requester}}" style="font-size: 15px;display: block; margin: 28px auto; 

--- a/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
+++ b/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
@@ -27,12 +27,12 @@ const prepareMessage = (context, emailForApproval, data, variables) => {
             </div> 
             <div style="margin: 10px 0;"> 
                 <img alt="clock" style="width: 16px; height: 16px; vertical-align: sub;" 
-                    src="https://png.pngtree.com/svg/20151126/alarm_clock_small_icon_637578.png"> 
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpolyline points='12 6 12 12 16 14'/%3E%3C/svg%3E"> 
                 <span style="margin-left: 6px; font-size: 12px;">{{task_decision_by}}</span> 
             </div> 
             <div style="margin: 15px 0;"> 
                 <img alt="person" style="width: 14px; height: 14px; vertical-align: sub;" 
-                    src="http://cdn.onlinewebfonts.com/svg/img_405324.png"> 
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'/%3E%3Ccircle cx='12' cy='7' r='4'/%3E%3C/svg%3E"> 
                 <span style="margin-left: 6px; font-size: 12px;">{{requester_email}}</span> 
             </div> 
             <div style="width: 100%; text-align: center;"> 
@@ -70,12 +70,12 @@ const prepareMessage = (context, emailForApproval, data, variables) => {
                 </div> 
                 <div style="margin: 10px 0;"> 
                     <img alt="clock" style="width: 16px; height: 16px; vertical-align: sub;" 
-                        src="https://png.pngtree.com/svg/20151126/alarm_clock_small_icon_637578.png"> 
+                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpolyline points='12 6 12 12 16 14'/%3E%3C/svg%3E"> 
                     <span style="margin-left: 6px; font-size: 12px;">{{task_decision_by}}</span> 
                 </div> 
                 <div style="margin: 15px 0;"> 
                     <img alt="person" style="width: 14px; height: 14px; vertical-align: sub;" 
-                        src="http://cdn.onlinewebfonts.com/svg/img_405324.png"> 
+                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23555' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2'/%3E%3Ccircle cx='12' cy='7' r='4'/%3E%3C/svg%3E"> 
                     <span style="margin-left: 6px; font-size: 12px;">{{requester_email}}</span> 
                 </div> 
                 <a href="{{task_dashboard_link_requester}}" style="font-size: 15px;display: block; margin: 28px auto; 

--- a/src/appmixer/utils/tasks/bundle.json
+++ b/src/appmixer/utils/tasks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.tasks",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "changelog": {
         "1.0.2": [
             "Using new context.job.lock function."
@@ -14,6 +14,9 @@
         ],
         "1.1.1": [
             "Request Approval: description field no longer supports Markdown."
+        ],
+        "1.1.2": [
+            "RequestApprovalEmail: replace broken third-party icon URLs with inline SVG data URIs."
         ]
     },
     "engine": ">=5.1"


### PR DESCRIPTION
## Summary

The clock and person icons in `RequestApprovalEmail` were loaded from third-party CDNs (`png.pngtree.com` and `cdn.onlinewebfonts.com`) that are now returning 403 errors, causing the icons to not render in approval request emails.

## Changes

- Replaced the broken clock icon URL with an inline SVG data URI (clock/timer icon)
- Replaced the broken person icon URL with an inline SVG data URI (person/user icon)
- Both replacements applied in both email templates (`approversEmailTemplate` and `requestersEmailTemplate`)
- Bumped `appmixer.utils.tasks` bundle version to `1.1.2`

## Why inline SVG?

Using `data:image/svg+xml` URIs means:
- No external HTTP requests at email render time
- No dependency on third-party CDN availability
- Icons always render regardless of host/network environment

Fixes Appmixer-ai/appmixer-components#2675