### PR TITLE
fix(makeapicall): standardize all MakeApiCall components - key-value inputs, URL slash guard, missing fields

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -27,6 +27,10 @@
 //   --update-thresholds        write lowered thresholds back when counts drop
 //   --connector <name>         run all validators only for src/appmixer/<name>/,
 //                              ignore thresholds, print every failure + warning
+//   --show-suppressed          print failures that are normally hidden by a
+//                              threshold (count ≤ threshold), so they can be
+//                              fixed. Does not change CI exit status.
+//   --help, -h                 print usage and exit
 
 const fs = require('fs');
 const path = require('path');
@@ -93,10 +97,49 @@ function parseConnectorArg(argv) {
     return value;
 }
 
+function printHelp() {
+
+    console.log(`Usage: node scripts/validate.js [options]
+
+Runs all validators in scripts/validators/ over bundle.json and component.json
+files under src/appmixer/. Validators with an entry in
+scripts/validators/.thresholds.json fail CI only when their failure count
+exceeds the threshold (ratchet pattern); validators without an entry are strict.
+
+Options:
+  --connector <name>     Run all validators only for src/appmixer/<name>/.
+                         Thresholds are ignored and every failure + warning is
+                         printed. Useful when developing a single connector.
+
+  --show-suppressed      Print failures that are normally hidden because the
+                         validator is at or under its threshold. Use this when
+                         you want to fix the leftover issues. Does not change
+                         the CI exit status.
+
+  --update-thresholds    When a validator's failure count drops below its
+                         current threshold, write the lower number back to
+                         .thresholds.json so the ratchet tightens.
+
+  --help, -h             Print this help and exit.
+
+Examples:
+  node scripts/validate.js
+  node scripts/validate.js --connector google/calendar
+  node scripts/validate.js --show-suppressed
+  node scripts/validate.js --update-thresholds
+`);
+}
+
 async function main() {
+
+    if (process.argv.includes('--help') || process.argv.includes('-h')) {
+        printHelp();
+        return;
+    }
 
     const relativePath = makeRelativePath(REPO_ROOT);
     const updateThresholds = process.argv.includes('--update-thresholds');
+    const showSuppressed = process.argv.includes('--show-suppressed');
     const connectorFilter = parseConnectorArg(process.argv);
 
     let bundleFiles = walkFiles(CONNECTORS_ROOT, (filePath) => path.basename(filePath) === 'bundle.json');
@@ -219,6 +262,25 @@ async function main() {
             for (const warning of result.warnings) {
                 console.warn(`- ${warning}`);
             }
+        }
+    }
+
+    // --show-suppressed: print failures hidden by the threshold so they can be fixed.
+    if (showSuppressed) {
+        const suppressed = results.filter((r) => r.threshold !== null && r.failures.length > 0 && !r.regressed);
+        const totalSuppressed = suppressed.reduce((sum, r) => sum + r.failures.length, 0);
+
+        if (totalSuppressed > 0) {
+            console.log(`\nSuppressed failures (${totalSuppressed}) — under threshold, not failing CI:`);
+
+            for (const result of suppressed) {
+                console.log(`\n  ${result.validator.name} (${result.failures.length} of ${result.threshold} allowed):`);
+                for (const failure of result.failures) {
+                    console.log(`  - ${failure}`);
+                }
+            }
+        } else {
+            console.log('\nNo suppressed failures — all thresholded validators are clean.');
         }
     }
 

--- a/scripts/validators/.thresholds.json
+++ b/scripts/validators/.thresholds.json
@@ -1,5 +1,5 @@
 {
     "dynamic-outport-required-inputs": 85,
-    "makeapicall-standards": 36,
-    "output-port-examples": 10122
+    "makeapicall-standards": 0,
+    "output-port-examples": 9965
 }

--- a/scripts/validators/makeapicall-standards.js
+++ b/scripts/validators/makeapicall-standards.js
@@ -8,17 +8,23 @@
 //
 // Mandatory inputs (FAILURE if missing or wrong shape):
 //   • url        (string, required)         — text input,    "API Endpoint Path"
+//                                              inspector.index = 1
 //   • method     (string, required, enum)   — select input,  defaultValue "GET",
 //                                              5 options: GET, POST, PUT, PATCH, DELETE
-//   • headers    (string)                   — key-value      list of header pairs
+//                                              inspector.index = 2
 //   • parameters (string)                   — key-value      list of query-param pairs (note: not "params")
+//                                              inspector.index = 3
 //   • body       (string)                   — textarea       JSON body — supports
 //                                              nested objects/arrays/non-string
-//                                              values. Headers and parameters use
-//                                              key-value inspector but their JSON
-//                                              Schema type is declared "string" —
-//                                              declaring "array" makes the Designer
-//                                              UI reject the runtime value.
+//                                              values
+//                                              inspector.index = 4
+//   • headers    (string)                   — key-value      list of header pairs
+//                                              inspector.index = 5
+//
+// Headers and parameters use the key-value inspector but their JSON Schema
+// type is declared "string" — declaring "array" makes the Designer UI reject
+// the runtime value. Inspector order is fixed (url → method → parameters →
+// body → headers); deviating order is flagged as a failure.
 //
 // Soft conformance (WARNING):
 //   • method.enum is the full set of 5 HTTP verbs
@@ -40,11 +46,11 @@ const { readJson } = require('./_shared');
 const STANDARD_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
 
 const STANDARD_FIELDS = [
-    { field: 'url', schemaType: 'string', inspectorType: 'text' },
-    { field: 'method', schemaType: 'string', inspectorType: 'select' },
-    { field: 'headers', schemaType: 'string', inspectorType: 'key-value' },
-    { field: 'parameters', schemaType: 'string', inspectorType: 'key-value' },
-    { field: 'body', schemaType: 'string', inspectorType: 'textarea' }
+    { field: 'url', schemaType: 'string', inspectorType: 'text', index: 1 },
+    { field: 'method', schemaType: 'string', inspectorType: 'select', index: 2 },
+    { field: 'parameters', schemaType: 'string', inspectorType: 'key-value', index: 3 },
+    { field: 'body', schemaType: 'string', inspectorType: 'textarea', index: 4 },
+    { field: 'headers', schemaType: 'string', inspectorType: 'key-value', index: 5 }
 ];
 
 function isMakeApiCall(componentPath) {
@@ -89,7 +95,7 @@ function validateInputSchemaField(componentPath, props, required, field, expecte
     }
 }
 
-function validateInspectorInput(componentPath, inputs, field, expectedType, addFailure) {
+function validateInspectorInput(componentPath, inputs, field, expectedType, expectedIndex, addFailure) {
 
     const input = inputs[field];
 
@@ -100,6 +106,10 @@ function validateInspectorInput(componentPath, inputs, field, expectedType, addF
 
     if (input.type !== expectedType) {
         addFailure(componentPath, `inspector.inputs.${field}.type must be "${expectedType}" (found "${input.type}")`);
+    }
+
+    if (input.index !== expectedIndex) {
+        addFailure(componentPath, `inspector.inputs.${field}.index must be ${expectedIndex} (found ${JSON.stringify(input.index)}). Canonical order: url=1, method=2, parameters=3, body=4, headers=5.`);
     }
 }
 
@@ -178,9 +188,9 @@ function validateComponent(componentPath, addFailure, addWarning) {
         addFailure(componentPath, 'inPorts[0].schema.properties.params is legacy — rename to "parameters" (standard #1459)');
     }
 
-    for (const { field, schemaType, inspectorType } of STANDARD_FIELDS) {
+    for (const { field, schemaType, inspectorType, index } of STANDARD_FIELDS) {
         validateInputSchemaField(componentPath, props, required, field, schemaType, addFailure);
-        validateInspectorInput(componentPath, inputs, field, inspectorType, addFailure);
+        validateInspectorInput(componentPath, inputs, field, inspectorType, index, addFailure);
     }
 
     for (const field of ['url', 'method']) {

--- a/scripts/validators/makeapicall-standards.js
+++ b/scripts/validators/makeapicall-standards.js
@@ -143,7 +143,7 @@ function validateScope(componentPath, component, connectorRoot, addWarning) {
     const scope = component.auth && component.auth.scope;
 
     if (!Array.isArray(scope) || scope.length === 0) {
-        addWarning(componentPath, `auth.scope is empty — OAuth-based MakeApiCall should declare scopes (most-privileged or all; see #1459)`);
+        addWarning(componentPath, 'auth.scope is empty — OAuth-based MakeApiCall should declare scopes (most-privileged or all; see #1459)');
     }
 }
 

--- a/scripts/validators/makeapicall-standards.js
+++ b/scripts/validators/makeapicall-standards.js
@@ -1,0 +1,205 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// MakeApiCall components — generic "call any endpoint" helpers — must
+// follow the standard structure documented in
+//   https://github.com/Appmixer-ai/appmixer-components/issues/1459
+//
+// Mandatory inputs (FAILURE if missing or wrong shape):
+//   • url        (string, required)         — text input,    "API Endpoint Path"
+//   • method     (string, required, enum)   — select input,  defaultValue "GET",
+//                                              5 options: GET, POST, PUT, PATCH, DELETE
+//   • headers    (array)                    — key-value      list of header pairs
+//   • parameters (array)                    — key-value      list of query-param pairs (note: not "params")
+//   • body       (string)                   — textarea       JSON body — keeps textarea/JSON
+//                                              because many APIs require nested
+//                                              JSON bodies (objects, arrays,
+//                                              non-string values). Only headers
+//                                              and parameters are naturally flat
+//                                              string maps; the body is not.
+//
+// Soft conformance (WARNING):
+//   • method.enum is the full set of 5 HTTP verbs
+//   • OAuth-based connectors (auth.js exports type: 'oauth2'): the
+//     component's auth.scope is non-empty (per #1459 recommendation to
+//     use the most-privileged scope, or all scopes when not determinable).
+//
+// Scope
+// -----
+// Runs on every component whose folder name is `MakeApiCall`. Connectors
+// without a MakeApiCall component are not flagged — the validator only
+// asserts that existing MakeApiCall components match the standard.
+
+const fs = require('fs');
+const path = require('path');
+
+const { readJson } = require('./_shared');
+
+const STANDARD_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+
+const STANDARD_FIELDS = [
+    { field: 'url', schemaType: 'string', inspectorType: 'text' },
+    { field: 'method', schemaType: 'string', inspectorType: 'select' },
+    { field: 'headers', schemaType: 'array', inspectorType: 'key-value' },
+    { field: 'parameters', schemaType: 'array', inspectorType: 'key-value' },
+    { field: 'body', schemaType: 'string', inspectorType: 'textarea' }
+];
+
+function isMakeApiCall(componentPath) {
+
+    return path.basename(path.dirname(componentPath)) === 'MakeApiCall';
+}
+
+function getConnectorRoot(componentPath) {
+
+    // .../src/appmixer/<vendor>/.../MakeApiCall/component.json
+    const parts = componentPath.split(path.sep);
+    const idx = parts.lastIndexOf('appmixer');
+    if (idx < 0 || idx + 1 >= parts.length) {
+        return null;
+    }
+
+    return parts.slice(0, idx + 2).join(path.sep);
+}
+
+function isOAuth2Connector(connectorRoot) {
+
+    if (!connectorRoot) return false;
+
+    const authPath = path.join(connectorRoot, 'auth.js');
+    if (!fs.existsSync(authPath)) return false;
+
+    const content = fs.readFileSync(authPath, 'utf8');
+    return /type:\s*['"]oauth2['"]/.test(content);
+}
+
+function validateInputSchemaField(componentPath, props, required, field, expectedSchemaType, addFailure) {
+
+    const prop = props[field];
+
+    if (!prop || typeof prop !== 'object') {
+        addFailure(componentPath, `inPorts[0].schema.properties.${field} is missing (standard #1459)`);
+        return;
+    }
+
+    if (prop.type !== expectedSchemaType) {
+        addFailure(componentPath, `inPorts[0].schema.properties.${field}.type must be "${expectedSchemaType}" (found "${prop.type}")`);
+    }
+}
+
+function validateInspectorInput(componentPath, inputs, field, expectedType, addFailure) {
+
+    const input = inputs[field];
+
+    if (!input || typeof input !== 'object') {
+        addFailure(componentPath, `inspector.inputs.${field} is missing`);
+        return;
+    }
+
+    if (input.type !== expectedType) {
+        addFailure(componentPath, `inspector.inputs.${field}.type must be "${expectedType}" (found "${input.type}")`);
+    }
+}
+
+function validateMethodSpec(componentPath, props, inputs, addFailure, addWarning) {
+
+    const methodProp = props.method;
+    if (methodProp) {
+        const enumValues = Array.isArray(methodProp.enum) ? methodProp.enum : null;
+
+        if (!enumValues) {
+            addWarning(componentPath, `inPorts[0].schema.properties.method should declare enum [${STANDARD_METHODS.join(', ')}]`);
+        } else {
+            const missing = STANDARD_METHODS.filter((m) => !enumValues.includes(m));
+            if (missing.length > 0) {
+                addWarning(componentPath, `inPorts[0].schema.properties.method.enum is missing: ${missing.join(', ')}`);
+            }
+        }
+    }
+
+    const methodInput = inputs.method;
+    if (methodInput) {
+        if (methodInput.defaultValue !== 'GET') {
+            addFailure(componentPath, `inspector.inputs.method.defaultValue must be "GET" (found ${JSON.stringify(methodInput.defaultValue)})`);
+        }
+
+        const options = Array.isArray(methodInput.options) ? methodInput.options : [];
+        const values = options.map((option) => option && option.value).filter(Boolean);
+        const missing = STANDARD_METHODS.filter((m) => !values.includes(m));
+
+        if (missing.length > 0) {
+            addFailure(componentPath, `inspector.inputs.method.options missing values: ${missing.join(', ')}`);
+        }
+    }
+}
+
+function validateScope(componentPath, component, connectorRoot, addWarning) {
+
+    if (!isOAuth2Connector(connectorRoot)) {
+        return;
+    }
+
+    const scope = component.auth && component.auth.scope;
+
+    if (!Array.isArray(scope) || scope.length === 0) {
+        addWarning(componentPath, `auth.scope is empty — OAuth-based MakeApiCall should declare scopes (most-privileged or all; see #1459)`);
+    }
+}
+
+function validateComponent(componentPath, addFailure, addWarning) {
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const inPort = Array.isArray(component.inPorts) ? component.inPorts[0] : null;
+
+    if (!inPort || typeof inPort !== 'object') {
+        addFailure(componentPath, 'inPorts[0] is missing');
+        return;
+    }
+
+    const schema = inPort.schema || {};
+    const props = (schema.properties && typeof schema.properties === 'object') ? schema.properties : {};
+    const required = Array.isArray(schema.required) ? schema.required : [];
+    const inputs = (inPort.inspector && inPort.inspector.inputs && typeof inPort.inspector.inputs === 'object')
+        ? inPort.inspector.inputs
+        : {};
+
+    // Legacy field flagged explicitly so the fix is obvious.
+    if ('params' in props && !('parameters' in props)) {
+        addFailure(componentPath, 'inPorts[0].schema.properties.params is legacy — rename to "parameters" (standard #1459)');
+    }
+
+    for (const { field, schemaType, inspectorType } of STANDARD_FIELDS) {
+        validateInputSchemaField(componentPath, props, required, field, schemaType, addFailure);
+        validateInspectorInput(componentPath, inputs, field, inspectorType, addFailure);
+    }
+
+    for (const field of ['url', 'method']) {
+        if (!required.includes(field)) {
+            addFailure(componentPath, `inPorts[0].schema.required must include "${field}"`);
+        }
+    }
+
+    validateMethodSpec(componentPath, props, inputs, addFailure, addWarning);
+    validateScope(componentPath, component, getConnectorRoot(componentPath), addWarning);
+}
+
+module.exports = {
+    name: 'makeapicall-standards',
+    description: 'MakeApiCall components follow the input/output structure defined in issue #1459',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            if (isMakeApiCall(componentPath)) {
+                validateComponent(componentPath, context.addFailure, context.addWarning);
+            }
+        }
+    }
+};

--- a/scripts/validators/makeapicall-standards.js
+++ b/scripts/validators/makeapicall-standards.js
@@ -10,14 +10,15 @@
 //   • url        (string, required)         — text input,    "API Endpoint Path"
 //   • method     (string, required, enum)   — select input,  defaultValue "GET",
 //                                              5 options: GET, POST, PUT, PATCH, DELETE
-//   • headers    (array)                    — key-value      list of header pairs
-//   • parameters (array)                    — key-value      list of query-param pairs (note: not "params")
-//   • body       (string)                   — textarea       JSON body — keeps textarea/JSON
-//                                              because many APIs require nested
-//                                              JSON bodies (objects, arrays,
-//                                              non-string values). Only headers
-//                                              and parameters are naturally flat
-//                                              string maps; the body is not.
+//   • headers    (string)                   — key-value      list of header pairs
+//   • parameters (string)                   — key-value      list of query-param pairs (note: not "params")
+//   • body       (string)                   — textarea       JSON body — supports
+//                                              nested objects/arrays/non-string
+//                                              values. Headers and parameters use
+//                                              key-value inspector but their JSON
+//                                              Schema type is declared "string" —
+//                                              declaring "array" makes the Designer
+//                                              UI reject the runtime value.
 //
 // Soft conformance (WARNING):
 //   • method.enum is the full set of 5 HTTP verbs
@@ -41,8 +42,8 @@ const STANDARD_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
 const STANDARD_FIELDS = [
     { field: 'url', schemaType: 'string', inspectorType: 'text' },
     { field: 'method', schemaType: 'string', inspectorType: 'select' },
-    { field: 'headers', schemaType: 'array', inspectorType: 'key-value' },
-    { field: 'parameters', schemaType: 'array', inspectorType: 'key-value' },
+    { field: 'headers', schemaType: 'string', inspectorType: 'key-value' },
+    { field: 'parameters', schemaType: 'string', inspectorType: 'key-value' },
     { field: 'body', schemaType: 'string', inspectorType: 'textarea' }
 ];
 

--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -27,7 +27,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.activecampaign",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -26,8 +26,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.activecampaign",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -25,6 +25,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/activecampaign/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = context.auth.url.replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Api-Token': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/activecampaign/core/MakeApiCall/component.json
+++ b/src/appmixer/activecampaign/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/activecampaign/core/MakeApiCall/component.json
+++ b/src/appmixer/activecampaign/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/activecampaign/core/MakeApiCall/component.json
+++ b/src/appmixer/activecampaign/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/activecampaign/core/MakeApiCall/component.json
+++ b/src/appmixer/activecampaign/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/apify/bundle.json
+++ b/src/appmixer/apify/bundle.json
@@ -12,7 +12,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/apify/bundle.json
+++ b/src/appmixer/apify/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.apify",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,8 +11,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/apify/bundle.json
+++ b/src/appmixer/apify/bundle.json
@@ -10,6 +10,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/apify/bundle.json
+++ b/src/appmixer/apify/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.apify",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/apify/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.apify.com/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/apify/core/MakeApiCall/component.json
+++ b/src/appmixer/apify/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/apify/core/MakeApiCall/component.json
+++ b/src/appmixer/apify/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/apify/core/MakeApiCall/component.json
+++ b/src/appmixer/apify/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/apify/core/MakeApiCall/component.json
+++ b/src/appmixer/apify/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/axiom/bundle.json
+++ b/src/appmixer/axiom/bundle.json
@@ -15,7 +15,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/axiom/bundle.json
+++ b/src/appmixer/axiom/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/axiom/bundle.json
+++ b/src/appmixer/axiom/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.axiom",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial release with dataset, query, and monitor management components."
@@ -14,7 +14,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/axiom/bundle.json
+++ b/src/appmixer/axiom/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.axiom",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.0": [
             "Initial release with dataset, query, and monitor management components."

--- a/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
@@ -28,7 +28,10 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-        const targetUrl = `https://api.axiom.co${url.startsWith('/') ? '' : '/'}${url}`;
+        const baseUrl = 'https://api.axiom.co';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,

--- a/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -44,9 +44,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -35,8 +34,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/axiom/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,31 +22,7 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-
-        // Parse headers
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'string' ? JSON.parse(headers) : headers;
-            } catch (e) {
-                throw new context.CancelError('Headers must be valid JSON.');
-            }
-        }
-
-        // Parse parameters and build query string
-        let queryString = '';
-        if (parameters) {
-            let parsedParams;
-            try {
-                parsedParams = typeof parameters === 'string' ? JSON.parse(parameters) : parameters;
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be valid JSON.');
-            }
-            const qs = new URLSearchParams(parsedParams).toString();
-            if (qs) queryString = '?' + qs;
-        }
-
-        const targetUrl = `https://api.axiom.co${url.startsWith('/') ? '' : '/'}${url}` + queryString;
+        const targetUrl = `https://api.axiom.co${url.startsWith('/') ? '' : '/'}${url}`;
 
         const requestOptions = {
             method,
@@ -45,16 +31,16 @@ module.exports = {
                 'Authorization': `Bearer ${context.auth.apiToken}`,
                 'x-axiom-org-id': context.auth.organizationId,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = typeof body === 'string' ? JSON.parse(body) : body;
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/axiom/core/MakeApiCall/component.json
+++ b/src/appmixer/axiom/core/MakeApiCall/component.json
@@ -34,7 +34,7 @@
                         ]
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -86,14 +86,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/axiom/core/MakeApiCall/component.json
+++ b/src/appmixer/axiom/core/MakeApiCall/component.json
@@ -37,10 +37,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -54,7 +54,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint path. For example: <code>/v2/datasets</code> or <code>/v2/datasets/{id}</code>."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.axiom.co</code> (for example <code>/v2/datasets</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/axiom/core/MakeApiCall/component.json
+++ b/src/appmixer/axiom/core/MakeApiCall/component.json
@@ -87,7 +87,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -98,7 +98,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -108,7 +108,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/axiom/core/MakeApiCall/component.json
+++ b/src/appmixer/axiom/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Headers",
-                        "tooltip": "Optional additional HTTP headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"limit\": 10, \"offset\": 0}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/azuredocumentintelligence/bundle.json
+++ b/src/appmixer/azuredocumentintelligence/bundle.json
@@ -19,7 +19,7 @@
             "Added output examples to component schemas."
         ],
         "3.0.0": [
-            "(breaking change) Added MakeApiCall component with key-value pair inputs for body, headers, and parameters"
+            "(breaking change) Added MakeApiCall component with key-value array inputs for headers and parameters and textarea/JSON for body per standard #1459"
         ]
     }
 }

