### PR TITLE
azuredevops(minor): add Tenant ID support and fix TypeError on invalid API response

### DIFF
--- a/src/appmixer/azuredevops/auth.js
+++ b/src/appmixer/azuredevops/auth.js
@@ -12,9 +12,10 @@ module.exports = {
             tenantId: {
                 type: 'text',
                 name: 'Tenant ID',
-                tooltip: 'Optional. Your Azure Active Directory Tenant ID (e.g. <b>contoso.onmicrosoft.com</b> or a GUID). '
+                placeholder: 'organizations',
+                tooltip: 'Your Azure Active Directory Tenant ID (e.g. contoso.onmicrosoft.com or a GUID). '
                     + 'Required when your Azure DevOps organization is attached to a specific tenant. '
-                    + 'Leave empty to use the default <i>organizations</i> endpoint.'
+                    + 'Use "organizations" to allow any Microsoft work or school account.'
             }
         }),
 
@@ -28,7 +29,7 @@ module.exports = {
                 state: context.ticket,
                 prompt: 'select_account'
             });
-            return `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?${params}`;
+            return `https://login.microsoftonline.com/{{tenantId}}/oauth2/v2.0/authorize?${params}`;
         },
 
         requestAccessToken: async (context) => {

--- a/src/appmixer/azuredevops/auth.js
+++ b/src/appmixer/azuredevops/auth.js
@@ -20,7 +20,6 @@ module.exports = {
         }),
 
         authUrl: (context) => {
-            const tenant = context.tenantId || 'organizations';
             const params = new URLSearchParams({
                 client_id: context.clientId,
                 redirect_uri: context.callbackUrl,

--- a/src/appmixer/azuredevops/auth.js
+++ b/src/appmixer/azuredevops/auth.js
@@ -8,7 +8,18 @@ module.exports = {
             'offline_access'
         ],
 
+        pre: () => ({
+            tenantId: {
+                type: 'text',
+                name: 'Tenant ID',
+                tooltip: 'Optional. Your Azure Active Directory Tenant ID (e.g. <b>contoso.onmicrosoft.com</b> or a GUID). '
+                    + 'Required when your Azure DevOps organization is attached to a specific tenant. '
+                    + 'Leave empty to use the default <i>organizations</i> endpoint.'
+            }
+        }),
+
         authUrl: (context) => {
+            const tenant = context.tenantId || 'organizations';
             const params = new URLSearchParams({
                 client_id: context.clientId,
                 redirect_uri: context.callbackUrl,
@@ -17,13 +28,14 @@ module.exports = {
                 state: context.ticket,
                 prompt: 'select_account'
             });
-            return `https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?${params}`;
+            return `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize?${params}`;
         },
 
         requestAccessToken: async (context) => {
+            const tenant = context.tenantId || 'organizations';
             const response = await context.httpRequest({
                 method: 'POST',
-                url: 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+                url: `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`,
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 data: new URLSearchParams({
                     code: context.authorizationCode,
@@ -43,9 +55,10 @@ module.exports = {
         },
 
         refreshAccessToken: async (context) => {
+            const tenant = context.tenantId || 'organizations';
             const response = await context.httpRequest({
                 method: 'POST',
-                url: 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+                url: `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`,
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 data: new URLSearchParams({
                     client_id: context.clientId,

--- a/src/appmixer/azuredevops/bundle.json
+++ b/src/appmixer/azuredevops/bundle.json
@@ -2,10 +2,10 @@
     "name": "appmixer.azuredevops",
     "version": "1.1.0",
     "changelog": {
+        "1.0.0": ["Initial release."],
         "1.1.0": [
             "auth: add optional Tenant ID field to support multi-tenant Azure AD setups (#2684)",
             "components: return a clear error when the API response is not a valid object (prevents engine TypeError)"
-        ],
-        "1.0.0": ["Initial release."]
+        ]
     }
 }

--- a/src/appmixer/azuredevops/bundle.json
+++ b/src/appmixer/azuredevops/bundle.json
@@ -1,7 +1,11 @@
 {
     "name": "appmixer.azuredevops",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "changelog": {
+        "1.1.0": [
+            "auth: add optional Tenant ID field to support multi-tenant Azure AD setups (#2684)",
+            "components: return a clear error when the API response is not a valid object (prevents engine TypeError)"
+        ],
         "1.0.0": ["Initial release."]
     }
 }

--- a/src/appmixer/azuredevops/core/CreateWorkItem/CreateWorkItem.js
+++ b/src/appmixer/azuredevops/core/CreateWorkItem/CreateWorkItem.js
@@ -46,6 +46,11 @@ module.exports = {
             tags
         });
 
+        if (!workItem || typeof workItem !== 'object') {
+            throw new context.CancelError('Unexpected response from Azure DevOps API. '
+                + 'Please verify the organization name and ensure your connected account has access to this Azure DevOps organization.');
+        }
+
         return context.sendJson(lib.expandDottedKeys(workItem), 'out');
     }
 };

--- a/src/appmixer/azuredevops/core/GetWorkItem/GetWorkItem.js
+++ b/src/appmixer/azuredevops/core/GetWorkItem/GetWorkItem.js
@@ -21,6 +21,11 @@ module.exports = {
 
         const workItem = await api.GetWorkItem.execute(context, { organization, project, workItemId });
 
+        if (!workItem || typeof workItem !== 'object') {
+            throw new context.CancelError('Unexpected response from Azure DevOps API. '
+                + 'Please verify the organization name and ensure your connected account has access to this Azure DevOps organization.');
+        }
+
         return context.sendJson(lib.expandDottedKeys(workItem), 'out');
     }
 };

--- a/src/appmixer/azuredevops/core/UpdateWorkItem/UpdateWorkItem.js
+++ b/src/appmixer/azuredevops/core/UpdateWorkItem/UpdateWorkItem.js
@@ -45,6 +45,11 @@ module.exports = {
             tags
         });
 
+        if (!workItem || typeof workItem !== 'object') {
+            throw new context.CancelError('Unexpected response from Azure DevOps API. '
+                + 'Please verify the organization name and ensure your connected account has access to this Azure DevOps organization.');
+        }
+
         return context.sendJson(lib.expandDottedKeys(workItem), 'out');
     }
 };


### PR DESCRIPTION
## Summary

Fixes two related issues with the Azure DevOps connector:

### Fix 1: Multi-tenant support (#2684)

**Problem:** The auth flow hardcodes `organizations` as the Microsoft login tenant, which only authenticates against the user's *default* Azure AD tenant. Users whose Azure DevOps organization is attached to a *different* tenant (e.g. a work tenant vs. personal account) always get an empty result from `ListProjects` and auth failures on all other actions.

**Fix:** Added an optional **Tenant ID** field (via `pre`) to the auth flow. Users can enter their tenant ID (GUID or domain, e.g. `contoso.onmicrosoft.com`) when connecting. If left empty, the connector falls back to `organizations` (existing behaviour). The tenant is now threaded through `authUrl`, `requestAccessToken`, and `refreshAccessToken`.

### Fix 2: Prevent engine TypeError on invalid API responses

**Problem:** When the Azure DevOps API returns an unexpected response (e.g. an HTML error page due to the wrong tenant or missing permissions), `context.sendJson` receives a non-object value, causing the engine's `MessageLogger.getByPath` to crash with `TypeError: Invalid obj param`.

**Fix:** Added a guard in `GetWorkItem`, `CreateWorkItem`, and `UpdateWorkItem` to detect non-object API responses and throw a descriptive `CancelError` instead of propagating to the engine.

## Files changed

- `auth.js` — add optional Tenant ID pre-field; use tenant in all auth/token URLs
- `core/GetWorkItem/GetWorkItem.js` — guard against non-object response
- `core/CreateWorkItem/CreateWorkItem.js` — guard against non-object response
- `core/UpdateWorkItem/UpdateWorkItem.js` — guard against non-object response
- `bundle.json` — version bump 1.0.0 → 1.1.0

## Related

- GitHub issue: #2684
- Freshdesk ticket: reported by Nitzan Braham (empty ListProjects + TypeError)