### PR TITLE
utils.tasks(patch): validate decisionBy is a future date

### DIFF
--- a/src/appmixer/utils/tasks/RequestApproval/RequestApproval.js
+++ b/src/appmixer/utils/tasks/RequestApproval/RequestApproval.js
@@ -21,7 +21,11 @@ module.exports = {
         const body = context.messages.task.content;
 
         if (body.decisionBy) {
-            body.decisionBy = new Date(body.decisionBy).toISOString();
+            const decisionBy = new Date(body.decisionBy);
+            if (decisionBy.getTime() <= Date.now()) {
+                throw new context.CancelError('Decision by must be a future date.');
+            }
+            body.decisionBy = decisionBy.toISOString();
         }
 
         const task = await context.callAppmixer({

--- a/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
+++ b/src/appmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js
@@ -216,7 +216,11 @@ module.exports = {
         const body = context.messages.task.content;
 
         if (body.decisionBy) {
-            body.decisionBy = new Date(body.decisionBy).toISOString();
+            const decisionBy = new Date(body.decisionBy);
+            if (decisionBy.getTime() <= Date.now()) {
+                throw new context.CancelError('Decision by must be a future date.');
+            }
+            body.decisionBy = decisionBy.toISOString();
         }
 
         const task = await context.callAppmixer({

--- a/src/appmixer/utils/tasks/artifacts/test/RequestApprovalComponent.test.js
+++ b/src/appmixer/utils/tasks/artifacts/test/RequestApprovalComponent.test.js
@@ -17,8 +17,8 @@ describe('Utils RequestApproval component', () => {
     });
 
     it('creates task, emits created, registers webhook, saves state', async () => {
-        // Arrange input and stubs
-        const iso = new Date().toISOString();
+        // Arrange input and stubs — decisionBy must be in the future
+        const iso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
         context.messages = {
             task: {
                 content: {
@@ -71,6 +71,28 @@ describe('Utils RequestApproval component', () => {
         assert(context.stateSet.calledOnce);
         assert.strictEqual(context.stateSet.firstCall.args[0], 'W1');
         assert.deepStrictEqual(context.stateSet.firstCall.args[1], {});
+    });
+
+    it('rejects decisionBy in the past with CancelError', async () => {
+        context.messages = {
+            task: {
+                content: {
+                    title: 'Title',
+                    decisionBy: new Date(Date.now() - 1000).toISOString()
+                }
+            }
+        };
+
+        const Component = require('../../RequestApproval/RequestApproval.js');
+
+        await assert.rejects(
+            () => Component.receive(context),
+            err => {
+                assert(err instanceof context.CancelError, 'should throw CancelError');
+                assert(/future date/i.test(err.message), 'message should mention future date');
+                return true;
+            }
+        );
     });
 
     it('handles webhook payload and emits to status outport, responds 200', async () => {

--- a/src/appmixer/utils/tasks/bundle.json
+++ b/src/appmixer/utils/tasks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.tasks",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "changelog": {
         "1.0.2": [
             "Using new context.job.lock function."
@@ -17,6 +17,9 @@
         ],
         "1.1.2": [
             "RequestApprovalEmail: replace broken third-party icon URLs with inline SVG data URIs."
+        ],
+        "1.1.3": [
+            "RequestApproval, RequestApprovalEmail: validate that decisionBy is a future date."
         ]
     },
     "engine": ">=5.1"


### PR DESCRIPTION
## Summary

Adds future-date validation for `decisionBy` in `RequestApproval` and `RequestApprovalEmail` to prevent creation of pre-expired approval tasks.

## Root Cause

Both components only normalized `decisionBy` via `new Date(...).toISOString()` without checking it is in the future. A past date creates a task that immediately matches the due-tasks cron query and expires within seconds.

## Fix

Before the `callApmmixer` POST, validate that `decisionBy` is in the future. Throws `CancelError` with a clear message if not.

## Changes

- `src/apmmixer/utils/tasks/RequestApproval/RequestApproval.js`: added future-date validation
- `src/apmmixer/utils/tasks/RequestApprovalEmail/RequestApprovalEmail.js`: added future-date validation

Fixes Apmmixer-ai/apmmixer-components#2692