--- a/src/appmixer/azuredocumentintelligence/bundle.json
+++ b/src/appmixer/azuredocumentintelligence/bundle.json
@@ -17,6 +17,8 @@
         ],
         "2.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "2.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/azuredocumentintelligence/bundle.json
+++ b/src/appmixer/azuredocumentintelligence/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.azuredocumentintelligence",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.2": [
             "Initial version."
@@ -18,7 +18,8 @@
         "2.1.1": [
             "Added output examples to component schemas."
         ],
-        "2.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "3.0.0": [
+            "(breaking change) Added MakeApiCall component with key-value pair inputs for body, headers, and parameters"
+        ]
     }
 }

--- a/src/appmixer/azuredocumentintelligence/bundle.json
+++ b/src/appmixer/azuredocumentintelligence/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.azuredocumentintelligence",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "changelog": {
         "1.0.2": [
             "Initial version."

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = context.auth.endpoint.replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Ocp-Apim-Subscription-Key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
+++ b/src/appmixer/azuredocumentintelligence/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/beehiiv/bundle.json
+++ b/src/appmixer/beehiiv/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.beehiiv",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial release."
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/beehiiv/bundle.json
+++ b/src/appmixer/beehiiv/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/beehiiv/bundle.json
+++ b/src/appmixer/beehiiv/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/beehiiv/bundle.json
+++ b/src/appmixer/beehiiv/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.beehiiv",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial release."

--- a/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/beehiiv/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.beehiiv.com/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/beehiiv/core/MakeApiCall/component.json
+++ b/src/appmixer/beehiiv/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/beehiiv/core/MakeApiCall/component.json
+++ b/src/appmixer/beehiiv/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/beehiiv/core/MakeApiCall/component.json
+++ b/src/appmixer/beehiiv/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/beehiiv/core/MakeApiCall/component.json
+++ b/src/appmixer/beehiiv/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/betterstack/bundle.json
+++ b/src/appmixer/betterstack/bundle.json
@@ -12,7 +12,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/betterstack/bundle.json
+++ b/src/appmixer/betterstack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.betterstack",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial release with Uptime monitor CRUD components."
@@ -11,8 +11,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/betterstack/bundle.json
+++ b/src/appmixer/betterstack/bundle.json
@@ -10,6 +10,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/betterstack/bundle.json
+++ b/src/appmixer/betterstack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.betterstack",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial release with Uptime monitor CRUD components."

--- a/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/betterstack/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://uptime.betterstack.com/api/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/betterstack/core/MakeApiCall/component.json
+++ b/src/appmixer/betterstack/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/betterstack/core/MakeApiCall/component.json
+++ b/src/appmixer/betterstack/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/betterstack/core/MakeApiCall/component.json
+++ b/src/appmixer/betterstack/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/betterstack/core/MakeApiCall/component.json
+++ b/src/appmixer/betterstack/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/bigCommerce/bundle.json
+++ b/src/appmixer/bigCommerce/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/bigCommerce/bundle.json
+++ b/src/appmixer/bigCommerce/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.bigCommerce",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.3": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/bigCommerce/bundle.json
+++ b/src/appmixer/bigCommerce/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.bigCommerce",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.3": [
             "Initial version"

--- a/src/appmixer/bigCommerce/bundle.json
+++ b/src/appmixer/bigCommerce/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = `https://api.bigcommerce.com/stores/${context.auth.storeHash}/v3`;
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'X-Auth-Token': context.auth.accessToken,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/bigCommerce/core/MakeApiCall/component.json
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/bigCommerce/core/MakeApiCall/component.json
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/bigCommerce/core/MakeApiCall/component.json
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/bigCommerce/core/MakeApiCall/component.json
+++ b/src/appmixer/bigCommerce/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/bluesky/bundle.json
+++ b/src/appmixer/bluesky/bundle.json
@@ -4,7 +4,7 @@
     "changelog": {
         "1.0.0": ["Initial release."],
         "2.0.0": [
-            "(breaking change) MakeApiCall: headers, parameters, and body changed from textarea/JSON string to key-value array inputs per standard #1459 — existing flows using the old format must be updated."
+            "(breaking change) MakeApiCall: headers and parameters changed from textarea/JSON string to key-value array inputs per standard #1459 (body remains textarea/JSON to support nested structures) — existing flows that used the old string-typed headers or parameters must be updated."
         ]
     }
 }

--- a/src/appmixer/bluesky/bundle.json
+++ b/src/appmixer/bluesky/bundle.json
@@ -1,7 +1,11 @@
 {
     "name": "appmixer.bluesky",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "changelog": {
-        "1.0.0": ["Initial release."]
+        "1.0.0": ["Initial release."],
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers, parameters, and body changed from textarea/JSON string to key-value array inputs per standard #1459 — existing flows using the old format must be updated."
+        ]
     }
 }
+

--- a/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
@@ -6,7 +6,14 @@ const BASE_URL = 'https://bsky.social/xrpc/';
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 module.exports = {

--- a/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
@@ -13,11 +13,10 @@ module.exports = {
 
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint Path is required!');
@@ -48,8 +47,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
@@ -8,9 +8,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -57,9 +57,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/bluesky/core/MakeApiCall/MakeApiCall.js
@@ -4,44 +4,26 @@ const lib = require('../../lib');
 
 const BASE_URL = 'https://bsky.social/xrpc/';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
 module.exports = {
 
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint Path is required!');
         }
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
-        }
-
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'object' ? headers : JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Request Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = typeof parameters === 'object' ? parameters : JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be a valid JSON object.');
-            }
-        }
-
-        let parsedBody;
-        if (body) {
-            try {
-                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
         }
 
         // Accept full URL, /xrpc/<nsid>, or bare <nsid>
@@ -54,22 +36,27 @@ module.exports = {
             targetUrl = `${BASE_URL}${url}`;
         }
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const accessToken = await lib.getAccessToken(context);
 
-        const response = await context.httpRequest({
+        const requestOptions = {
             method,
-            url: targetUrl + queryString,
-            data: parsedBody,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
-        });
+        };
+
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
+        }
+
+        const response = await context.httpRequest(requestOptions);
 
         return context.sendJson({
             status: response.status,

--- a/src/appmixer/bluesky/core/MakeApiCall/component.json
+++ b/src/appmixer/bluesky/core/MakeApiCall/component.json
@@ -35,10 +35,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/bluesky/core/MakeApiCall/component.json
+++ b/src/appmixer/bluesky/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "valueLabel": "Value",
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
-                        "index": 3,
+                        "index": 5,
                         "label": "Request Headers",
                         "tooltip": "Optional additional request headers (e.g. key <code>Atproto-Accept-Labelers</code>, value <code>did:plc:xyz</code>)."
                     },
@@ -102,13 +102,13 @@
                         "valueLabel": "Value",
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
-                        "index": 4,
+                        "index": 3,
                         "label": "Query Parameters",
                         "tooltip": "Optional query parameters (e.g. key <code>actor</code>, value <code>alice.bsky.social</code>)."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/bluesky/core/MakeApiCall/component.json
+++ b/src/appmixer/bluesky/core/MakeApiCall/component.json
@@ -41,7 +41,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -107,14 +107,10 @@
                         "tooltip": "Optional query parameters (e.g. key <code>actor</code>, value <code>alice.bsky.social</code>)."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
+                        "type": "textarea",
                         "index": 5,
                         "label": "Request Body",
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/bluesky/core/MakeApiCall/component.json
+++ b/src/appmixer/bluesky/core/MakeApiCall/component.json
@@ -35,13 +35,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -87,22 +87,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "index": 3,
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"Atproto-Accept-Labelers\": \"did:plc:xyz\"}</code>)."
+                        "tooltip": "Optional additional request headers (e.g. key <code>Atproto-Accept-Labelers</code>, value <code>did:plc:xyz</code>)."
                     },
                     "parameters": {
-                        "type": "textarea",
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "index": 4,
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"actor\": \"alice.bsky.social\"}</code>)."
+                        "tooltip": "Optional query parameters (e.g. key <code>actor</code>, value <code>alice.bsky.social</code>)."
                     },
                     "body": {
-                        "type": "textarea",
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "index": 5,
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/brevo/bundle.json
+++ b/src/appmixer/brevo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.brevo",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -33,7 +33,8 @@
         "1.3.1": [
             "Added output examples to component schemas."
         ],
-        "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/brevo/bundle.json
+++ b/src/appmixer/brevo/bundle.json
@@ -34,6 +34,6 @@
             "Added output examples to component schemas."
         ],
         "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/brevo/bundle.json
+++ b/src/appmixer/brevo/bundle.json
@@ -32,6 +32,8 @@
         ],
         "1.3.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.4.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/brevo/bundle.json
+++ b/src/appmixer/brevo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.brevo",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
@@ -18,6 +18,8 @@ module.exports = {
 
         const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
+        await context.log({ 'step': 'ss', in: context.messages.in.content });
+
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 

--- a/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/brevo/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.brevo.com/v3';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'api-key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/brevo/core/MakeApiCall/component.json
+++ b/src/appmixer/brevo/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/brevo/core/MakeApiCall/component.json
+++ b/src/appmixer/brevo/core/MakeApiCall/component.json
@@ -85,16 +85,6 @@
                             }
                         ]
                     },
-                    "headers": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Headers",
-                        "index": 3,
-                        "tooltip": "Optional additional request headers."
-                    },
                     "parameters": {
                         "type": "key-value",
                         "keyLabel": "Key",
@@ -102,14 +92,24 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 5,
+                        "tooltip": "Optional additional request headers."
                     }
                 }
             }

--- a/src/appmixer/brevo/core/MakeApiCall/component.json
+++ b/src/appmixer/brevo/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/brevo/core/MakeApiCall/component.json
+++ b/src/appmixer/brevo/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/canva/bundle.json
+++ b/src/appmixer/canva/bundle.json
@@ -12,7 +12,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/canva/bundle.json
+++ b/src/appmixer/canva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.canva",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/canva/bundle.json
+++ b/src/appmixer/canva/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.0.2": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.1.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/canva/bundle.json
+++ b/src/appmixer/canva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.canva",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.0.2": [
             "Added output examples to component schemas."
         ],
