### PR TITLE
utils.forms(patch): update tooltip on Logo URL field

### DIFF
--- a/src/appmixer/utils/forms/FormAction/component.json
+++ b/src/appmixer/utils/forms/FormAction/component.json
@@ -33,7 +33,7 @@
                     "logo": {
                         "type": "text",
                         "label": "Logo URL",
-                        "tooltip": "URL of a logo image to display in the form header and footer. Defaults to the Appmixer logo.",
+                        "tooltip": "URL of a logo image to display in the form header and footer.",
                         "index": 2,
                         "group": "configuration"
                     },

--- a/src/appmixer/utils/forms/FormTrigger/component.json
+++ b/src/appmixer/utils/forms/FormTrigger/component.json
@@ -26,7 +26,7 @@
                 "logo": {
                     "type": "text",
                     "label": "Logo URL",
-                    "tooltip": "URL of a logo image to display in the form header and footer. Defaults to the Appmixer logo.",
+                    "tooltip": "URL of a logo image to display in the form header and footer.",
                     "index": 2,
                     "group": "configuration"
                 },

--- a/src/appmixer/utils/forms/bundle.json
+++ b/src/appmixer/utils/forms/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.forms",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -10,6 +10,9 @@
         ],
         "1.1.0": [
             "Form Trigger and Form Action: expose Logo URL field in inspector."
+        ],
+        "1.1.1": [
+            "Form Trigger and Form Action: update tooltips on Logo URL field."
         ]
     }
 }


### PR DESCRIPTION
## Summary

- Removes "Defaults to the Appmixer logo." from the Logo URL tooltip in both `FormTrigger` and `FormAction` — the default behaviour is an implementation detail, not relevant to users configuring the field
- Bumps `utils.forms` to `1.1.1`

## Test plan

- [ ] Open a flow with `FormTrigger` or `FormAction`, hover the Logo URL field, confirm tooltip reads: *"URL of a logo image to display in the form header and footer."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)