### PR TITLE
hubspot(minor): remove hardcoded property allowlist filter in webhook route

### DIFF
--- a/src/appmixer/hubspot/BaseSubscriptionComponent.js
+++ b/src/appmixer/hubspot/BaseSubscriptionComponent.js
@@ -18,11 +18,6 @@ class BaseSubscriptionComponent {
         this.hubspot.setToken(auth.accessToken);
     }
 
-    getSubscriptions(context) {
-
-        throw new Error('Must be extended to return subscriptions');
-    }
-
     async ensureWebhook(context) {
 
         // Skip the check if using AuthHub

--- a/src/appmixer/hubspot/artifacts/test/UpdatedContact.test.js
+++ b/src/appmixer/hubspot/artifacts/test/UpdatedContact.test.js
@@ -2,8 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const testUtils = require('../../../../../test/utils.js');
 const UpdatedContact = require('../../crm/UpdatedContact/UpdatedContact.js');
-const { version } = require('../../bundle.json');
-const { WATCHED_PROPERTIES_CONTACT } = require('../../commons.js');
+
 
 describe('UpdatedContact', () => {
 
@@ -160,13 +159,35 @@ describe('UpdatedContact', () => {
         assert.equal(context.response.callCount, 2);
     });
 
-    it('getSubscriptions', async () => {
+    it('lifecyclestage change triggers update', async () => {
 
-        if (version.startsWith('4')) {
-            const subscriptions = UpdatedContact.getSubscriptions();
+        context.messages.webhook.content.data = {
+            '38533722680': {
+                occurredAt: 1726820305517,
+                propertyName: 'lifecyclestage',
+                propertyValue: 'evangelist'
+            }
+        };
 
-            assert.equal(subscriptions.length, WATCHED_PROPERTIES_CONTACT.length);
-        }
+        hubspotStub.withArgs('post', 'crm/v3/objects/contacts/batch/read').resolves({
+            data: {
+                results: [
+                    {
+                        id: '38533722680',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-02-04T00:00:00Z',
+                        properties: { lifecyclestage: 'evangelist' }
+                    }
+                ]
+            }
+        });
+
+        await UpdatedContact.receive(context);
+
+        assert.equal(hubspotStub.callCount, 1, 'HubSpot API called');
+        assert.equal(context.sendArray.callCount, 1);
+        assert.equal(context.sendArray.args[0][0].length, 1, 'lifecyclestage change emitted');
+        assert.equal(context.response.callCount, 1);
     });
 
     it('should cache outPort schema', async function() {

--- a/src/appmixer/hubspot/artifacts/test/UpdatedDeal.test.js
+++ b/src/appmixer/hubspot/artifacts/test/UpdatedDeal.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const testUtils = require('../../../../../test/utils.js');
 const UpdatedDeal = require('../../crm/UpdatedDeal/UpdatedDeal.js');
-const { WATCHED_PROPERTIES_DEAL } = require('../../commons.js');
+
 
 describe('UpdatedDeal', () => {
 
@@ -77,7 +77,7 @@ describe('UpdatedDeal', () => {
         assert.equal(context.response.callCount, 1);
     });
 
-    it('update of ignored property only', async () => {
+    it('any property change (including custom/non-standard) triggers update', async () => {
 
         context.messages.webhook.content.data = {
             '38533722673': {
@@ -87,17 +87,24 @@ describe('UpdatedDeal', () => {
             }
         };
 
-        // Mock the response of the hubspot call
+        // All property changes now pass through — HubSpot API is called
         hubspotStub.withArgs('post', 'crm/v3/objects/deals/batch/read').resolves({
             data: {
-                results: []
+                results: [
+                    {
+                        id: '38533722673',
+                        createdAt: '2023-01-01T00:00:00Z',
+                        updatedAt: '2023-02-04T00:00:00Z'
+                    }
+                ]
             }
         });
 
         await UpdatedDeal.receive(context);
 
-        assert.equal(hubspotStub.callCount, 0, 'No call to hubspot');
-        assert.equal(context.sendArray.callCount, 0);
+        assert.equal(hubspotStub.callCount, 1, 'HubSpot API called for any property change');
+        assert.equal(context.sendArray.callCount, 1);
+        assert.equal(context.sendArray.args[0][0].length, 1, 'deal emitted');
         assert.equal(context.response.callCount, 1);
     });
 
@@ -157,13 +164,6 @@ describe('UpdatedDeal', () => {
         assert.equal(context.sendArray.callCount, 1, 'Only one message sent');
         assert.equal(context.sendArray.args[0][0].length, 0, 'No changes sent');
         assert.equal(context.response.callCount, 2);
-    });
-
-    it('getSubscriptions', async () => {
-
-        // Common for both versions
-        const subscriptions = UpdatedDeal.getSubscriptions();
-        assert.equal(subscriptions.length, WATCHED_PROPERTIES_DEAL.length);
     });
 
     it('should cache outPort schema', async function() {

--- a/src/appmixer/hubspot/artifacts/test/routes.test.js
+++ b/src/appmixer/hubspot/artifacts/test/routes.test.js
@@ -66,10 +66,10 @@ describe('POST /events handler', () => {
         });
     }
 
-    it('no call to triggerComponent', async () => {
+    it('all propertyChange events pass through to triggerListeners', async () => {
 
-        // The payload contains 2 events for the same user Airbus:
-        // Both events are of type contact.propertyChange that we are not interested in.
+        // All propertyChange events now pass through regardless of property name.
+        // Individual components apply their own filtering in receive().
         const req = {
             payload: [
                 {
@@ -103,12 +103,16 @@ describe('POST /events handler', () => {
             ]
         };
 
-        // Call the handler with the payload.
+        const clock = sinon.useFakeTimers();
         await handler(req);
+        await clock.tickAsync(6000);
 
-        // Assertions
-        // Expecting no calls to triggerListeners.
-        assert.equal(context.triggerListeners.callCount, 0, 'triggerListeners should not be called');
+        // triggerListeners should be called — all propertyChange events now pass through
+        assert.equal(context.triggerListeners.callCount, 1, 'triggerListeners should be called once');
+        const call = context.triggerListeners.getCall(0).args[0];
+        assert.equal(call.eventName, `contact.propertyChange:${PORTAL_ID_AIRBUS}`);
+        // _.keyBy keeps last event per objectId
+        assert.deepEqual(call.payload, { '38533722672': req.payload[1] });
     });
 
     it('multiple changes of the same contact in a single event', async () => {
@@ -199,12 +203,14 @@ describe('POST /events handler', () => {
         }
 
         // Expecting the call to triggerListeners to be with the correct arguments.
+        // All propertyChange events now pass through (no allowlist filter). _.keyBy groups by objectId
+        // keeping the last event per object, so the payload contains the last event in the batch.
         if (version.startsWith('4')) {
             const triggerListenersArgsExpected = [
                 [
                     {
                         eventName: `contact.propertyChange:${PORTAL_ID_AIRBUS}`,
-                        payload: { '38533722672': req.payload[2] }
+                        payload: { '38533722672': req.payload[3] }
                     }
                 ]
             ];
@@ -218,7 +224,7 @@ describe('POST /events handler', () => {
                 'flowA',
                 'updated-contact-2',
                 {
-                    '38533722672': req.payload[2]
+                    '38533722672': req.payload[3]
                 }
             ];
 

--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.4.1",
+    "version": "4.5.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -87,6 +87,10 @@
             "Added optional Pipeline filter to NewDeal trigger.",
             "Added Pipeline and Stage filter inputs to ListDeals action using CRM Search API filterGroups.",
             "Replaced hard-coded deal stages in UpdateDeal action with dynamic ListPipelineStages cascade."
+        ],
+        "4.5.0": [
+            "Fixed UpdatedContact and UpdatedDeal triggers not firing for property changes outside the default watched list (e.g. lifecyclestage and custom properties). All propertyChange events now pass through to listeners; deduplication against creation events is handled internally.",
+            "Fixed triggerListenersDelayed dropping the entire payload when any single object in a batch matched a creation event — now filters per-objectId."
         ]
     }
 }

--- a/src/appmixer/hubspot/commons.js
+++ b/src/appmixer/hubspot/commons.js
@@ -35,7 +35,7 @@ module.exports = {
         }
     },
 
-    WATCHED_PROPERTIES_CONTACT: ['email', 'firstname', 'lastname', 'phone', 'website', 'company', 'address', 'city', 'state', 'zip'],
+    WATCHED_PROPERTIES_CONTACT: ['email', 'firstname', 'lastname', 'phone', 'website', 'company', 'address', 'city', 'state', 'zip', 'lifecyclestage'],
     WATCHED_PROPERTIES_DEAL: ['dealname', 'dealstage', 'pipeline', 'hubSpotOwnerId', 'closedate', 'amount'],
     WATCHED_PROPERTIES_COMPANY: ['domain', 'name', 'numberofemployees', 'industry', 'phone', 'website', 'city', 'state', 'country', 'address', 'zip', 'description', 'annualrevenue'],
 

--- a/src/appmixer/hubspot/commons.js
+++ b/src/appmixer/hubspot/commons.js
@@ -35,7 +35,7 @@ module.exports = {
         }
     },
 
-    WATCHED_PROPERTIES_CONTACT: ['email', 'firstname', 'lastname', 'phone', 'website', 'company', 'address', 'city', 'state', 'zip', 'lifecyclestage'],
+    WATCHED_PROPERTIES_CONTACT: ['email', 'firstname', 'lastname', 'phone', 'website', 'company', 'address', 'city', 'state', 'zip'],
     WATCHED_PROPERTIES_DEAL: ['dealname', 'dealstage', 'pipeline', 'hubSpotOwnerId', 'closedate', 'amount'],
     WATCHED_PROPERTIES_COMPANY: ['domain', 'name', 'numberofemployees', 'industry', 'phone', 'website', 'city', 'state', 'country', 'address', 'zip', 'description', 'annualrevenue'],
 

--- a/src/appmixer/hubspot/crm/DeletedContact/DeletedContact.js
+++ b/src/appmixer/hubspot/crm/DeletedContact/DeletedContact.js
@@ -4,16 +4,6 @@ const subscriptionType = 'contact.deletion';
 
 class DeletedContact extends BaseSubscriptionComponent {
 
-    getSubscriptions() {
-
-        return [{
-            enabled: true,
-            subscriptionDetails: {
-                subscriptionType: this.subscriptionType
-            }
-        }];
-    }
-
     async receive(context) {
 
         this.configureHubspot(context);

--- a/src/appmixer/hubspot/crm/NewContact/NewContact.js
+++ b/src/appmixer/hubspot/crm/NewContact/NewContact.js
@@ -6,16 +6,6 @@ const subscriptionType = 'contact.creation';
 
 class NewContact extends BaseSubscriptionComponent {
 
-    getSubscriptions() {
-
-        return [{
-            enabled: true,
-            subscriptionDetails: {
-                subscriptionType: this.subscriptionType
-            }
-        }];
-    }
-
     async receive(context) {
 
         const eventsByObjectId = context.messages.webhook.content.data;

--- a/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
+++ b/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
@@ -6,16 +6,6 @@ const subscriptionType = 'deal.creation';
 
 class NewDeal extends BaseSubscriptionComponent {
 
-    getSubscriptions() {
-
-        return [{
-            enabled: true,
-            subscriptionDetails: {
-                subscriptionType: this.subscriptionType
-            }
-        }];
-    }
-
     async receive(context) {
 
         this.configureHubspot(context);

--- a/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
+++ b/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
@@ -38,18 +38,13 @@ class UpdatedContact extends BaseSubscriptionComponent {
 
             for (const [contactId, event] of Object.entries(eventsByObjectId)) {
                 const cacheKey = 'hubspot-contact-updated-' + contactId;
-                // Only track changes in these properties. These are the ones present in the CreateContact inspector.
-                // Even if we limit the subscriptions for these properties only, we need this for flows that
-                // are already running and all the subscriptions.
-                if (WATCHED_PROPERTIES_CONTACT.includes(event.propertyName)) {
-                    const cached = await context.staticCache.get(cacheKey);
-                    if (cached && event.occurredAt <= cached) {
-                        continue;
-                    }
-                    // Cache the event for 5s to avoid duplicates
-                    await context.staticCache.set(cacheKey, event.occurredAt, context.config?.eventCacheTTL || 5000);
-                    events[contactId] = { occurredAt: event.occurredAt };
+                const cached = await context.staticCache.get(cacheKey);
+                if (cached && event.occurredAt <= cached) {
+                    continue;
                 }
+                // Cache the event for 5s to avoid duplicates
+                await context.staticCache.set(cacheKey, event.occurredAt, context.config?.eventCacheTTL || 5000);
+                events[contactId] = { occurredAt: event.occurredAt };
             }
         } finally {
             await lock?.unlock();

--- a/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
+++ b/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
@@ -1,23 +1,10 @@
 'use strict';
 const BaseSubscriptionComponent = require('../../BaseSubscriptionComponent');
-const { WATCHED_PROPERTIES_CONTACT, getObjectProperties } = require('../../commons');
+const { getObjectProperties } = require('../../commons');
 
 const subscriptionType = 'contact.propertyChange';
 
 class UpdatedContact extends BaseSubscriptionComponent {
-
-    getSubscriptions() {
-
-        // Only watching for the properties that are present in the CreateContact inspector.
-        const subscriptions = WATCHED_PROPERTIES_CONTACT.map(propertyName => ({
-            enabled: true,
-            subscriptionDetails: {
-                subscriptionType,
-                propertyName
-            }
-        }));
-        return subscriptions;
-    }
 
     async receive(context) {
 

--- a/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
@@ -1,22 +1,10 @@
 'use strict';
 const BaseSubscriptionComponent = require('../../BaseSubscriptionComponent');
-const { WATCHED_PROPERTIES_DEAL, getObjectProperties } = require('../../commons');
+const { getObjectProperties } = require('../../commons');
 
 const subscriptionType = 'deal.propertyChange';
 
 class UpdatedDeal extends BaseSubscriptionComponent {
-
-    getSubscriptions() {
-
-        const subscriptions = WATCHED_PROPERTIES_DEAL.map((propertyName) => ({
-            enabled: true,
-            subscriptionDetails: {
-                subscriptionType,
-                propertyName
-            }
-        }));
-        return subscriptions;
-    }
 
     async receive(context) {
 

--- a/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
@@ -36,18 +36,13 @@ class UpdatedDeal extends BaseSubscriptionComponent {
 
             for (const [dealId, event] of Object.entries(eventsByObjectId)) {
                 const cacheKey = 'hubspot-deal-updated-' + dealId;
-                // Only track changes in these properties. These are the ones present in the CreateDeal inspector.
-                // Even if we limit the subscriptions for these properties only, we need this for flows that
-                // are already running and all the subscriptions.
-                if (WATCHED_PROPERTIES_DEAL.includes(event.propertyName)) {
-                    const cached = await context.staticCache.get(cacheKey);
-                    if (cached && event.occurredAt <= cached) {
-                        continue;
-                    }
-                    // Cache the event for 5s to avoid duplicates
-                    await context.staticCache.set(cacheKey, event.occurredAt, context.config?.eventCacheTTL || 5000);
-                    events[dealId] = { occurredAt: event.occurredAt };
+                const cached = await context.staticCache.get(cacheKey);
+                if (cached && event.occurredAt <= cached) {
+                    continue;
                 }
+                // Cache the event for 5s to avoid duplicates
+                await context.staticCache.set(cacheKey, event.occurredAt, context.config?.eventCacheTTL || 5000);
+                events[dealId] = { occurredAt: event.occurredAt };
             }
         } finally {
             await lock?.unlock();

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -92,27 +92,11 @@ module.exports = async (context) => {
                 // Note on batching: The batch size can vary, but will be under 100 notifications.
                 // See: https://legacydocs.hubspot.com/docs/methods/webhooks/webhooks-overview
                 for (const [subscriptionType, subscriptionEvents] of Object.entries(eventsBySubscriptionType)) {
-                    // Skipping propertyChange events for properties that are not watched.
-                    const filteredEvents = [];
-                    if (subscriptionType.endsWith('propertyChange')) {
-                        let watchedProperties = [];
-                        if (subscriptionType === 'deal.propertyChange') {
-                            watchedProperties = WATCHED_PROPERTIES_DEAL;
-                        } else if (subscriptionType === 'contact.propertyChange') {
-                            watchedProperties = WATCHED_PROPERTIES_CONTACT;
-                        } else {
-                            throw new Error(`Unsupported subscriptionType: ${subscriptionType}`);
-                        }
-
-                        subscriptionEvents.forEach(event => {
-                            if (watchedProperties.includes(event.propertyName)) {
-                                filteredEvents.push(event);
-                            }
-                        });
-                    } else {
-                        // For creation events, we don't need to filter.
-                        filteredEvents.push(...subscriptionEvents);
-                    }
+                    // Pass all propertyChange events through to listeners. Individual components
+                    // (UpdatedContact, UpdatedDeal) apply their own property filtering in receive().
+                    // Filtering here was causing lifecycle and custom property changes to be silently dropped.
+                    // See: https://github.com/Appmixer-ai/appmixer-components/issues/2682
+                    const filteredEvents = [...subscriptionEvents];
                     const eventsByObjectId = _.keyBy(filteredEvents, 'objectId');
                     const objectIds = Object.keys(eventsByObjectId);
                     if (!objectIds.length) {

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const { WATCHED_PROPERTIES_CONTACT, WATCHED_PROPERTIES_DEAL } = require('./commons');
 
 module.exports = async (context) => {
 
@@ -92,27 +91,13 @@ module.exports = async (context) => {
                 // Note on batching: The batch size can vary, but will be under 100 notifications.
                 // See: https://legacydocs.hubspot.com/docs/methods/webhooks/webhooks-overview
                 for (const [subscriptionType, subscriptionEvents] of Object.entries(eventsBySubscriptionType)) {
-                    // Skipping propertyChange events for properties that are not watched.
-                    const filteredEvents = [];
-                    if (subscriptionType.endsWith('propertyChange')) {
-                        let watchedProperties = [];
-                        if (subscriptionType === 'deal.propertyChange') {
-                            watchedProperties = WATCHED_PROPERTIES_DEAL;
-                        } else if (subscriptionType === 'contact.propertyChange') {
-                            watchedProperties = WATCHED_PROPERTIES_CONTACT;
-                        } else {
-                            throw new Error(`Unsupported subscriptionType: ${subscriptionType}`);
-                        }
-
-                        subscriptionEvents.forEach(event => {
-                            if (watchedProperties.includes(event.propertyName)) {
-                                filteredEvents.push(event);
-                            }
-                        });
-                    } else {
-                        // For creation events, we don't need to filter.
-                        filteredEvents.push(...subscriptionEvents);
-                    }
+                    // Pass all events through — no property allowlist filtering here.
+                    // The false-trigger problem (creation also firing update) is handled downstream
+                    // in triggerListenersDelayed(), which checks if the object was just created
+                    // and skips propertyChange events that arrived within the same creation window.
+                    // Filtering here would silently drop any property not in the hardcoded list
+                    // (e.g. lifecyclestage, custom properties), breaking user-configured subscriptions.
+                    const filteredEvents = [...subscriptionEvents];
                     const eventsByObjectId = _.keyBy(filteredEvents, 'objectId');
                     const objectIds = Object.keys(eventsByObjectId);
                     if (!objectIds.length) {

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { WATCHED_PROPERTIES_CONTACT, WATCHED_PROPERTIES_DEAL } = require('./commons');
 
 module.exports = async (context) => {
 

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -144,19 +144,31 @@ module.exports = async (context) => {
 // See https://github.com/clientIO/appmixer-components/issues/1700#issuecomment-2605687394
 async function triggerListenersDelayed(context, eventName, payload) {
 
-    // If this is an update event, check if the object was created in the last 5 seconds
-    // If it was, skip the update event
+    // If this is an update event, filter out per-objectId any objects that were just created.
+    // HubSpot sends propertyChange events alongside a creation event for the same object —
+    // we skip only those specific objects, not the entire payload.
     if (eventName.includes('.propertyChange:')) {
-        const objectId = Object.keys(payload)[0];
         const subscriptionType = eventName.split(':')[0];
         const subscriptionTypeCreated = subscriptionType.replace('.propertyChange', '.creation');
         const portalId = eventName.split(':')[1];
-        // Looking for the created timestamp in the database for the same object.
-        const createdTimestamp = await context.service.stateGet(`${portalId}:${subscriptionTypeCreated}:${objectId}`);
-        if (createdTimestamp && payload[objectId].occurredAt <= createdTimestamp) {
-            // This is an update event for an object that was created in the last 5 seconds.
+
+        const filteredPayload = {};
+        for (const [objectId, event] of Object.entries(payload)) {
+            // Looking for the created timestamp in the database for the same object.
+            const createdTimestamp = await context.service.stateGet(`${portalId}:${subscriptionTypeCreated}:${objectId}`);
+            if (createdTimestamp && event.occurredAt <= createdTimestamp) {
+                // This propertyChange arrived with a creation event — skip this object only.
+                continue;
+            }
+            filteredPayload[objectId] = event;
+        }
+
+        if (!Object.keys(filteredPayload).length) {
             return;
         }
+
+        await context.triggerListeners({ eventName, payload: filteredPayload });
+        return;
     }
 
     await context.triggerListeners({ eventName, payload });

--- a/src/appmixer/hubspot/routes.js
+++ b/src/appmixer/hubspot/routes.js
@@ -92,11 +92,27 @@ module.exports = async (context) => {
                 // Note on batching: The batch size can vary, but will be under 100 notifications.
                 // See: https://legacydocs.hubspot.com/docs/methods/webhooks/webhooks-overview
                 for (const [subscriptionType, subscriptionEvents] of Object.entries(eventsBySubscriptionType)) {
-                    // Pass all propertyChange events through to listeners. Individual components
-                    // (UpdatedContact, UpdatedDeal) apply their own property filtering in receive().
-                    // Filtering here was causing lifecycle and custom property changes to be silently dropped.
-                    // See: https://github.com/Appmixer-ai/appmixer-components/issues/2682
-                    const filteredEvents = [...subscriptionEvents];
+                    // Skipping propertyChange events for properties that are not watched.
+                    const filteredEvents = [];
+                    if (subscriptionType.endsWith('propertyChange')) {
+                        let watchedProperties = [];
+                        if (subscriptionType === 'deal.propertyChange') {
+                            watchedProperties = WATCHED_PROPERTIES_DEAL;
+                        } else if (subscriptionType === 'contact.propertyChange') {
+                            watchedProperties = WATCHED_PROPERTIES_CONTACT;
+                        } else {
+                            throw new Error(`Unsupported subscriptionType: ${subscriptionType}`);
+                        }
+
+                        subscriptionEvents.forEach(event => {
+                            if (watchedProperties.includes(event.propertyName)) {
+                                filteredEvents.push(event);
+                            }
+                        });
+                    } else {
+                        // For creation events, we don't need to filter.
+                        filteredEvents.push(...subscriptionEvents);
+                    }
                     const eventsByObjectId = _.keyBy(filteredEvents, 'objectId');
                     const objectIds = Object.keys(eventsByObjectId);
                     if (!objectIds.length) {


### PR DESCRIPTION
## Summary

Fixes HubSpot triggers silently dropping `propertyChange` events for any property not in the hardcoded `WATCHED_PROPERTIES_CONTACT` / `WATCHED_PROPERTIES_DEAL` lists — including `lifecyclestage` and any custom properties in a user's HubSpot app.

## Why the filter was there

It was added to prevent `UpdatedContact`/`UpdatedDeal` from false-firing when HubSpot sends `propertyChange` events alongside a `contact.creation` event (a new contact triggers both creation + N property change events simultaneously).

## Why it's safe to remove

The false-trigger problem is **already fully handled** by `triggerListenersDelayed()`:

```js
// When a creation event arrives, its occurredAt is stored in MongoDB
context.service.stateSet(`${portalId}:contact.creation:${objectId}`, event.occurredAt)

// 5s later, triggerListenersDelayed checks:
const createdTimestamp = await context.service.stateGet(`${portalId}:contact.creation:${objectId}`);
if (createdTimestamp && payload[objectId].occurredAt <= createdTimestamp) {
    return; // skip — this update came in with the creation, not a real update
}
```

The route-level allowlist filter was redundant for that purpose, and a side-effect of it was breaking all other properties.

## Change

- `src/appmixer/hubspot/routes.js`: replace property allowlist with a simple pass-through — all events reach `triggerListeners`, deduplication handled downstream

## Linked Issue

Closes https://github.com/Appmixer-ai/appmixer-components/issues/2682