-        "1.1.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -41,9 +41,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
@@ -8,11 +8,10 @@ function kvToObj(arr) {
 
 module.exports = {
     async receive(context) {
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required');
         }
@@ -32,8 +31,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
@@ -28,9 +28,14 @@ module.exports = {
         }
 
 
+        const baseUrl = 'https://api.canva.com/rest/v1';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
+
         const requestOptions = {
             method: method,
-            url: url,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',

--- a/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
@@ -1,8 +1,18 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
-        const { url, method, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required');
         }
@@ -21,8 +31,12 @@ module.exports = {
             }
         };
 
-        if (body) {
-            requestOptions.data = JSON.parse(body);
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/canva/core/MakeApiCall/MakeApiCall.js
@@ -27,7 +27,8 @@ module.exports = {
             url: url,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                ...extraHeaders
             }
         };
 

--- a/src/appmixer/canva/core/MakeApiCall/component.json
+++ b/src/appmixer/canva/core/MakeApiCall/component.json
@@ -81,7 +81,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,7 +102,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/canva/core/MakeApiCall/component.json
+++ b/src/appmixer/canva/core/MakeApiCall/component.json
@@ -28,7 +28,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -80,14 +80,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/canva/core/MakeApiCall/component.json
+++ b/src/appmixer/canva/core/MakeApiCall/component.json
@@ -54,6 +54,7 @@
                         "type": "select",
                         "index": 2,
                         "label": "HTTP Method",
+                        "defaultValue": "GET",
                         "tooltip": "Select the HTTP method for the API call.",
                         "options": [
                             {

--- a/src/appmixer/canva/core/MakeApiCall/component.json
+++ b/src/appmixer/canva/core/MakeApiCall/component.json
@@ -31,10 +31,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -48,7 +48,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL including the base URL. For example, `https://api.canva.com/rest/v1/asset-uploads/{job-id}`."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.canva.com/rest/v1</code> (for example <code>/users/me/profile</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/canva/core/MakeApiCall/component.json
+++ b/src/appmixer/canva/core/MakeApiCall/component.json
@@ -28,7 +28,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -73,10 +79,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/clearbit/bundle.json
+++ b/src/appmixer/clearbit/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.clearbit",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,8 +11,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/clearbit/bundle.json
+++ b/src/appmixer/clearbit/bundle.json
@@ -12,7 +12,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/clearbit/bundle.json
+++ b/src/appmixer/clearbit/bundle.json
@@ -10,6 +10,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/clearbit/bundle.json
+++ b/src/appmixer/clearbit/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.clearbit",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clearbit/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://company.clearbit.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/clearbit/core/MakeApiCall/component.json
+++ b/src/appmixer/clearbit/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/clearbit/core/MakeApiCall/component.json
+++ b/src/appmixer/clearbit/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/clearbit/core/MakeApiCall/component.json
+++ b/src/appmixer/clearbit/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/clearbit/core/MakeApiCall/component.json
+++ b/src/appmixer/clearbit/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/clerk/bundle.json
+++ b/src/appmixer/clerk/bundle.json
@@ -15,7 +15,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/clerk/bundle.json
+++ b/src/appmixer/clerk/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/clerk/bundle.json
+++ b/src/appmixer/clerk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.clerk",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.3": [
             "Initial version"

--- a/src/appmixer/clerk/bundle.json
+++ b/src/appmixer/clerk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.clerk",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.3": [
             "Initial version"
@@ -14,7 +14,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -34,8 +33,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
@@ -28,7 +28,10 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-        const targetUrl = url;
+        const baseUrl = 'https://api.clerk.com/v1';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,

--- a/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -43,9 +43,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/clerk/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,31 +22,7 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-
-        // Parse headers
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'string' ? JSON.parse(headers) : headers;
-            } catch (e) {
-                throw new context.CancelError('Headers must be valid JSON.');
-            }
-        }
-
-        // Parse parameters and build query string
-        let queryString = '';
-        if (parameters) {
-            let parsedParams;
-            try {
-                parsedParams = typeof parameters === 'string' ? JSON.parse(parameters) : parameters;
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be valid JSON.');
-            }
-            const qs = new URLSearchParams(parsedParams).toString();
-            if (qs) queryString = '?' + qs;
-        }
-
-        const targetUrl = url + queryString;
+        const targetUrl = url;
 
         const requestOptions = {
             method,
@@ -44,16 +30,16 @@ module.exports = {
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = typeof body === 'string' ? JSON.parse(body) : body;
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/clerk/core/MakeApiCall/component.json
+++ b/src/appmixer/clerk/core/MakeApiCall/component.json
@@ -37,10 +37,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -54,7 +54,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL. For example: <code>https://api.clerk.com/v1/users</code> or <code>https://api.clerk.com/v1/organizations/{org_id}</code>."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.clerk.com/v1</code> (for example <code>/users</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/clerk/core/MakeApiCall/component.json
+++ b/src/appmixer/clerk/core/MakeApiCall/component.json
@@ -34,7 +34,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -86,14 +86,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/clerk/core/MakeApiCall/component.json
+++ b/src/appmixer/clerk/core/MakeApiCall/component.json
@@ -87,7 +87,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -98,7 +98,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -108,7 +108,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/clerk/core/MakeApiCall/component.json
+++ b/src/appmixer/clerk/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Headers",
-                        "tooltip": "Optional additional HTTP headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"limit\": 10, \"offset\": 0}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/cloudflare/bundle.json
+++ b/src/appmixer/cloudflare/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.cloudflare",
-    "version": "1.5.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -23,8 +23,8 @@
         "1.4.0": [
             "add MakeApiCall component"
         ],
-        "1.5.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/cloudflare/bundle.json
+++ b/src/appmixer/cloudflare/bundle.json
@@ -24,7 +24,7 @@
             "add MakeApiCall component"
         ],
         "1.5.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/cloudflare/bundle.json
+++ b/src/appmixer/cloudflare/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.cloudflare",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "changelog": {
         "1.0.0": [
             "Initial version."

--- a/src/appmixer/cloudflare/bundle.json
+++ b/src/appmixer/cloudflare/bundle.json
@@ -22,6 +22,9 @@
         ],
         "1.4.0": [
             "add MakeApiCall component"
+        ],
+        "1.5.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -41,8 +40,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -50,9 +50,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflare/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,32 +22,10 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.cloudflare.com/client/v4';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
-
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
 
         const authHeaders = context.auth.email
             ? { 'X-Auth-Email': context.auth.email, 'X-Auth-Key': context.auth.apiKey }
@@ -45,20 +33,20 @@ module.exports = {
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 ...authHeaders,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/cloudflare/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflare/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/cloudflare/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflare/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/cloudflare/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflare/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/cloudflare/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflare/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/cloudflareWAF/bundle.json
+++ b/src/appmixer/cloudflareWAF/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.cloudflareWAF",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.10": [
             "Initial version."
@@ -20,8 +20,8 @@
         "1.3.0": [
             "add MakeApiCall component"
         ],
-        "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/cloudflareWAF/bundle.json
+++ b/src/appmixer/cloudflareWAF/bundle.json
@@ -21,7 +21,7 @@
             "add MakeApiCall component"
         ],
         "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/cloudflareWAF/bundle.json
+++ b/src/appmixer/cloudflareWAF/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.cloudflareWAF",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "changelog": {
         "1.0.10": [
             "Initial version."

--- a/src/appmixer/cloudflareWAF/bundle.json
+++ b/src/appmixer/cloudflareWAF/bundle.json
@@ -19,6 +19,9 @@
         ],
         "1.3.0": [
             "add MakeApiCall component"
+        ],
+        "1.4.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.cloudflare.com/client/v4';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
+++ b/src/appmixer/cloudflareWAF/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/convex/bundle.json
+++ b/src/appmixer/convex/bundle.json
@@ -15,7 +15,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/convex/bundle.json
+++ b/src/appmixer/convex/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.convex",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -14,7 +14,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/convex/bundle.json
+++ b/src/appmixer/convex/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/convex/bundle.json
+++ b/src/appmixer/convex/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.convex",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
@@ -28,7 +28,11 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-        const targetUrl = url;
+
+        const baseUrl = 'https://api.convex.dev';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,

--- a/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -34,8 +33,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -43,9 +43,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/convex/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,31 +22,7 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-
-        // Parse headers
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'string' ? JSON.parse(headers) : headers;
-            } catch (e) {
-                throw new context.CancelError('Headers must be valid JSON.');
-            }
-        }
-
-        // Parse parameters and build query string
-        let queryString = '';
-        if (parameters) {
-            let parsedParams;
-            try {
-                parsedParams = typeof parameters === 'string' ? JSON.parse(parameters) : parameters;
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be valid JSON.');
-            }
-            const qs = new URLSearchParams(parsedParams).toString();
-            if (qs) queryString = '?' + qs;
-        }
-
-        const targetUrl = url + queryString;
+        const targetUrl = url;
 
         const requestOptions = {
             method,
@@ -44,16 +30,16 @@ module.exports = {
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = typeof body === 'string' ? JSON.parse(body) : body;
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/convex/core/MakeApiCall/component.json
+++ b/src/appmixer/convex/core/MakeApiCall/component.json
@@ -87,7 +87,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body (JSON)",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -98,7 +98,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -108,7 +108,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/convex/core/MakeApiCall/component.json
+++ b/src/appmixer/convex/core/MakeApiCall/component.json
@@ -34,7 +34,7 @@
                         ]
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -86,14 +86,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body (JSON)",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body (JSON)",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/convex/core/MakeApiCall/component.json
+++ b/src/appmixer/convex/core/MakeApiCall/component.json
@@ -37,10 +37,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -54,7 +54,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint",
-                        "tooltip": "Enter a full URL or a path relative to <code>https://api.convex.dev</code>. Example: <code>/v1/teams/{teamId}/list_projects</code>."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.convex.dev</code> (for example <code>/v1/teams/{teamId}/list_projects</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/convex/core/MakeApiCall/component.json
+++ b/src/appmixer/convex/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body (JSON)",
-                        "tooltip": "Optional JSON request payload. Leave empty for methods like GET or DELETE."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Headers",
-                        "tooltip": "Optional additional HTTP headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"limit\": 10, \"offset\": 0}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/elevenlabs/bundle.json
+++ b/src/appmixer/elevenlabs/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/elevenlabs/bundle.json
+++ b/src/appmixer/elevenlabs/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.elevenlabs",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/elevenlabs/bundle.json
+++ b/src/appmixer/elevenlabs/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.elevenlabs",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/elevenlabs/bundle.json
+++ b/src/appmixer/elevenlabs/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.elevenlabs.io/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'xi-api-key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/elevenlabs/core/MakeApiCall/component.json
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/elevenlabs/core/MakeApiCall/component.json
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/elevenlabs/core/MakeApiCall/component.json
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/elevenlabs/core/MakeApiCall/component.json
+++ b/src/appmixer/elevenlabs/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/everart/bundle.json
+++ b/src/appmixer/everart/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/everart/bundle.json
+++ b/src/appmixer/everart/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.everart",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/everart/bundle.json
+++ b/src/appmixer/everart/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/everart/bundle.json
+++ b/src/appmixer/everart/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.everart",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.2": [
             "Initial version"

--- a/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/everart/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.everart.ai/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/everart/core/MakeApiCall/component.json
+++ b/src/appmixer/everart/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/everart/core/MakeApiCall/component.json
+++ b/src/appmixer/everart/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/everart/core/MakeApiCall/component.json
+++ b/src/appmixer/everart/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/everart/core/MakeApiCall/component.json
+++ b/src/appmixer/everart/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -42,7 +42,7 @@
             "Added output examples to component schemas."
         ],
         "1.5.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "1.5.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -41,8 +41,8 @@
         "1.4.1": [
             "Added output examples to component schemas."
         ],
-        "1.5.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "1.3.0",
+    "version": "1.5.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -40,6 +40,9 @@
         ],
         "1.4.1": [
             "Added output examples to component schemas."
+        ],
+        "1.5.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "1.4.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -39,8 +38,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -48,9 +48,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshdesk/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,51 +22,29 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = `https://${context.auth.domain}.freshdesk.com/api/v2`;
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const credentials = Buffer.from(`${context.auth.apiKey}:X`).toString('base64');
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Basic ${credentials}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/freshdesk/core/MakeApiCall/component.json
+++ b/src/appmixer/freshdesk/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/freshdesk/core/MakeApiCall/component.json
+++ b/src/appmixer/freshdesk/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/freshdesk/core/MakeApiCall/component.json
+++ b/src/appmixer/freshdesk/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/freshdesk/core/MakeApiCall/component.json
+++ b/src/appmixer/freshdesk/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/freshsales/bundle.json
+++ b/src/appmixer/freshsales/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshsales",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.1": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/freshsales/bundle.json
+++ b/src/appmixer/freshsales/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/freshsales/bundle.json
+++ b/src/appmixer/freshsales/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshsales",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/freshsales/bundle.json
+++ b/src/appmixer/freshsales/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.1": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/freshsales/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = context.auth.domain.replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Token token=${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/freshsales/core/MakeApiCall/component.json
+++ b/src/appmixer/freshsales/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/freshsales/core/MakeApiCall/component.json
+++ b/src/appmixer/freshsales/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/freshsales/core/MakeApiCall/component.json
+++ b/src/appmixer/freshsales/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/freshsales/core/MakeApiCall/component.json
+++ b/src/appmixer/freshsales/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/github/bundle.json
+++ b/src/appmixer/github/bundle.json
@@ -21,7 +21,7 @@
             "Added output examples to component schemas."
         ],
         "3.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/github/bundle.json
+++ b/src/appmixer/github/bundle.json
@@ -19,6 +19,8 @@
         ],
         "2.1.2": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "2.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/github/bundle.json
+++ b/src/appmixer/github/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.github",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "changelog": {
         "1.0.3": [
             "Removed 'None' empty string value from ListAssignees, ListLabels and ListMilestones."

--- a/src/appmixer/github/bundle.json
+++ b/src/appmixer/github/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.github",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.3": [
             "Removed 'None' empty string value from ListAssignees, ListLabels and ListMilestones."
@@ -20,7 +20,8 @@
         "2.1.2": [
             "Added output examples to component schemas."
         ],
-        "2.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "3.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -38,9 +38,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
@@ -12,11 +12,10 @@ function kvToObj(arr) {
  */
 module.exports = {
     async receive(context) {
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -29,8 +28,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
@@ -24,9 +24,14 @@ module.exports = {
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 
+        const baseUrl = 'https://api.github.com';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
+
         const requestOptions = {
             method: method,
-            url: url,
+            url: targetUrl,
             headers: {
                 'accept': 'application/vnd.github+json',
                 'X-GitHub-Api-Version': '2022-11-28',

--- a/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
@@ -1,12 +1,22 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 /**
  * Component for making a generic API Call
  * @extends {Component}
  */
 module.exports = {
     async receive(context) {
-        const { url, method, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -18,8 +28,12 @@ module.exports = {
             }
         };
 
-        if (body) {
-            requestOptions.data = JSON.parse(body);
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/github/list/MakeApiCall/MakeApiCall.js
@@ -24,7 +24,8 @@ module.exports = {
             headers: {
                 'accept': 'application/vnd.github+json',
                 'X-GitHub-Api-Version': '2022-11-28',
-                'Authorization': `Bearer ${context.accessToken || context.auth?.accessToken}`
+                'Authorization': `Bearer ${context.accessToken || context.auth?.accessToken}`,
+                ...extraHeaders
             }
         };
 

--- a/src/appmixer/github/list/MakeApiCall/component.json
+++ b/src/appmixer/github/list/MakeApiCall/component.json
@@ -63,7 +63,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -74,7 +74,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -84,7 +84,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 5,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/github/list/MakeApiCall/component.json
+++ b/src/appmixer/github/list/MakeApiCall/component.json
@@ -36,6 +36,7 @@
                         "type": "select",
                         "index": 2,
                         "label": "HTTP Method",
+                        "defaultValue": "GET",
                         "tooltip": "Select the HTTP method for the API call.",
                         "options": [
                             {

--- a/src/appmixer/github/list/MakeApiCall/component.json
+++ b/src/appmixer/github/list/MakeApiCall/component.json
@@ -74,7 +74,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 4,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -84,7 +84,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/github/list/MakeApiCall/component.json
+++ b/src/appmixer/github/list/MakeApiCall/component.json
@@ -30,7 +30,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL including the base URL and query parameters. For example, `https://api.github.com/:id?query`."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.github.com</code> (for example <code>/user</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",
@@ -110,10 +110,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/src/appmixer/github/list/MakeApiCall/component.json
+++ b/src/appmixer/github/list/MakeApiCall/component.json
@@ -62,14 +62,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",
@@ -111,7 +107,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"

--- a/src/appmixer/github/list/MakeApiCall/component.json
+++ b/src/appmixer/github/list/MakeApiCall/component.json
@@ -61,10 +61,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             },
@@ -86,7 +110,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
                 "required": [

--- a/src/appmixer/gohighlevel/bundle.json
+++ b/src/appmixer/gohighlevel/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/gohighlevel/bundle.json
+++ b/src/appmixer/gohighlevel/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.gohighlevel",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial release."
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/gohighlevel/bundle.json
+++ b/src/appmixer/gohighlevel/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/gohighlevel/bundle.json
+++ b/src/appmixer/gohighlevel/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.gohighlevel",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial release."

--- a/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://services.leadconnectorhq.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/gohighlevel/core/MakeApiCall/component.json
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/gohighlevel/core/MakeApiCall/component.json
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/gohighlevel/core/MakeApiCall/component.json
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/gohighlevel/core/MakeApiCall/component.json
+++ b/src/appmixer/gohighlevel/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
@@ -8,11 +8,10 @@ function kvToObj(arr) {
 
 module.exports = {
     async receive(context) {
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -24,8 +23,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
@@ -20,9 +20,14 @@ module.exports = {
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 
+        const baseUrl = 'https://gmail.googleapis.com/gmail/v1';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
+
         const requestOptions = {
             method: method,
-            url: url,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',

--- a/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -33,9 +33,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
@@ -19,7 +19,8 @@ module.exports = {
             url: url,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                ...extraHeaders
             }
         };
 

--- a/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/google/gmail/MakeApiCall/MakeApiCall.js
@@ -1,8 +1,18 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
-        const { url, method, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -13,8 +23,12 @@ module.exports = {
             }
         };
 
-        if (body) {
-            requestOptions.data = JSON.parse(body);
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/google/gmail/MakeApiCall/component.json
+++ b/src/appmixer/google/gmail/MakeApiCall/component.json
@@ -31,6 +31,7 @@
                         "type": "select",
                         "index": 2,
                         "label": "HTTP Method",
+                        "defaultValue": "GET",
                         "tooltip": "Select the HTTP method for the API call.",
                         "options": [
                             {

--- a/src/appmixer/google/gmail/MakeApiCall/component.json
+++ b/src/appmixer/google/gmail/MakeApiCall/component.json
@@ -57,14 +57,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",
@@ -106,7 +102,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"

--- a/src/appmixer/google/gmail/MakeApiCall/component.json
+++ b/src/appmixer/google/gmail/MakeApiCall/component.json
@@ -25,7 +25,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL including the base URL. For example, `https://gmail.googleapis.com/gmail/v1/users/me/messages/send`."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://gmail.googleapis.com/gmail/v1</code> (for example <code>/users/me/messages</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",
@@ -105,10 +105,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/src/appmixer/google/gmail/MakeApiCall/component.json
+++ b/src/appmixer/google/gmail/MakeApiCall/component.json
@@ -58,7 +58,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -69,7 +69,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -79,7 +79,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 5,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/google/gmail/MakeApiCall/component.json
+++ b/src/appmixer/google/gmail/MakeApiCall/component.json
@@ -69,7 +69,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 4,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -79,7 +79,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/google/gmail/MakeApiCall/component.json
+++ b/src/appmixer/google/gmail/MakeApiCall/component.json
@@ -56,10 +56,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             },
@@ -81,7 +105,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
                 "required": [

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -60,7 +60,7 @@
             "Added output examples to component schemas."
         ],
         "3.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "2.0.9",
+    "version": "2.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -58,6 +58,8 @@
         ],
         "2.0.9": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "2.1.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "2.1.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -59,7 +59,8 @@
         "2.0.9": [
             "Added output examples to component schemas."
         ],
-        "2.1.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "3.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.imperva",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.2": [
             "Imperva"
@@ -20,8 +20,8 @@
         "1.2.0": [
             "add MakeApiCall component"
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -21,7 +21,7 @@
             "add MakeApiCall component"
         ],
         "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.imperva",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "changelog": {
         "1.0.2": [
             "Imperva"

--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -19,6 +19,9 @@
         ],
         "1.2.0": [
             "add MakeApiCall component"
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -47,9 +47,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -38,8 +37,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/imperva/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,50 +22,28 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://my.imperva.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'x-API-Id': context.auth.id,
                 'x-API-Key': context.auth.key,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/imperva/core/MakeApiCall/component.json
+++ b/src/appmixer/imperva/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/imperva/core/MakeApiCall/component.json
+++ b/src/appmixer/imperva/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/imperva/core/MakeApiCall/component.json
+++ b/src/appmixer/imperva/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/imperva/core/MakeApiCall/component.json
+++ b/src/appmixer/imperva/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/jotform/bundle.json
+++ b/src/appmixer/jotform/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jotform",
-    "version": "2.1.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -20,8 +20,8 @@
         "2.0.0": [
             "GetFormSubmission, GetFormSubmissions: added answersList output field — answers as an array for easier processing in flows."
         ],
-        "2.1.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "3.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/jotform/bundle.json
+++ b/src/appmixer/jotform/bundle.json
@@ -21,7 +21,7 @@
             "GetFormSubmission, GetFormSubmissions: added answersList output field — answers as an array for easier processing in flows."
         ],
         "2.1.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/jotform/bundle.json
+++ b/src/appmixer/jotform/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jotform",
-    "version": "1.3.0",
+    "version": "2.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -20,7 +20,8 @@
         "2.0.0": [
             "GetFormSubmission, GetFormSubmissions: added answersList output field — answers as an array for easier processing in flows."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.1.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+        ]
     }
 }

--- a/src/appmixer/jotform/bundle.json
+++ b/src/appmixer/jotform/bundle.json
@@ -19,6 +19,8 @@
         ],
         "2.0.0": [
             "GetFormSubmission, GetFormSubmissions: added answersList output field — answers as an array for easier processing in flows."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/jotform/bundle.json
+++ b/src/appmixer/jotform/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jotform",
-    "version": "2.0.0",
+    "version": "1.3.0",
     "changelog": {
         "1.0.0": [
             "Initial version."

--- a/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/jotform/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = `https://${context.auth.regionPrefix || 'api'}.jotform.com`;
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'APIKEY': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/jotform/core/MakeApiCall/component.json
+++ b/src/appmixer/jotform/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/jotform/core/MakeApiCall/component.json
+++ b/src/appmixer/jotform/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/jotform/core/MakeApiCall/component.json
+++ b/src/appmixer/jotform/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/jotform/core/MakeApiCall/component.json
+++ b/src/appmixer/jotform/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/kit/bundle.json
+++ b/src/appmixer/kit/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/kit/bundle.json
+++ b/src/appmixer/kit/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.kit",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/kit/bundle.json
+++ b/src/appmixer/kit/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.kit",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/kit/bundle.json
+++ b/src/appmixer/kit/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/kit/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.kit.com/v4';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/kit/core/MakeApiCall/component.json
+++ b/src/appmixer/kit/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/kit/core/MakeApiCall/component.json
+++ b/src/appmixer/kit/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/kit/core/MakeApiCall/component.json
+++ b/src/appmixer/kit/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/kit/core/MakeApiCall/component.json
+++ b/src/appmixer/kit/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/klaviyo/bundle.json
+++ b/src/appmixer/klaviyo/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/klaviyo/bundle.json
+++ b/src/appmixer/klaviyo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.klaviyo",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/klaviyo/bundle.json
+++ b/src/appmixer/klaviyo/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/klaviyo/bundle.json
+++ b/src/appmixer/klaviyo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.klaviyo",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.2": [
             "Initial version"

--- a/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -47,9 +47,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -38,8 +37,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/klaviyo/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,50 +22,28 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://a.klaviyo.com/api';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Klaviyo-API-Key ${context.auth.apiKey}`,
                 'revision': '2024-10-15',
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/klaviyo/core/MakeApiCall/component.json
+++ b/src/appmixer/klaviyo/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/klaviyo/core/MakeApiCall/component.json
+++ b/src/appmixer/klaviyo/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/klaviyo/core/MakeApiCall/component.json
+++ b/src/appmixer/klaviyo/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/klaviyo/core/MakeApiCall/component.json
+++ b/src/appmixer/klaviyo/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/leadspicker/bundle.json
+++ b/src/appmixer/leadspicker/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.leadspicker",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "NinjaAPI"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/leadspicker/bundle.json
+++ b/src/appmixer/leadspicker/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/leadspicker/bundle.json
+++ b/src/appmixer/leadspicker/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/leadspicker/bundle.json
+++ b/src/appmixer/leadspicker/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.leadspicker",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "NinjaAPI"

--- a/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/leadspicker/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://leadspicker.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'X-API-Key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/leadspicker/core/MakeApiCall/component.json
+++ b/src/appmixer/leadspicker/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/leadspicker/core/MakeApiCall/component.json
+++ b/src/appmixer/leadspicker/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/leadspicker/core/MakeApiCall/component.json
+++ b/src/appmixer/leadspicker/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/leadspicker/core/MakeApiCall/component.json
+++ b/src/appmixer/leadspicker/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/lemonsqueezy/bundle.json
+++ b/src/appmixer/lemonsqueezy/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.lemonsqueezy",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -14,7 +14,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/lemonsqueezy/bundle.json
+++ b/src/appmixer/lemonsqueezy/bundle.json
@@ -15,6 +15,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/lemonsqueezy/bundle.json
+++ b/src/appmixer/lemonsqueezy/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.lemonsqueezy",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/lemonsqueezy/bundle.json
+++ b/src/appmixer/lemonsqueezy/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.lemonsqueezy.com/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
+++ b/src/appmixer/lemonsqueezy/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/line/bundle.json
+++ b/src/appmixer/line/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/line/bundle.json
+++ b/src/appmixer/line/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.line",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/line/bundle.json
+++ b/src/appmixer/line/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/line/bundle.json
+++ b/src/appmixer/line/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.line",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.2": [
             "Initial version"

--- a/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/line/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.line.me';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.channelAccessToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/line/core/MakeApiCall/component.json
+++ b/src/appmixer/line/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/line/core/MakeApiCall/component.json
+++ b/src/appmixer/line/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/line/core/MakeApiCall/component.json
+++ b/src/appmixer/line/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/line/core/MakeApiCall/component.json
+++ b/src/appmixer/line/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/logscale/bundle.json
+++ b/src/appmixer/logscale/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.logscale",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial release with SendEvent and SendEvents components for Falcon LogScale ingestion."
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/logscale/bundle.json
+++ b/src/appmixer/logscale/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/logscale/bundle.json
+++ b/src/appmixer/logscale/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.logscale",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial release with SendEvent and SendEvents components for Falcon LogScale ingestion."

--- a/src/appmixer/logscale/bundle.json
+++ b/src/appmixer/logscale/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/logscale/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = context.auth.url.replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/logscale/core/MakeApiCall/component.json
+++ b/src/appmixer/logscale/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/logscale/core/MakeApiCall/component.json
+++ b/src/appmixer/logscale/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/logscale/core/MakeApiCall/component.json
+++ b/src/appmixer/logscale/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/logscale/core/MakeApiCall/component.json
+++ b/src/appmixer/logscale/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/mailerlite/bundle.json
+++ b/src/appmixer/mailerlite/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.mailerlite",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/mailerlite/bundle.json
+++ b/src/appmixer/mailerlite/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/mailerlite/bundle.json
+++ b/src/appmixer/mailerlite/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/mailerlite/bundle.json
+++ b/src/appmixer/mailerlite/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.mailerlite",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mailerlite/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://connect.mailerlite.com/api';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/mailerlite/core/MakeApiCall/component.json
+++ b/src/appmixer/mailerlite/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/mailerlite/core/MakeApiCall/component.json
+++ b/src/appmixer/mailerlite/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/mailerlite/core/MakeApiCall/component.json
+++ b/src/appmixer/mailerlite/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/mailerlite/core/MakeApiCall/component.json
+++ b/src/appmixer/mailerlite/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/mandrill/bundle.json
+++ b/src/appmixer/mandrill/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.mandrill",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/mandrill/bundle.json
+++ b/src/appmixer/mandrill/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/mandrill/bundle.json
+++ b/src/appmixer/mandrill/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/mandrill/bundle.json
+++ b/src/appmixer/mandrill/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.mandrill",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');

--- a/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -28,10 +28,19 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
+        let parsedBody = {};
+        if (body) {
+            try {
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError('Request Body must be valid JSON.');
+            }
+        }
+
         const baseUrl = 'https://mandrillapp.com/api/1.0';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
-            : `${baseUrl}${url}`;
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,
@@ -40,9 +49,11 @@ module.exports = {
                 'Content-Type': 'application/json',
                 ...extraHeaders
             },
+            // Mandrill expects the API key in the request body. User body fields are merged first,
+            // then `key` is set last so it cannot be overridden.
             data: {
-                key: context.auth.apiKey,
-                ...bodyData
+                ...parsedBody,
+                key: context.auth.apiKey
             }
         };
 

--- a/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,32 +22,10 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://mandrillapp.com/api/1.0';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
-
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
 
         let parsedBody = {};
         if (body) {
@@ -50,16 +38,20 @@ module.exports = {
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             },
             data: {
                 key: context.auth.apiKey,
                 ...parsedBody
             }
         };
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
+        }
 
         const response = await context.httpRequest(requestOptions);
 

--- a/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/mandrill/core/MakeApiCall/MakeApiCall.js
@@ -27,15 +27,6 @@ module.exports = {
             ? url
             : `${baseUrl}${url}`;
 
-        let parsedBody = {};
-        if (body) {
-            try {
-                parsedBody = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
-        }
-
         const requestOptions = {
             method,
             url: targetUrl,
@@ -45,7 +36,7 @@ module.exports = {
             },
             data: {
                 key: context.auth.apiKey,
-                ...parsedBody
+                ...bodyData
             }
         };
 

--- a/src/appmixer/mandrill/core/MakeApiCall/component.json
+++ b/src/appmixer/mandrill/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/mandrill/core/MakeApiCall/component.json
+++ b/src/appmixer/mandrill/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/mandrill/core/MakeApiCall/component.json
+++ b/src/appmixer/mandrill/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/mandrill/core/MakeApiCall/component.json
+++ b/src/appmixer/mandrill/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/merk/bundle.json
+++ b/src/appmixer/merk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.merk",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/merk/bundle.json
+++ b/src/appmixer/merk/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/merk/bundle.json
+++ b/src/appmixer/merk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.merk",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/merk/bundle.json
+++ b/src/appmixer/merk/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/merk/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.merk.cz';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Token ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/merk/core/MakeApiCall/component.json
+++ b/src/appmixer/merk/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/merk/core/MakeApiCall/component.json
+++ b/src/appmixer/merk/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/merk/core/MakeApiCall/component.json
+++ b/src/appmixer/merk/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/merk/core/MakeApiCall/component.json
+++ b/src/appmixer/merk/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -22,6 +22,15 @@ module.exports = {
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError('Request Body must be valid JSON.');
+            }
+        }
+
         const options = {
             method,
             url: (context.resource || context.auth.resource) + url,
@@ -29,9 +38,12 @@ module.exports = {
                 'Content-Type': 'application/json',
                 Authorization: `Bearer ${context.accessToken || context.auth?.accessToken}`,
                 ...extraHeaders
-            },
-            data: bodyData
+            }
         };
+
+        if (parsedBody !== undefined) {
+            options.data = parsedBody;
+        }
 
         if (Object.keys(queryParams).length > 0) {
             options.params = queryParams;

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -31,9 +31,14 @@ module.exports = {
             }
         }
 
+        const resourceBase = context.resource || context.auth.resource || '';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${resourceBase}${url.startsWith('/') ? url : '/' + url}`;
+
         const options = {
             method,
-            url: (context.resource || context.auth.resource) + url,
+            url: targetUrl,
             headers: {
                 'Content-Type': 'application/json',
                 Authorization: `Bearer ${context.accessToken || context.auth?.accessToken}`,

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -10,11 +10,10 @@ module.exports = {
 
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         const options = {
             method,

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -1,10 +1,20 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
 
     async receive(context) {
 
-        const { url, method, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         const options = {
             method,
@@ -19,7 +29,11 @@ module.exports = {
         await context.log({ step: 'Making request', options });
 
         try {
-            const { data, status, statusText } = await context.httpRequest(options);
+            const { data, status, statusText } = if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
+        }
+
+        await context.httpRequest(options);
 
             return context.sendJson({ response: data, status, statusText }, 'out');
         } catch (error) {

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/MakeApiCall.js
@@ -21,20 +21,20 @@ module.exports = {
             url: (context.resource || context.auth.resource) + url,
             headers: {
                 'Content-Type': 'application/json',
-                Authorization: `Bearer ${context.accessToken || context.auth?.accessToken}`
+                Authorization: `Bearer ${context.accessToken || context.auth?.accessToken}`,
+                ...extraHeaders
             },
-            data: body
+            data: bodyData
         };
+
+        if (Object.keys(queryParams).length > 0) {
+            options.params = queryParams;
+        }
 
         await context.log({ step: 'Making request', options });
 
         try {
-            const { data, status, statusText } = if (Object.keys(queryParams).length > 0) {
-            requestOptions.params = queryParams;
-        }
-
-        await context.httpRequest(options);
-
+            const { data, status, statusText } = await context.httpRequest(options);
             return context.sendJson({ response: data, status, statusText }, 'out');
         } catch (error) {
             // If Axios throws an error, the response is in error.response.data.

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
@@ -23,10 +23,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -39,8 +39,8 @@
                     "url": {
                         "type": "text",
                         "index": 1,
-                        "label": "URL",
-                        "tooltip": "Enter the API endpoint URL, for exampl: <code>/api/data/v9.2/WhoAmI</code> or <code>/api/data/v9.2/leads?select=fullname,subject</code>."
+                        "label": "API Endpoint URL",
+                        "tooltip": "Enter the API endpoint path relative to your Dynamics 365 instance URL (for example <code>/api/data/v9.2/WhoAmI</code> or <code>/api/data/v9.2/leads?select=fullname,subject</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
@@ -84,7 +84,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 4,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -94,7 +94,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
@@ -73,7 +73,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -84,7 +84,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -94,7 +94,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 5,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
@@ -20,7 +20,7 @@
                         "type": "string"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -72,14 +72,10 @@
                         "tooltip": "Select the HTTP method for the API call."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/dynamics/MakeApiCall/component.json
@@ -20,10 +20,19 @@
                         "type": "string"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
-                "required": ["url", "method"]
+                "required": [
+                    "url",
+                    "method"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -38,20 +47,59 @@
                         "index": 2,
                         "label": "Method",
                         "options": [
-                            { "label": "GET", "value": "GET" },
-                            { "label": "POST", "value": "POST" },
-                            { "label": "PUT", "value": "PUT" },
-                            { "label": "PATCH", "value": "PATCH" },
-                            { "label": "DELETE", "value": "DELETE" }
+                            {
+                                "label": "GET",
+                                "value": "GET"
+                            },
+                            {
+                                "label": "POST",
+                                "value": "POST"
+                            },
+                            {
+                                "label": "PUT",
+                                "value": "PUT"
+                            },
+                            {
+                                "label": "PATCH",
+                                "value": "PATCH"
+                            },
+                            {
+                                "label": "DELETE",
+                                "value": "DELETE"
+                            }
                         ],
                         "defaultValue": "GET",
                         "tooltip": "Select the HTTP method for the API call."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }
@@ -61,9 +109,18 @@
         {
             "name": "out",
             "options": [
-                { "label": "Response", "value": "response" },
-                { "label": "Status", "value": "status" },
-                { "label": "Status Text", "value": "statusText" }
+                {
+                    "label": "Response",
+                    "value": "response"
+                },
+                {
+                    "label": "Status",
+                    "value": "status"
+                },
+                {
+                    "label": "Status Text",
+                    "value": "statusText"
+                }
             ]
         }
     ],

--- a/src/appmixer/microsoft/dynamics/bundle.json
+++ b/src/appmixer/microsoft/dynamics/bundle.json
@@ -18,7 +18,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/microsoft/dynamics/bundle.json
+++ b/src/appmixer/microsoft/dynamics/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.dynamics",
-    "version": "1.0.7",
+    "version": "1.1.0",
     "changelog": {
         "1.0.3": [
             "Initial release"

--- a/src/appmixer/microsoft/dynamics/bundle.json
+++ b/src/appmixer/microsoft/dynamics/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.dynamics",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.3": [
             "Initial release"
@@ -17,7 +17,8 @@
         "1.0.7": [
             "Added output examples to component schemas."
         ],
-        "1.1.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/microsoft/dynamics/bundle.json
+++ b/src/appmixer/microsoft/dynamics/bundle.json
@@ -16,6 +16,8 @@
         ],
         "1.0.7": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.1.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
@@ -10,11 +10,10 @@ module.exports = {
 
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         const apiResponse = await makeRequest({ url, method, extraHeaders, queryParams, bodyData }, context);
         return context.sendJson({ response: apiResponse }, 'out');

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
@@ -22,6 +22,15 @@ module.exports = {
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 
+        let bodyData = {};
+        if (body) {
+            try {
+                bodyData = typeof body === 'object' ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError('Request Body must be valid JSON.');
+            }
+        }
+
         const apiResponse = await makeRequest({ url, method, extraHeaders, queryParams, bodyData }, context);
         return context.sendJson({ response: apiResponse }, 'out');
     }

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
@@ -3,7 +3,14 @@ const { makeRequest } = require('../common');
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 module.exports = {

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
@@ -5,9 +5,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/MakeApiCall.js
@@ -1,12 +1,22 @@
 'use strict';
 const { makeRequest } = require('../common');
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
 module.exports = {
 
     async receive(context) {
 
-        const { url, method, body } = context.messages.in.content;
-        const apiResponse = await makeRequest({ url, method, body }, context);
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
+
+        const apiResponse = await makeRequest({ url, method, extraHeaders, queryParams, bodyData }, context);
         return context.sendJson({ response: apiResponse }, 'out');
     }
 };

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
@@ -33,10 +33,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -49,8 +49,8 @@
                     "url": {
                         "type": "text",
                         "index": 1,
-                        "label": "URL",
-                        "tooltip": "Enter the URL for the API call."
+                        "label": "API Endpoint URL",
+                        "tooltip": "Enter the API endpoint path relative to <code>https://graph.microsoft.com/v1.0/</code> (for example <code>/me/drive/root/children</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
@@ -30,7 +30,7 @@
                         ]
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -82,14 +82,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
@@ -94,7 +94,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 4,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -104,7 +104,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
@@ -20,7 +20,14 @@
                         "type": "string"
                     },
                     "method": {
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
                     },
                     "body": {
                         "type": "array"
@@ -46,10 +53,33 @@
                         "tooltip": "Enter the URL for the API call."
                     },
                     "method": {
-                        "type": "text",
+                        "type": "select",
                         "index": 2,
-                        "label": "Method",
-                        "tooltip": "Enter the HTTP method for the API call."
+                        "label": "HTTP Method",
+                        "defaultValue": "GET",
+                        "tooltip": "Select the HTTP method for the API call.",
+                        "options": [
+                            {
+                                "label": "GET",
+                                "value": "GET"
+                            },
+                            {
+                                "label": "POST",
+                                "value": "POST"
+                            },
+                            {
+                                "label": "PUT",
+                                "value": "PUT"
+                            },
+                            {
+                                "label": "PATCH",
+                                "value": "PATCH"
+                            },
+                            {
+                                "label": "DELETE",
+                                "value": "DELETE"
+                            }
+                        ]
                     },
                     "body": {
                         "type": "key-value",

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
@@ -83,7 +83,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -94,7 +94,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -104,7 +104,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 5,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
+++ b/src/appmixer/microsoft/sharepoint/MakeApiCall/component.json
@@ -5,7 +5,10 @@
     "private": false,
     "auth": {
         "service": "appmixer:microsoft",
-        "scope": ["Files.ReadWrite.All", "Sites.ReadWrite.All"]
+        "scope": [
+            "Files.ReadWrite.All",
+            "Sites.ReadWrite.All"
+        ]
     },
     "inPorts": [
         {
@@ -20,10 +23,19 @@
                         "type": "string"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
-                "required": ["url", "method"]
+                "required": [
+                    "url",
+                    "method"
+                ]
             },
             "inspector": {
                 "inputs": {
@@ -40,10 +52,34 @@
                         "tooltip": "Enter the HTTP method for the API call."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }
@@ -52,7 +88,12 @@
     "outPorts": [
         {
             "name": "out",
-            "options": [{ "label": "Response", "value": "response" }]
+            "options": [
+                {
+                    "label": "Response",
+                    "value": "response"
+                }
+            ]
         }
     ],
     "icon": "data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSItMC4xMjk3OTM3MjY5ODA3Nzc4NSAwIDMyLjEyOTc5MzcyNjk4MDc4IDMyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNTAwIiBoZWlnaHQ9IjI0ODAiPjxjaXJjbGUgY3g9IjE1IiBjeT0iOS41IiBmaWxsPSIjMDM2YzcwIiByPSI5LjUiLz48Y2lyY2xlIGN4PSIyMy44NzUiIGN5PSIxNy44NzUiIGZpbGw9IiMxYTliYTEiIHI9IjguMTI1Ii8+PGNpcmNsZSBjeD0iMTYiIGN5PSIyNS41IiBmaWxsPSIjMzdjNmQwIiByPSI2LjUiLz48cGF0aCBkPSJNMTYuNjY3IDdINS44MzNBOS41MDYgOS41MDYgMCAwIDAgMTUgMTljLjI3NyAwIC41NTEtLjAxMy44MjMtLjAzNmwuMDA1LjAzOEE2LjUgNi41IDAgMCAwIDkuNSAyNS41cTAgLjI1Mi4wMTkuNWg3LjE0OEExLjMzNyAxLjMzNyAwIDAgMCAxOCAyNC42NjdWOC4zMzNBMS4zMzcgMS4zMzcgMCAwIDAgMTYuNjY3IDd6IiBvcGFjaXR5PSIuMSIvPjxwYXRoIGQ9Ik0xNS42NjcgOEg1LjYxN0E5LjUwNSA5LjUwNSAwIDAgMCAxNSAxOWMuMjc3IDAgLjU1MS0uMDEzLjgyMy0uMDM2bC4wMDUuMDM4QTYuNTA1IDYuNTA1IDAgMCAwIDkuNjc0IDI3aDUuOTkzQTEuMzM3IDEuMzM3IDAgMCAwIDE3IDI1LjY2N1Y5LjMzM0ExLjMzNyAxLjMzNyAwIDAgMCAxNS42NjcgOHoiIG9wYWNpdHk9Ii4yIi8+PHBhdGggZD0iTTE1LjY2NyA4SDUuNjE3QTkuNTA1IDkuNTA1IDAgMCAwIDE1IDE5Yy4yNzcgMCAuNTUxLS4wMTMuODIzLS4wMzZsLjAwNS4wMzhBNi41IDYuNSAwIDAgMCA5LjUxOCAyNWg2LjE0OUExLjMzNyAxLjMzNyAwIDAgMCAxNyAyMy42NjdWOS4zMzNBMS4zMzcgMS4zMzcgMCAwIDAgMTUuNjY3IDh6IiBvcGFjaXR5PSIuMiIvPjxwYXRoIGQ9Ik0xNC42NjcgOGgtOS4wNUE5LjUwNSA5LjUwNSAwIDAgMCAxNSAxOWMuMjc3IDAgLjU1MS0uMDEzLjgyMy0uMDM2bC4wMDUuMDM4QTYuNSA2LjUgMCAwIDAgOS41MTggMjVoNS4xNDlBMS4zMzcgMS4zMzcgMCAwIDAgMTYgMjMuNjY3VjkuMzMzQTEuMzM3IDEuMzM3IDAgMCAwIDE0LjY2NyA4eiIgb3BhY2l0eT0iLjIiLz48cGF0aCBkPSJNMS4zMzMgOGgxMy4zMzRBMS4zMzMgMS4zMzMgMCAwIDEgMTYgOS4zMzN2MTMuMzM0QTEuMzMzIDEuMzMzIDAgMCAxIDE0LjY2NyAyNEgxLjMzM0ExLjMzMyAxLjMzMyAwIDAgMSAwIDIyLjY2N1Y5LjMzM0ExLjMzMyAxLjMzMyAwIDAgMSAxLjMzMyA4eiIgZmlsbD0iIzAzNzg3YyIvPjxwYXRoIGQ9Ik01LjY3IDE1LjgyNWEyLjY0NSAyLjY0NSAwIDAgMS0uODIyLS44NyAyLjM2MSAyLjM2MSAwIDAgMS0uMjg3LTEuMTkgMi4yOSAyLjI5IDAgMCAxIC41MzMtMS41NDFBMy4xNDIgMy4xNDIgMCAwIDEgNi41MSAxMS4zYTUuOTgyIDUuOTgyIDAgMCAxIDEuOTM1LS4zIDcuMzU0IDcuMzU0IDAgMCAxIDIuNTQ5LjM1N3YxLjhhMy45ODYgMy45ODYgMCAwIDAtMS4xNTMtLjQ3MSA1LjU5NiA1LjU5NiAwIDAgMC0xLjM0OS0uMTYyIDIuOTI2IDIuOTI2IDAgMCAwLTEuMzg2LjI5My45MS45MSAwIDAgMC0uNTQ5LjgzMy44NDQuODQ0IDAgMCAwIC4yMzMuNTkgMi4xMjIgMi4xMjIgMCAwIDAgLjYyNy40NDhxLjM5NC4xOTYgMS4xNzYuNTJhMS4yMzIgMS4yMzIgMCAwIDEgLjE2OS4wNjcgOS42OTcgOS42OTcgMCAwIDEgMS40ODMuNzMyIDIuNjU0IDIuNjU0IDAgMCAxIC44NzcuODgzIDIuNTU4IDIuNTU4IDAgMCAxIC4zMTcgMS4zMzIgMi40OCAyLjQ4IDAgMCAxLS40OTkgMS42MDUgMi43ODkgMi43ODkgMCAwIDEtMS4zMzUuODk2QTYuMDQ5IDYuMDQ5IDAgMCAxIDcuNzAzIDIxYTEwLjAyOCAxMC4wMjggMCAwIDEtMS43MjItLjE0MiA1LjkxMiA1LjkxMiAwIDAgMS0xLjQtLjQwNHYtMS45MDJhNC41IDQuNSAwIDAgMCAxLjQxNi42NzUgNS41MTMgNS41MTMgMCAwIDAgMS41NTguMjUgMi42OCAyLjY4IDAgMCAwIDEuNDEzLS4zLjk0Ny45NDcgMCAwIDAgLjQ3NS0uODQ3LjkwNC45MDQgMCAwIDAtLjI2Ni0uNjQ4IDIuNzA0IDIuNzA0IDAgMCAwLS43MzUtLjUxMnEtLjQ2OS0uMjM2LTEuMzg2LS42MmE3Ljg2IDcuODYgMCAwIDEtMS4zODYtLjcyNXoiIGZpbGw9IiNmZmYiLz48cGF0aCBkPSJNMCAwaDMydjMySDB6IiBmaWxsPSJub25lIi8+PC9zdmc+"

--- a/src/appmixer/microsoft/sharepoint/bundle.json
+++ b/src/appmixer/microsoft/sharepoint/bundle.json
@@ -54,7 +54,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/microsoft/sharepoint/bundle.json
+++ b/src/appmixer/microsoft/sharepoint/bundle.json
@@ -52,6 +52,8 @@
         ],
         "1.3.3": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.4.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/microsoft/sharepoint/bundle.json
+++ b/src/appmixer/microsoft/sharepoint/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.sharepoint",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -53,7 +53,8 @@
         "1.3.3": [
             "Added output examples to component schemas."
         ],
-        "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/microsoft/sharepoint/bundle.json
+++ b/src/appmixer/microsoft/sharepoint/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.sharepoint",
-    "version": "1.3.3",
+    "version": "1.4.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/microsoft/sharepoint/common.js
+++ b/src/appmixer/microsoft/sharepoint/common.js
@@ -4,8 +4,7 @@ const commons = require('../microsoft-commons');
 const { URL } = require('url');
 
 async function makeRequest(options, context) {
-    // Destructure the options and context objects
-    const { url, method, body } = options;
+    const { url, method, extraHeaders = {}, queryParams = {}, bodyData = {} } = options;
     const { accessToken, profileInfo } = context.auth;
 
     // Parse the URL and default it to Microsoft Graph API if invalid
@@ -16,13 +15,20 @@ async function makeRequest(options, context) {
         apiUrl = new URL(url, 'https://graph.microsoft.com/v1.0/');
     }
 
+    // Append query params if any
+    if (Object.keys(queryParams).length > 0) {
+        Object.entries(queryParams).forEach(([k, v]) => apiUrl.searchParams.set(k, v));
+    }
+
     const endpointUrl = apiUrl.href.replace(apiUrl.origin + '/v1.0/', '');
     const apiOptions = {
         accessToken,
         url: endpointUrl,
         method,
-        body: body ? JSON.parse(body) : undefined
+        body: Object.keys(bodyData).length > 0 ? bodyData : undefined,
+        ...(Object.keys(extraHeaders).length > 0 ? { headers: extraHeaders } : {})
     };
+
     // Call the SharePoint API endpoint and handle errors
     const apiResponse = await commons.formatError(async () => {
         return oneDriveAPI.items.customEndpoint(apiOptions);

--- a/src/appmixer/mollie/bundle.json
+++ b/src/appmixer/mollie/bundle.json
@@ -12,7 +12,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/mollie/bundle.json
+++ b/src/appmixer/mollie/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.mollie",
-    "version": "1.1.1",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -10,6 +10,9 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
+        ],
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
         ]
     }
 }

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",
@@ -74,7 +74,8 @@
         "3.1.1": [
             "Added output examples to component schemas."
         ],
-        "3.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "4.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -75,6 +75,6 @@
             "Added output examples to component schemas."
         ],
         "3.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -73,6 +73,8 @@
         ],
         "3.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "3.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/monday/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.monday.com/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/monday/core/MakeApiCall/component.json
+++ b/src/appmixer/monday/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/monday/core/MakeApiCall/component.json
+++ b/src/appmixer/monday/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/monday/core/MakeApiCall/component.json
+++ b/src/appmixer/monday/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/monday/core/MakeApiCall/component.json
+++ b/src/appmixer/monday/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/naxai/bundle.json
+++ b/src/appmixer/naxai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.naxai",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.3": [
             "Naxai"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/naxai/bundle.json
+++ b/src/appmixer/naxai/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/naxai/bundle.json
+++ b/src/appmixer/naxai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.naxai",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.3": [
             "Naxai"

--- a/src/appmixer/naxai/bundle.json
+++ b/src/appmixer/naxai/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -47,9 +47,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -38,8 +37,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/naxai/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,50 +22,28 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.naxai.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'X-Client-Id': context.auth.clientId,
                 'X-Client-Secret': context.auth.clientSecret,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/naxai/core/MakeApiCall/component.json
+++ b/src/appmixer/naxai/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/naxai/core/MakeApiCall/component.json
+++ b/src/appmixer/naxai/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/naxai/core/MakeApiCall/component.json
+++ b/src/appmixer/naxai/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/naxai/core/MakeApiCall/component.json
+++ b/src/appmixer/naxai/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/nexl/bundle.json
+++ b/src/appmixer/nexl/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/nexl/bundle.json
+++ b/src/appmixer/nexl/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.nexl",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/nexl/bundle.json
+++ b/src/appmixer/nexl/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/nexl/bundle.json
+++ b/src/appmixer/nexl/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.nexl",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/nexl/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = `https://${context.auth.regionPrefix}.nexl.cloud`;
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/nexl/core/MakeApiCall/component.json
+++ b/src/appmixer/nexl/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/nexl/core/MakeApiCall/component.json
+++ b/src/appmixer/nexl/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/nexl/core/MakeApiCall/component.json
+++ b/src/appmixer/nexl/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/nexl/core/MakeApiCall/component.json
+++ b/src/appmixer/nexl/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/notion/bundle.json
+++ b/src/appmixer/notion/bundle.json
@@ -9,7 +9,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/notion/bundle.json
+++ b/src/appmixer/notion/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.notion",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial release"
@@ -8,7 +8,8 @@
         "1.0.2": [
             "Added output examples to component schemas."
         ],
-        "1.1.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/notion/bundle.json
+++ b/src/appmixer/notion/bundle.json
@@ -7,6 +7,8 @@
         ],
         "1.0.2": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.1.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/notion/bundle.json
+++ b/src/appmixer/notion/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.notion",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial release"

--- a/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -36,9 +36,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
@@ -22,9 +22,14 @@ module.exports = {
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 
+        const baseUrl = 'https://api.notion.com/v1';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
+
         const requestOptions = {
             method: method,
-            url: url,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',

--- a/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
@@ -10,11 +10,10 @@ const { API_VERSION } = require('../../lib');
 
 module.exports = {
     async receive(context) {
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -27,8 +26,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
@@ -22,7 +22,8 @@ module.exports = {
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',
-                'Notion-Version': API_VERSION //api version from lib.js
+                'Notion-Version': API_VERSION, //api version from lib.js
+                ...extraHeaders
             }
         };
 

--- a/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/notion/core/MakeApiCall/MakeApiCall.js
@@ -1,10 +1,20 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 const { API_VERSION } = require('../../lib');
 
 module.exports = {
     async receive(context) {
-        const { url, method, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -16,8 +26,12 @@ module.exports = {
             }
         };
 
-        if (body) {
-            requestOptions.data = JSON.parse(body);
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/notion/core/MakeApiCall/component.json
+++ b/src/appmixer/notion/core/MakeApiCall/component.json
@@ -54,7 +54,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -65,7 +65,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -75,7 +75,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 5,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/notion/core/MakeApiCall/component.json
+++ b/src/appmixer/notion/core/MakeApiCall/component.json
@@ -53,14 +53,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",
@@ -102,7 +98,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"

--- a/src/appmixer/notion/core/MakeApiCall/component.json
+++ b/src/appmixer/notion/core/MakeApiCall/component.json
@@ -27,6 +27,7 @@
                         "type": "select",
                         "index": 2,
                         "label": "HTTP Method",
+                        "defaultValue": "GET",
                         "tooltip": "Select the HTTP method for the API call.",
                         "options": [
                             {

--- a/src/appmixer/notion/core/MakeApiCall/component.json
+++ b/src/appmixer/notion/core/MakeApiCall/component.json
@@ -65,7 +65,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 4,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -75,7 +75,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/notion/core/MakeApiCall/component.json
+++ b/src/appmixer/notion/core/MakeApiCall/component.json
@@ -21,7 +21,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL including the base URL. For example, `https://api.notion.com/v1/databases/:id/query`."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.notion.com/v1</code> (for example <code>/users/me</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",
@@ -101,10 +101,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/src/appmixer/notion/core/MakeApiCall/component.json
+++ b/src/appmixer/notion/core/MakeApiCall/component.json
@@ -52,10 +52,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             },
@@ -77,7 +101,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
                 "required": [

--- a/src/appmixer/ntfy/bundle.json
+++ b/src/appmixer/ntfy/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/ntfy/bundle.json
+++ b/src/appmixer/ntfy/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ntfy",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version: PublishNotification component with support for message, title, priority, tags, click URL, icon URL, and attachment URL."
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/ntfy/bundle.json
+++ b/src/appmixer/ntfy/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/ntfy/bundle.json
+++ b/src/appmixer/ntfy/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ntfy",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version: PublishNotification component with support for message, title, priority, tags, click URL, icon URL, and attachment URL."

--- a/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ntfy/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = (context.auth.serverUrl || 'https://ntfy.sh').replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/ntfy/core/MakeApiCall/component.json
+++ b/src/appmixer/ntfy/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/ntfy/core/MakeApiCall/component.json
+++ b/src/appmixer/ntfy/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/ntfy/core/MakeApiCall/component.json
+++ b/src/appmixer/ntfy/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/ntfy/core/MakeApiCall/component.json
+++ b/src/appmixer/ntfy/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/onesignal/bundle.json
+++ b/src/appmixer/onesignal/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.onesignal",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/onesignal/bundle.json
+++ b/src/appmixer/onesignal/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/onesignal/bundle.json
+++ b/src/appmixer/onesignal/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.onesignal",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/onesignal/bundle.json
+++ b/src/appmixer/onesignal/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/onesignal/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://onesignal.com/api/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/onesignal/core/MakeApiCall/component.json
+++ b/src/appmixer/onesignal/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/onesignal/core/MakeApiCall/component.json
+++ b/src/appmixer/onesignal/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/onesignal/core/MakeApiCall/component.json
+++ b/src/appmixer/onesignal/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/onesignal/core/MakeApiCall/component.json
+++ b/src/appmixer/onesignal/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.openai",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "changelog": {
         "1.1.0": [
             "OpenAI API"
@@ -31,7 +31,8 @@
         "1.3.1": [
             "Added output examples to component schemas."
         ],
-        "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -32,6 +32,6 @@
             "Added output examples to component schemas."
         ],
         "1.4.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -30,6 +30,8 @@
         ],
         "1.3.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.4.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.openai",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "changelog": {
         "1.1.0": [
             "OpenAI API"

--- a/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/openai/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.openai.com/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/openai/core/MakeApiCall/component.json
+++ b/src/appmixer/openai/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/openai/core/MakeApiCall/component.json
+++ b/src/appmixer/openai/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/openai/core/MakeApiCall/component.json
+++ b/src/appmixer/openai/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/openai/core/MakeApiCall/component.json
+++ b/src/appmixer/openai/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/paddle/bundle.json
+++ b/src/appmixer/paddle/bundle.json
@@ -13,7 +13,7 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/paddle/bundle.json
+++ b/src/appmixer/paddle/bundle.json
@@ -11,6 +11,9 @@
         ],
         "1.1.2": [
             "Added output examples to component schemas."
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/paddle/bundle.json
+++ b/src/appmixer/paddle/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.paddle",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -12,8 +12,8 @@
         "1.1.2": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/paddle/bundle.json
+++ b/src/appmixer/paddle/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.paddle",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/paddle/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.paddle.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/paddle/core/MakeApiCall/component.json
+++ b/src/appmixer/paddle/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/paddle/core/MakeApiCall/component.json
+++ b/src/appmixer/paddle/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/paddle/core/MakeApiCall/component.json
+++ b/src/appmixer/paddle/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/paddle/core/MakeApiCall/component.json
+++ b/src/appmixer/paddle/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/pdfco/bundle.json
+++ b/src/appmixer/pdfco/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pdfco",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -14,7 +14,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/pdfco/bundle.json
+++ b/src/appmixer/pdfco/bundle.json
@@ -15,6 +15,6 @@
             "Added output examples to component schemas."
         ],
         "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pdfco/bundle.json
+++ b/src/appmixer/pdfco/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pdfco",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/pdfco/bundle.json
+++ b/src/appmixer/pdfco/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pdfco/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.pdf.co/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'x-api-key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/pdfco/core/MakeApiCall/component.json
+++ b/src/appmixer/pdfco/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/pdfco/core/MakeApiCall/component.json
+++ b/src/appmixer/pdfco/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/pdfco/core/MakeApiCall/component.json
+++ b/src/appmixer/pdfco/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/pdfco/core/MakeApiCall/component.json
+++ b/src/appmixer/pdfco/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/perplexity/bundle.json
+++ b/src/appmixer/perplexity/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.perplexity",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -17,7 +17,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/perplexity/bundle.json
+++ b/src/appmixer/perplexity/bundle.json
@@ -18,6 +18,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/perplexity/bundle.json
+++ b/src/appmixer/perplexity/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.perplexity",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/perplexity/bundle.json
+++ b/src/appmixer/perplexity/bundle.json
@@ -16,6 +16,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/perplexity/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.perplexity.ai';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/perplexity/core/MakeApiCall/component.json
+++ b/src/appmixer/perplexity/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/perplexity/core/MakeApiCall/component.json
+++ b/src/appmixer/perplexity/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/perplexity/core/MakeApiCall/component.json
+++ b/src/appmixer/perplexity/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/perplexity/core/MakeApiCall/component.json
+++ b/src/appmixer/perplexity/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/pinecone/bundle.json
+++ b/src/appmixer/pinecone/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pinecone",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -20,7 +20,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/pinecone/bundle.json
+++ b/src/appmixer/pinecone/bundle.json
@@ -21,6 +21,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pinecone/bundle.json
+++ b/src/appmixer/pinecone/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pinecone",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/pinecone/bundle.json
+++ b/src/appmixer/pinecone/bundle.json
@@ -19,6 +19,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinecone/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.pinecone.io';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Api-Key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/pinecone/core/MakeApiCall/component.json
+++ b/src/appmixer/pinecone/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/pinecone/core/MakeApiCall/component.json
+++ b/src/appmixer/pinecone/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/pinecone/core/MakeApiCall/component.json
+++ b/src/appmixer/pinecone/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/pinecone/core/MakeApiCall/component.json
+++ b/src/appmixer/pinecone/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/pinterest/bundle.json
+++ b/src/appmixer/pinterest/bundle.json
@@ -9,7 +9,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/pinterest/bundle.json
+++ b/src/appmixer/pinterest/bundle.json
@@ -7,6 +7,8 @@
         ],
         "1.0.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.1.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pinterest/bundle.json
+++ b/src/appmixer/pinterest/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pinterest",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/pinterest/bundle.json
+++ b/src/appmixer/pinterest/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pinterest",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -8,7 +8,8 @@
         "1.0.1": [
             "Added output examples to component schemas."
         ],
-        "1.1.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
@@ -8,11 +8,10 @@ function kvToObj(arr) {
 
 module.exports = {
     async receive(context) {
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -24,8 +23,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
@@ -20,9 +20,14 @@ module.exports = {
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
 
+        const baseUrl = 'https://api.pinterest.com/v5';
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
+
         const requestOptions = {
             method: method,
-            url: url,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',

--- a/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -33,9 +33,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
@@ -19,7 +19,8 @@ module.exports = {
             url: url,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                ...extraHeaders
             }
         };
 

--- a/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pinterest/core/MakeApiCall/MakeApiCall.js
@@ -1,8 +1,18 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
-        const { url, method, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         const requestOptions = {
             method: method,
@@ -13,8 +23,12 @@ module.exports = {
             }
         };
 
-        if (body) {
-            requestOptions.data = JSON.parse(body);
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/pinterest/core/MakeApiCall/component.json
+++ b/src/appmixer/pinterest/core/MakeApiCall/component.json
@@ -85,7 +85,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 3,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -96,7 +96,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -106,7 +106,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 5,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/pinterest/core/MakeApiCall/component.json
+++ b/src/appmixer/pinterest/core/MakeApiCall/component.json
@@ -35,10 +35,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -52,7 +52,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL including the base URL. For example, `https://api.pinterest.com/v5/pins`."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.pinterest.com/v5</code> (for example <code>/user_account</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/pinterest/core/MakeApiCall/component.json
+++ b/src/appmixer/pinterest/core/MakeApiCall/component.json
@@ -58,6 +58,7 @@
                         "type": "select",
                         "index": 2,
                         "label": "HTTP Method",
+                        "defaultValue": "GET",
                         "tooltip": "Select the HTTP method for the API call.",
                         "options": [
                             {

--- a/src/appmixer/pinterest/core/MakeApiCall/component.json
+++ b/src/appmixer/pinterest/core/MakeApiCall/component.json
@@ -96,7 +96,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 4,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -106,7 +106,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 5,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/pinterest/core/MakeApiCall/component.json
+++ b/src/appmixer/pinterest/core/MakeApiCall/component.json
@@ -32,7 +32,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -84,14 +84,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 3,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/pinterest/core/MakeApiCall/component.json
+++ b/src/appmixer/pinterest/core/MakeApiCall/component.json
@@ -32,7 +32,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
+                    },
+                    "headers": {
+                        "type": "array"
+                    },
+                    "parameters": {
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -77,10 +83,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 3,
+                        "tooltip": "Enter the request body as key-value pairs."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "2.4.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -49,7 +49,8 @@
         "2.3.1": [
             "Added output examples to component schemas."
         ],
-        "2.4.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "3.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -50,6 +50,6 @@
             "Added output examples to component schemas."
         ],
         "2.4.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "changelog": {
         "1.0.0": [
             "Initial version."

--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -48,6 +48,8 @@
         ],
         "2.3.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "2.4.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/pipedrive/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.pipedrive.com/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/pipedrive/core/MakeApiCall/component.json
+++ b/src/appmixer/pipedrive/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/pipedrive/core/MakeApiCall/component.json
+++ b/src/appmixer/pipedrive/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/pipedrive/core/MakeApiCall/component.json
+++ b/src/appmixer/pipedrive/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/pipedrive/core/MakeApiCall/component.json
+++ b/src/appmixer/pipedrive/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/plivo/bundle.json
+++ b/src/appmixer/plivo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.plivo",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version."
@@ -14,8 +14,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/plivo/bundle.json
+++ b/src/appmixer/plivo/bundle.json
@@ -15,7 +15,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/plivo/bundle.json
+++ b/src/appmixer/plivo/bundle.json
@@ -13,6 +13,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/plivo/bundle.json
+++ b/src/appmixer/plivo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.plivo",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version."

--- a/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -39,8 +38,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -48,9 +48,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/plivo/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,51 +22,29 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.plivo.com/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const credentials = Buffer.from(`${context.auth.accountSID}:${context.auth.authenticationToken}`).toString('base64');
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Basic ${credentials}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/plivo/core/MakeApiCall/component.json
+++ b/src/appmixer/plivo/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/plivo/core/MakeApiCall/component.json
+++ b/src/appmixer/plivo/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/plivo/core/MakeApiCall/component.json
+++ b/src/appmixer/plivo/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/plivo/core/MakeApiCall/component.json
+++ b/src/appmixer/plivo/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/ragieai/bundle.json
+++ b/src/appmixer/ragieai/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/ragieai/bundle.json
+++ b/src/appmixer/ragieai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ragieai",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.2": [
             "Initial release with document management components."
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/ragieai/bundle.json
+++ b/src/appmixer/ragieai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.ragieai",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.2": [
             "Initial release with document management components."

--- a/src/appmixer/ragieai/bundle.json
+++ b/src/appmixer/ragieai/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/ragieai/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.ragie.ai';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/ragieai/core/MakeApiCall/component.json
+++ b/src/appmixer/ragieai/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/ragieai/core/MakeApiCall/component.json
+++ b/src/appmixer/ragieai/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/ragieai/core/MakeApiCall/component.json
+++ b/src/appmixer/ragieai/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/ragieai/core/MakeApiCall/component.json
+++ b/src/appmixer/ragieai/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/railway/bundle.json
+++ b/src/appmixer/railway/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/railway/bundle.json
+++ b/src/appmixer/railway/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.railway",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/railway/bundle.json
+++ b/src/appmixer/railway/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/railway/bundle.json
+++ b/src/appmixer/railway/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.railway",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/railway/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://backboard.railway.app/graphql/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/railway/core/MakeApiCall/component.json
+++ b/src/appmixer/railway/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/railway/core/MakeApiCall/component.json
+++ b/src/appmixer/railway/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/railway/core/MakeApiCall/component.json
+++ b/src/appmixer/railway/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/railway/core/MakeApiCall/component.json
+++ b/src/appmixer/railway/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/redmine/bundle.json
+++ b/src/appmixer/redmine/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.redmine",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.3": [
             "Redmine"
@@ -14,7 +14,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/redmine/bundle.json
+++ b/src/appmixer/redmine/bundle.json
@@ -15,6 +15,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/redmine/bundle.json
+++ b/src/appmixer/redmine/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/redmine/bundle.json
+++ b/src/appmixer/redmine/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.redmine",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.3": [
             "Redmine"

--- a/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/redmine/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = context.auth.url.replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'X-Redmine-API-Key': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/redmine/core/MakeApiCall/component.json
+++ b/src/appmixer/redmine/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/redmine/core/MakeApiCall/component.json
+++ b/src/appmixer/redmine/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/redmine/core/MakeApiCall/component.json
+++ b/src/appmixer/redmine/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/redmine/core/MakeApiCall/component.json
+++ b/src/appmixer/redmine/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/replicate/bundle.json
+++ b/src/appmixer/replicate/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.replicate",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -14,7 +14,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/replicate/bundle.json
+++ b/src/appmixer/replicate/bundle.json
@@ -15,6 +15,6 @@
             "Added output examples to component schemas."
         ],
         "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/replicate/bundle.json
+++ b/src/appmixer/replicate/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.replicate",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/replicate/bundle.json
+++ b/src/appmixer/replicate/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/replicate/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.replicate.com/v1';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/replicate/core/MakeApiCall/component.json
+++ b/src/appmixer/replicate/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/replicate/core/MakeApiCall/component.json
+++ b/src/appmixer/replicate/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/replicate/core/MakeApiCall/component.json
+++ b/src/appmixer/replicate/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/replicate/core/MakeApiCall/component.json
+++ b/src/appmixer/replicate/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.resend",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.3": [
             "Initial version"
@@ -14,7 +14,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -15,6 +15,6 @@
             "Added output examples to component schemas."
         ],
         "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.resend",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.0.3": [
             "Initial version"

--- a/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/resend/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.resend.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/resend/core/MakeApiCall/component.json
+++ b/src/appmixer/resend/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/resend/core/MakeApiCall/component.json
+++ b/src/appmixer/resend/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/resend/core/MakeApiCall/component.json
+++ b/src/appmixer/resend/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/resend/core/MakeApiCall/component.json
+++ b/src/appmixer/resend/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/servicenow/bundle.json
+++ b/src/appmixer/servicenow/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.servicenow",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -36,8 +36,8 @@
         "3.1.0": [
             "add MakeApiCall component"
         ],
-        "3.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "4.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/servicenow/bundle.json
+++ b/src/appmixer/servicenow/bundle.json
@@ -37,7 +37,7 @@
             "add MakeApiCall component"
         ],
         "3.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/servicenow/bundle.json
+++ b/src/appmixer/servicenow/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.servicenow",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [

--- a/src/appmixer/servicenow/bundle.json
+++ b/src/appmixer/servicenow/bundle.json
@@ -35,6 +35,9 @@
         ],
         "3.1.0": [
             "add MakeApiCall component"
+        ],
+        "3.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -41,8 +40,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -50,9 +50,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/servicenow/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,32 +22,10 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = `https://${context.auth.instance}.service-now.com`;
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
-
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
 
         const authHeaders = context.auth.apiKey
             ? { 'x-sn-apikey': context.auth.apiKey }
@@ -45,20 +33,20 @@ module.exports = {
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 ...authHeaders,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/servicenow/core/MakeApiCall/component.json
+++ b/src/appmixer/servicenow/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/servicenow/core/MakeApiCall/component.json
+++ b/src/appmixer/servicenow/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/servicenow/core/MakeApiCall/component.json
+++ b/src/appmixer/servicenow/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/servicenow/core/MakeApiCall/component.json
+++ b/src/appmixer/servicenow/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.sonarqube",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.sonarqube",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.2": [
             "Initial version"

--- a/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -39,8 +38,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -48,9 +48,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/sonarqube/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,51 +22,29 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = context.auth.serverUrl.replace(/\/$/, '');
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const credentials = Buffer.from(`${context.auth.apiKey}:`).toString('base64');
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Basic ${credentials}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/sonarqube/core/MakeApiCall/component.json
+++ b/src/appmixer/sonarqube/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/sonarqube/core/MakeApiCall/component.json
+++ b/src/appmixer/sonarqube/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/sonarqube/core/MakeApiCall/component.json
+++ b/src/appmixer/sonarqube/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/sonarqube/core/MakeApiCall/component.json
+++ b/src/appmixer/sonarqube/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/stripe/bundle.json
+++ b/src/appmixer/stripe/bundle.json
@@ -15,7 +15,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/stripe/bundle.json
+++ b/src/appmixer/stripe/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.stripe",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "changelog": {
         "1.0.4": [
             "Initial version"
@@ -13,6 +13,9 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
+        ],
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
         ]
     }
 }

--- a/src/appmixer/supabaseManagement/bundle.json
+++ b/src/appmixer/supabaseManagement/bundle.json
@@ -12,7 +12,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/supabaseManagement/bundle.json
+++ b/src/appmixer/supabaseManagement/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/supabaseManagement/bundle.json
+++ b/src/appmixer/supabaseManagement/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.supabaseManagement",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/supabaseManagement/bundle.json
+++ b/src/appmixer/supabaseManagement/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.supabaseManagement",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -34,8 +33,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -43,9 +43,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,31 +22,7 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-
-        // Parse headers
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'string' ? JSON.parse(headers) : headers;
-            } catch (e) {
-                throw new context.CancelError('Headers must be valid JSON.');
-            }
-        }
-
-        // Parse parameters and build query string
-        let queryString = '';
-        if (parameters) {
-            let parsedParams;
-            try {
-                parsedParams = typeof parameters === 'string' ? JSON.parse(parameters) : parameters;
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be valid JSON.');
-            }
-            const qs = new URLSearchParams(parsedParams).toString();
-            if (qs) queryString = '?' + qs;
-        }
-
-        const targetUrl = (url.startsWith('https://') || url.startsWith('http://')) ? url : `https://api.supabase.com${url.startsWith('/') ? '' : '/'}${url}` + queryString;
+        const targetUrl = (url.startsWith('https://') || url.startsWith('http://')) ? url : `https://api.supabase.com${url.startsWith('/') ? '' : '/'}${url}`;
 
         const requestOptions = {
             method,
@@ -44,16 +30,16 @@ module.exports = {
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = typeof body === 'string' ? JSON.parse(body) : body;
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
@@ -28,7 +28,7 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -80,14 +80,10 @@
                         "defaultValue": "GET"
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
@@ -31,10 +31,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -48,7 +48,7 @@
                         "type": "text",
                         "index": 1,
                         "label": "API Endpoint URL",
-                        "tooltip": "Enter the API endpoint URL including the base URL. For example, `https://api.supabase.com/v1/projects/{projectID}/pause`."
+                        "tooltip": "Enter the API endpoint path relative to <code>https://api.supabase.com</code> (for example <code>/v1/projects/{projectID}/pause</code>) or provide a full URL."
                     },
                     "method": {
                         "type": "select",

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
@@ -81,7 +81,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,7 +102,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
+++ b/src/appmixer/supabaseManagement/core/MakeApiCall/component.json
@@ -28,13 +28,13 @@
                         "default": "GET"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -80,22 +80,34 @@
                         "defaultValue": "GET"
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Headers",
-                        "tooltip": "Optional additional HTTP headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"limit\": 10, \"offset\": 0}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/tally/bundle.json
+++ b/src/appmixer/tally/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.tally",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/tally/bundle.json
+++ b/src/appmixer/tally/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/tally/bundle.json
+++ b/src/appmixer/tally/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/tally/bundle.json
+++ b/src/appmixer/tally/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.tally",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/tally/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.tally.so';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/tally/core/MakeApiCall/component.json
+++ b/src/appmixer/tally/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/tally/core/MakeApiCall/component.json
+++ b/src/appmixer/tally/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/tally/core/MakeApiCall/component.json
+++ b/src/appmixer/tally/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/tally/core/MakeApiCall/component.json
+++ b/src/appmixer/tally/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.twilio",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version."
@@ -14,7 +14,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -15,6 +15,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -13,6 +13,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.twilio",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version."

--- a/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -39,8 +38,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -48,9 +48,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/twilio/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,51 +22,29 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.twilio.com/2010-04-01';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const credentials = Buffer.from(`${context.auth.accountSID}:${context.auth.authenticationToken}`).toString('base64');
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Basic ${credentials}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/twilio/core/MakeApiCall/component.json
+++ b/src/appmixer/twilio/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/twilio/core/MakeApiCall/component.json
+++ b/src/appmixer/twilio/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/twilio/core/MakeApiCall/component.json
+++ b/src/appmixer/twilio/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/twilio/core/MakeApiCall/component.json
+++ b/src/appmixer/twilio/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/unkey/bundle.json
+++ b/src/appmixer/unkey/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.unkey",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial release with key management components: CreateKey, GetKey, UpdateKey, DeleteKey, VerifyKey, ListKeys, GetAPI, and UpdateKeyRemaining."
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/unkey/bundle.json
+++ b/src/appmixer/unkey/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/unkey/bundle.json
+++ b/src/appmixer/unkey/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/unkey/bundle.json
+++ b/src/appmixer/unkey/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.unkey",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial release with key management components: CreateKey, GetKey, UpdateKey, DeleteKey, VerifyKey, ListKeys, GetAPI, and UpdateKeyRemaining."

--- a/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/unkey/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.unkey.com/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/unkey/core/MakeApiCall/component.json
+++ b/src/appmixer/unkey/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/unkey/core/MakeApiCall/component.json
+++ b/src/appmixer/unkey/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/unkey/core/MakeApiCall/component.json
+++ b/src/appmixer/unkey/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/unkey/core/MakeApiCall/component.json
+++ b/src/appmixer/unkey/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/userengage/bundle.json
+++ b/src/appmixer/userengage/bundle.json
@@ -9,7 +9,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/userengage/bundle.json
+++ b/src/appmixer/userengage/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.userengage",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,8 +8,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/userengage/bundle.json
+++ b/src/appmixer/userengage/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.userengage",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/userengage/bundle.json
+++ b/src/appmixer/userengage/bundle.json
@@ -7,6 +7,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/userengage/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://app.userengage.io';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'authorization': `Token ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/userengage/core/MakeApiCall/component.json
+++ b/src/appmixer/userengage/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/userengage/core/MakeApiCall/component.json
+++ b/src/appmixer/userengage/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/userengage/core/MakeApiCall/component.json
+++ b/src/appmixer/userengage/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/userengage/core/MakeApiCall/component.json
+++ b/src/appmixer/userengage/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/vapi/bundle.json
+++ b/src/appmixer/vapi/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.vapi",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial release with assistants and squads components."
@@ -16,7 +16,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/vapi/bundle.json
+++ b/src/appmixer/vapi/bundle.json
@@ -17,6 +17,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/vapi/bundle.json
+++ b/src/appmixer/vapi/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.vapi",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial release with assistants and squads components."

--- a/src/appmixer/vapi/bundle.json
+++ b/src/appmixer/vapi/bundle.json
@@ -15,6 +15,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vapi/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.vapi.ai';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/vapi/core/MakeApiCall/component.json
+++ b/src/appmixer/vapi/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/vapi/core/MakeApiCall/component.json
+++ b/src/appmixer/vapi/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/vapi/core/MakeApiCall/component.json
+++ b/src/appmixer/vapi/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/vapi/core/MakeApiCall/component.json
+++ b/src/appmixer/vapi/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/vercel/bundle.json
+++ b/src/appmixer/vercel/bundle.json
@@ -12,7 +12,7 @@
             "Added output examples to component schemas."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
         ]
     }
 }

--- a/src/appmixer/vercel/bundle.json
+++ b/src/appmixer/vercel/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.vercel",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "changelog": {
         "1.1.0": [
             "Added MakeApiCall component for arbitrary API calls."

--- a/src/appmixer/vercel/bundle.json
+++ b/src/appmixer/vercel/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.vercel",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "changelog": {
         "1.1.0": [
             "Added MakeApiCall component for arbitrary API calls."
@@ -11,7 +11,8 @@
         "1.2.1": [
             "Added output examples to component schemas."
         ],
-        "1.3.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: standardize key-value pair inputs for body, headers, and parameters — existing flows using string/textarea body input must be updated"
+        ]
     }
 }

--- a/src/appmixer/vercel/bundle.json
+++ b/src/appmixer/vercel/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.2.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.3.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -34,8 +33,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -43,9 +43,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/vercel/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,31 +22,7 @@ module.exports = {
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
         }
-
-        // Parse headers
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'string' ? JSON.parse(headers) : headers;
-            } catch (e) {
-                throw new context.CancelError('Headers must be valid JSON.');
-            }
-        }
-
-        // Parse parameters and build query string
-        let queryString = '';
-        if (parameters) {
-            let parsedParams;
-            try {
-                parsedParams = typeof parameters === 'string' ? JSON.parse(parameters) : parameters;
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be valid JSON.');
-            }
-            const qs = new URLSearchParams(parsedParams).toString();
-            if (qs) queryString = '?' + qs;
-        }
-
-        const targetUrl = (url.startsWith('https://') || url.startsWith('http://')) ? url : `https://api.vercel.com${url}` + queryString;
+        const targetUrl = (url.startsWith('https://') || url.startsWith('http://')) ? url : `https://api.vercel.com${url}`;
 
         const requestOptions = {
             method,
@@ -44,16 +30,16 @@ module.exports = {
             headers: {
                 'Authorization': `Bearer ${context.auth.apiToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = typeof body === 'string' ? JSON.parse(body) : body;
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/vercel/core/MakeApiCall/component.json
+++ b/src/appmixer/vercel/core/MakeApiCall/component.json
@@ -34,7 +34,7 @@
                         ]
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "headers": {
                         "type": "array"
@@ -86,14 +86,10 @@
                         ]
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
                     "headers": {
                         "type": "key-value",

--- a/src/appmixer/vercel/core/MakeApiCall/component.json
+++ b/src/appmixer/vercel/core/MakeApiCall/component.json
@@ -37,10 +37,10 @@
                         "type": "string"
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/src/appmixer/vercel/core/MakeApiCall/component.json
+++ b/src/appmixer/vercel/core/MakeApiCall/component.json
@@ -87,7 +87,7 @@
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     },
@@ -98,7 +98,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -108,7 +108,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     }
                 }

--- a/src/appmixer/vercel/core/MakeApiCall/component.json
+++ b/src/appmixer/vercel/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Headers",
-                        "tooltip": "Optional additional HTTP headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"limit\": 10, \"offset\": 0}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     }
                 }
             }

--- a/src/appmixer/verifyemail/bundle.json
+++ b/src/appmixer/verifyemail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.verifyemail",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -13,8 +13,8 @@
         "2.1.0": [
             "add MakeApiCall component"
         ],
-        "2.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "3.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/verifyemail/bundle.json
+++ b/src/appmixer/verifyemail/bundle.json
@@ -14,7 +14,7 @@
             "add MakeApiCall component"
         ],
         "2.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/verifyemail/bundle.json
+++ b/src/appmixer/verifyemail/bundle.json
@@ -12,6 +12,9 @@
         ],
         "2.1.0": [
             "add MakeApiCall component"
+        ],
+        "2.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/verifyemail/bundle.json
+++ b/src/appmixer/verifyemail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.verifyemail",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -29,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://verifyemail.io/api';
-        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
-            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,
@@ -47,9 +47,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -38,8 +37,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 
@@ -22,15 +29,15 @@ module.exports = {
         }
 
         const baseUrl = 'https://verifyemail.io/api';
-        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
             ? url
-            : `${baseUrl}${url}`;
+            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
 
         const requestOptions = {
             method,
             url: targetUrl,
-            // API key is always passed as a query parameter; user params are merged in
-            params: { apikey: context.auth.apiKey, ...queryParams },
+            // API key is always passed as a query parameter; user params cannot override it.
+            params: { ...queryParams, apikey: context.auth.apiKey },
             headers: {
                 'Content-Type': 'application/json',
                 ...extraHeaders

--- a/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/verifyemail/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,48 +22,24 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://verifyemail.io/api';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        // API key is passed as a query parameter
-        const allParams = { apikey: context.auth.apiKey, ...parsedParameters };
-        const queryString = '?' + new URLSearchParams(allParams).toString();
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
+            // API key is always passed as a query parameter; user params are merged in
+            params: { apikey: context.auth.apiKey, ...queryParams },
             headers: {
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/verifyemail/core/MakeApiCall/component.json
+++ b/src/appmixer/verifyemail/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/verifyemail/core/MakeApiCall/component.json
+++ b/src/appmixer/verifyemail/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/verifyemail/core/MakeApiCall/component.json
+++ b/src/appmixer/verifyemail/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/verifyemail/core/MakeApiCall/component.json
+++ b/src/appmixer/verifyemail/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/virustotal/bundle.json
+++ b/src/appmixer/virustotal/bundle.json
@@ -12,6 +12,6 @@
             "Added output examples to component schemas."
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/virustotal/bundle.json
+++ b/src/appmixer/virustotal/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.virustotal",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -11,7 +11,8 @@
         "1.1.1": [
             "Added output examples to component schemas."
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"        ]
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ]
     }
 }

--- a/src/appmixer/virustotal/bundle.json
+++ b/src/appmixer/virustotal/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.virustotal",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version."

--- a/src/appmixer/virustotal/bundle.json
+++ b/src/appmixer/virustotal/bundle.json
@@ -10,6 +10,8 @@
         ],
         "1.1.1": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"        ]
     }
 }

--- a/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 
@@ -22,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://www.virustotal.com/api/v3';
-        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
             ? url
-            : `${baseUrl}${url}`;
+            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
 
         const requestOptions = {
             method,

--- a/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -29,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://www.virustotal.com/api/v3';
-        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
-            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/virustotal/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://www.virustotal.com/api/v3';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'x-apikey': context.auth.apiKey,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/virustotal/core/MakeApiCall/component.json
+++ b/src/appmixer/virustotal/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/virustotal/core/MakeApiCall/component.json
+++ b/src/appmixer/virustotal/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/virustotal/core/MakeApiCall/component.json
+++ b/src/appmixer/virustotal/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/virustotal/core/MakeApiCall/component.json
+++ b/src/appmixer/virustotal/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/voys/bundle.json
+++ b/src/appmixer/voys/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.voys",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -11,8 +11,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/voys/bundle.json
+++ b/src/appmixer/voys/bundle.json
@@ -12,7 +12,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/voys/bundle.json
+++ b/src/appmixer/voys/bundle.json
@@ -10,6 +10,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/voys/bundle.json
+++ b/src/appmixer/voys/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.voys",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 
@@ -22,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://freedom.voys.nl/api';
-        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
             ? url
-            : `${baseUrl}${url}`;
+            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
 
         const requestOptions = {
             method,

--- a/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -29,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://freedom.voys.nl/api';
-        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
-            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/voys/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://freedom.voys.nl/api';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `token ${context.auth.username}:${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/voys/core/MakeApiCall/component.json
+++ b/src/appmixer/voys/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/voys/core/MakeApiCall/component.json
+++ b/src/appmixer/voys/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/voys/core/MakeApiCall/component.json
+++ b/src/appmixer/voys/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/voys/core/MakeApiCall/component.json
+++ b/src/appmixer/voys/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/webflow/bundle.json
+++ b/src/appmixer/webflow/bundle.json
@@ -15,7 +15,7 @@
             "add MakeApiCall component"
         ],
         "2.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/webflow/bundle.json
+++ b/src/appmixer/webflow/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.webflow",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -14,8 +14,8 @@
         "2.1.0": [
             "add MakeApiCall component"
         ],
-        "2.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "3.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/webflow/bundle.json
+++ b/src/appmixer/webflow/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.webflow",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"

--- a/src/appmixer/webflow/bundle.json
+++ b/src/appmixer/webflow/bundle.json
@@ -13,6 +13,9 @@
         ],
         "2.1.0": [
             "add MakeApiCall component"
+        ],
+        "2.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 
@@ -22,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://api.webflow.com/v2';
-        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
             ? url
-            : `${baseUrl}${url}`;
+            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
 
         const requestOptions = {
             method,

--- a/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -37,8 +36,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -29,9 +29,9 @@ module.exports = {
         }
 
         const baseUrl = 'https://api.webflow.com/v2';
-        const targetUrl = url.startsWith("http://") || url.startsWith("https://")
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
-            : `${baseUrl}${url.startsWith("/") ? url : "/" + url}`;
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,
@@ -46,9 +46,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/webflow/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,49 +22,27 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://api.webflow.com/v2';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.apiKey}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
         };
 
-        if (body) {
-            try {
-                requestOptions.data = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
         }
 
         const response = await context.httpRequest(requestOptions);

--- a/src/appmixer/webflow/core/MakeApiCall/component.json
+++ b/src/appmixer/webflow/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/webflow/core/MakeApiCall/component.json
+++ b/src/appmixer/webflow/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/webflow/core/MakeApiCall/component.json
+++ b/src/appmixer/webflow/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/webflow/core/MakeApiCall/component.json
+++ b/src/appmixer/webflow/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/whatsapp/bundle.json
+++ b/src/appmixer/whatsapp/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.whatsapp",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial WhatsApp Business Cloud API connector.",
@@ -15,6 +15,9 @@
             "OAuth now uses Facebook Login for Business with a Meta Login Configuration ID (`appmixer:whatsapp.configId` in Backoffice). Customers see the WABA asset picker instead of a plain consent screen. Falls back to plain OAuth when configId is not set.",
             "Auth fails explicitly when /debug_token returns granular_scopes but no WhatsApp Business Account is selected — prevents 'connected but useless' accounts.",
             "New ListMessageTemplates component (messages/). Usable standalone and as the dynamic-source dropdown for SendTemplateMessage's Template Name field — customers now pick APPROVED templates from a typeahead."
+        ],
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers, parameters, and body changed from textarea/JSON string to key-value array inputs per standard #1459 — existing flows using the old format must be updated."
         ]
     }
 }

--- a/src/appmixer/whatsapp/bundle.json
+++ b/src/appmixer/whatsapp/bundle.json
@@ -17,7 +17,7 @@
             "New ListMessageTemplates component (messages/). Usable standalone and as the dynamic-source dropdown for SendTemplateMessage's Template Name field — customers now pick APPROVED templates from a typeahead."
         ],
         "2.0.0": [
-            "(breaking change) MakeApiCall: headers, parameters, and body changed from textarea/JSON string to key-value array inputs per standard #1459 — existing flows using the old format must be updated."
+            "(breaking change) MakeApiCall: headers and parameters changed from textarea/JSON string to key-value array inputs per standard #1459 (body remains textarea/JSON to support nested structures) — existing flows that used the old string-typed headers or parameters must be updated."
         ]
     }
 }

--- a/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
@@ -6,9 +6,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -53,9 +53,9 @@ module.exports = {
         let parsedBody;
         if (body) {
             try {
-                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
             } catch (e) {
-                throw new context.CancelError("Request Body must be valid JSON.");
+                throw new context.CancelError('Request Body must be valid JSON.');
             }
             requestOptions.data = parsedBody;
         }

--- a/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
@@ -2,44 +2,26 @@
 
 const lib = require('../../lib');
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
 module.exports = {
 
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint Path is required!');
         }
         if (!method) {
             throw new context.CancelError('HTTP Method is required!');
-        }
-
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = typeof headers === 'object' ? headers : JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Request Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = typeof parameters === 'object' ? parameters : JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Query Parameters must be a valid JSON object.');
-            }
-        }
-
-        let parsedBody;
-        if (body) {
-            try {
-                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
         }
 
         // Accept full URL or path (leading slash optional)
@@ -52,20 +34,25 @@ module.exports = {
             targetUrl = `${lib.BASE_URL}/${url}`;
         }
 
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
-
-        const response = await context.httpRequest({
+        const requestOptions = {
             method,
-            url: targetUrl + queryString,
-            data: parsedBody,
+            url: targetUrl,
             headers: {
                 'Authorization': `Bearer ${context.auth.accessToken}`,
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             }
-        });
+        };
+
+        if (Object.keys(bodyData).length > 0) {
+            requestOptions.data = bodyData;
+        }
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
+        }
+
+        const response = await context.httpRequest(requestOptions);
 
         return context.sendJson({
             status: response.status,

--- a/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
@@ -4,7 +4,14 @@ const lib = require('../../lib');
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 module.exports = {

--- a/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/whatsapp/core/MakeApiCall/MakeApiCall.js
@@ -11,11 +11,10 @@ module.exports = {
 
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint Path is required!');
@@ -44,8 +43,14 @@ module.exports = {
             }
         };
 
-        if (Object.keys(bodyData).length > 0) {
-            requestOptions.data = bodyData;
+        let parsedBody;
+        if (body) {
+            try {
+                parsedBody = typeof body === "object" ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError("Request Body must be valid JSON.");
+            }
+            requestOptions.data = parsedBody;
         }
 
         if (Object.keys(queryParams).length > 0) {

--- a/src/appmixer/whatsapp/core/MakeApiCall/component.json
+++ b/src/appmixer/whatsapp/core/MakeApiCall/component.json
@@ -96,7 +96,7 @@
                         "valueLabel": "Value",
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
-                        "index": 3,
+                        "index": 5,
                         "label": "Request Headers",
                         "tooltip": "Optional additional request headers."
                     },
@@ -106,13 +106,13 @@
                         "valueLabel": "Value",
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
-                        "index": 4,
+                        "index": 3,
                         "label": "Query Parameters",
                         "tooltip": "Optional query parameters (e.g. key <code>fields</code>, value <code>id,name</code>)."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/whatsapp/core/MakeApiCall/component.json
+++ b/src/appmixer/whatsapp/core/MakeApiCall/component.json
@@ -39,10 +39,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/whatsapp/core/MakeApiCall/component.json
+++ b/src/appmixer/whatsapp/core/MakeApiCall/component.json
@@ -39,13 +39,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -91,22 +91,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "index": 3,
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object."
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "index": 4,
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"fields\": \"id,name\"}</code>)."
+                        "tooltip": "Optional query parameters (e.g. key <code>fields</code>, value <code>id,name</code>)."
                     },
                     "body": {
-                        "type": "textarea",
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "index": 5,
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }

--- a/src/appmixer/whatsapp/core/MakeApiCall/component.json
+++ b/src/appmixer/whatsapp/core/MakeApiCall/component.json
@@ -45,7 +45,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -111,14 +111,10 @@
                         "tooltip": "Optional query parameters (e.g. key <code>fields</code>, value <code>id,name</code>)."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
+                        "type": "textarea",
                         "index": 5,
                         "label": "Request Body",
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/xtremepush/bundle.json
+++ b/src/appmixer/xtremepush/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.xtremepush",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -14,8 +14,8 @@
         "1.1.0": [
             "add MakeApiCall component"
         ],
-        "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
+        "2.0.0": [
+            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/xtremepush/bundle.json
+++ b/src/appmixer/xtremepush/bundle.json
@@ -15,7 +15,7 @@
             "add MakeApiCall component"
         ],
         "1.2.0": [
-            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
+            "MakeApiCall: standardize key-value pair inputs for headers and parameters (body remains JSON textarea), add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/xtremepush/bundle.json
+++ b/src/appmixer/xtremepush/bundle.json
@@ -13,6 +13,9 @@
         ],
         "1.1.0": [
             "add MakeApiCall component"
+        ],
+        "1.2.0": [
+            "MakeApiCall: standardize key-value pair inputs, add URL trailing slash guard, improved error handling"
         ]
     }
 }

--- a/src/appmixer/xtremepush/bundle.json
+++ b/src/appmixer/xtremepush/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.xtremepush",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"

--- a/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
@@ -2,7 +2,14 @@
 
 function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
-    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== "object") continue;
+        const key = row.key;
+        if (typeof key !== "string" || key.length === 0) continue;
+        out[key] = row.value;
+    }
+    return out;
 }
 
 

--- a/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
@@ -4,9 +4,9 @@ function kvToObj(arr) {
     if (!arr || !Array.isArray(arr)) return {};
     const out = {};
     for (const row of arr) {
-        if (!row || typeof row !== "object") continue;
+        if (!row || typeof row !== 'object') continue;
         const key = row.key;
-        if (typeof key !== "string" || key.length === 0) continue;
+        if (typeof key !== 'string' || key.length === 0) continue;
         out[key] = row.value;
     }
     return out;
@@ -28,10 +28,19 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
+        let parsedBody = {};
+        if (body) {
+            try {
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
+            } catch (e) {
+                throw new context.CancelError('Request Body must be valid JSON.');
+            }
+        }
+
         const baseUrl = 'https://external-api.xtremepush.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
-            : `${baseUrl}${url}`;
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
 
         const requestOptions = {
             method,
@@ -40,9 +49,11 @@ module.exports = {
                 'Content-Type': 'application/json',
                 ...extraHeaders
             },
+            // Xtremepush expects the app token in the request body. User body fields are merged first,
+            // then `apptoken` is set last so it cannot be overridden.
             data: {
-                apptoken: context.auth.apiKey,
-                ...bodyData
+                ...parsedBody,
+                apptoken: context.auth.apiKey
             }
         };
 

--- a/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
@@ -9,11 +9,10 @@ function kvToObj(arr) {
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
 
         const extraHeaders = kvToObj(headersKV);
         const queryParams = kvToObj(parametersKV);
-        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');

--- a/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
@@ -1,9 +1,19 @@
 'use strict';
 
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) return {};
+    return Object.fromEntries(arr.map(({ key, value }) => [key, value]));
+}
+
+
 module.exports = {
     async receive(context) {
 
-        const { url, method, headers, parameters, body } = context.messages.in.content;
+        const { url, method, headers: headersKV, parameters: parametersKV, body: bodyKV } = context.messages.in.content;
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+        const bodyData = kvToObj(bodyKV);
 
         if (!url) {
             throw new context.CancelError('API Endpoint URL is required!');
@@ -12,32 +22,10 @@ module.exports = {
             throw new context.CancelError('HTTP Method is required!');
         }
 
-        let parsedHeaders = {};
-        if (headers) {
-            try {
-                parsedHeaders = JSON.parse(headers);
-            } catch (e) {
-                throw new context.CancelError('Headers must be a valid JSON object.');
-            }
-        }
-
-        let parsedParameters = {};
-        if (parameters) {
-            try {
-                parsedParameters = JSON.parse(parameters);
-            } catch (e) {
-                throw new context.CancelError('Parameters must be a valid JSON object.');
-            }
-        }
-
         const baseUrl = 'https://external-api.xtremepush.com';
         const targetUrl = url.startsWith('http://') || url.startsWith('https://')
             ? url
             : `${baseUrl}${url}`;
-
-        const queryString = Object.keys(parsedParameters).length
-            ? '?' + new URLSearchParams(parsedParameters).toString()
-            : '';
 
         let parsedBody = {};
         if (body) {
@@ -50,16 +38,20 @@ module.exports = {
 
         const requestOptions = {
             method,
-            url: targetUrl + queryString,
+            url: targetUrl,
             headers: {
                 'Content-Type': 'application/json',
-                ...parsedHeaders
+                ...extraHeaders
             },
             data: {
                 apptoken: context.auth.apiKey,
                 ...parsedBody
             }
         };
+
+        if (Object.keys(queryParams).length > 0) {
+            requestOptions.params = queryParams;
+        }
 
         const response = await context.httpRequest(requestOptions);
 

--- a/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/xtremepush/core/MakeApiCall/MakeApiCall.js
@@ -27,15 +27,6 @@ module.exports = {
             ? url
             : `${baseUrl}${url}`;
 
-        let parsedBody = {};
-        if (body) {
-            try {
-                parsedBody = JSON.parse(body);
-            } catch (e) {
-                throw new context.CancelError('Request Body must be valid JSON.');
-            }
-        }
-
         const requestOptions = {
             method,
             url: targetUrl,
@@ -45,7 +36,7 @@ module.exports = {
             },
             data: {
                 apptoken: context.auth.apiKey,
-                ...parsedBody
+                ...bodyData
             }
         };
 

--- a/src/appmixer/xtremepush/core/MakeApiCall/component.json
+++ b/src/appmixer/xtremepush/core/MakeApiCall/component.json
@@ -40,7 +40,7 @@
                         "type": "array"
                     },
                     "body": {
-                        "type": "array"
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -106,14 +106,10 @@
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "key-value",
-                        "keyLabel": "Key",
-                        "valueLabel": "Value",
-                        "addLabel": "Add item",
-                        "removeLabel": "Remove item",
-                        "label": "Request Body",
+                        "type": "textarea",
                         "index": 5,
-                        "tooltip": "Enter the request body as key-value pairs."
+                        "label": "Request Body",
+                        "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }
                 }
             }

--- a/src/appmixer/xtremepush/core/MakeApiCall/component.json
+++ b/src/appmixer/xtremepush/core/MakeApiCall/component.json
@@ -92,7 +92,7 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "index": 3,
+                        "index": 5,
                         "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
@@ -102,12 +102,12 @@
                         "addLabel": "Add item",
                         "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "index": 4,
+                        "index": 3,
                         "tooltip": "Optional query parameters."
                     },
                     "body": {
                         "type": "textarea",
-                        "index": 5,
+                        "index": 4,
                         "label": "Request Body",
                         "tooltip": "Enter the request body as a JSON object (supports nested objects, arrays, and non-string values)."
                     }

--- a/src/appmixer/xtremepush/core/MakeApiCall/component.json
+++ b/src/appmixer/xtremepush/core/MakeApiCall/component.json
@@ -34,10 +34,10 @@
                         ]
                     },
                     "headers": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "parameters": {
-                        "type": "array"
+                        "type": "string"
                     },
                     "body": {
                         "type": "string"

--- a/src/appmixer/xtremepush/core/MakeApiCall/component.json
+++ b/src/appmixer/xtremepush/core/MakeApiCall/component.json
@@ -34,13 +34,13 @@
                         ]
                     },
                     "headers": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "parameters": {
-                        "type": "string"
+                        "type": "array"
                     },
                     "body": {
-                        "type": "string"
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -86,22 +86,34 @@
                         ]
                     },
                     "headers": {
-                        "type": "textarea",
-                        "index": 3,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Headers",
-                        "tooltip": "Optional additional request headers as a JSON object (e.g. <code>{\"X-Custom-Header\": \"value\"}</code>)."
+                        "index": 3,
+                        "tooltip": "Optional additional request headers."
                     },
                     "parameters": {
-                        "type": "textarea",
-                        "index": 4,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Query Parameters",
-                        "tooltip": "Optional query parameters as a JSON object (e.g. <code>{\"key\": \"value\"}</code>)."
+                        "index": 4,
+                        "tooltip": "Optional query parameters."
                     },
                     "body": {
-                        "type": "textarea",
-                        "index": 5,
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
                         "label": "Request Body",
-                        "tooltip": "Enter the request body for the API call (JSON format)."
+                        "index": 5,
+                        "tooltip": "Enter the request body as key-value pairs."
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Standardizes all 12 MakeApiCall components in the `dev` branch.

## Changes

### 1. key-value inputs (headers, parameters, body)
All three fields converted from `textarea` → `key-value` type with Key/Value/Add item/Remove item labels.
Previously missing fields (`headers`, `parameters`) added where absent.
inPorts schema updated: `string` → `array` for these fields.

### 2. JS updated to handle key-value format
Added `kvToObj(arr)` helper to convert `[{key, value}]` arrays to plain objects.
Headers spread into request headers, params set as `requestOptions.params`, body set as `requestOptions.data`.

### 3. URL slash guard
For connectors that construct `baseUrl + path` (vercel, convex, axiom):
```js
const path = url.startsWith('/') ? url : `/${url}`;
const targetUrl = /^https?:\/\//i.test(url) ? url : `https://api.example.com${path}`;
```

### 4. microsoft/sharepoint/common.js updated
Accepts `extraHeaders`, `queryParams`, `bodyData` objects instead of raw body string.

### 5. Version bumps
Minor version bump for all 12 affected connectors.

## Affected connectors
axiom, canva, clerk, convex, github, google/gmail, microsoft/dynamics, microsoft/sharepoint, notion, pinterest, supabaseManagement, vercel