### PR TITLE
todoist(patch): replace deprecated endpoints with new ones

### DIFF
--- a/src/appmixer/todoist/auth.js
+++ b/src/appmixer/todoist/auth.js
@@ -18,18 +18,14 @@ module.exports = {
 
             requestProfileInfo: async (context) => {
 
-                const response = await context.httpRequest({
-                    method: 'POST',
-                    url: 'https://api.todoist.com/sync/v9/sync',
+                const { data } = await context.httpRequest({
+                    method: 'GET',
+                    url: 'https://api.todoist.com/api/v1/user',
                     headers: {
                         'Authorization': `Bearer ${context.accessToken}`
-                    },
-                    data:  {
-                        resource_types: ['user']
                     }
                 });
-
-                return response?.data.user;
+                return data;
             },
 
             validateAccessToken: async (context) => {

--- a/src/appmixer/todoist/auth.js
+++ b/src/appmixer/todoist/auth.js
@@ -32,7 +32,7 @@ module.exports = {
 
                 const response = await context.httpRequest({
                     method: 'GET',
-                    url: 'https://api.todoist.com/rest/v2/projects',
+                    url: 'https://api.todoist.com/api/v1/user',
                     headers: {
                         'Authorization': `Bearer ${context.accessToken}`
                     }

--- a/src/appmixer/todoist/bundle.json
+++ b/src/appmixer/todoist/bundle.json
@@ -1,7 +1,8 @@
 {
     "name": "appmixer.todoist",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
-        "1.0.0": ["Initial version"]
+        "1.0.0": ["Initial version"],
+        "1.0.1": ["Replace deprecated API endpoints with new ones."]
     }
 }


### PR DESCRIPTION
Replaces deprecated Todoist API endpoints with updated ones.

**Changes:**
- `auth.js`: updated API endpoint URLs to use non-deprecated versions

**Bundle:** `1.0.0` → `1.0.1` (patch)