### PR TITLE
linkedin(major): add image post + organization posting (breaking: new OAuth scope)

### DIFF
--- a/src/appmixer/linkedin/bundle.json
+++ b/src/appmixer/linkedin/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.linkedin",
-    "version": "2.3.0",
+    "version": "3.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -14,8 +14,10 @@
         "2.2.0": [
             "Updated to new LinkedIn API version."
         ],
-        "2.3.0": [
-            "Added image post support and organization page posting."
+        "3.0.0": [
+            "BREAKING: Added w_organization_social OAuth scope to support posting as an organization page. Existing users must re-authenticate.",
+            "Added image post support (via URL or Appmixer file picker).",
+            "Added ability to post as an organization/company page."
         ]
 
     }

--- a/src/appmixer/linkedin/bundle.json
+++ b/src/appmixer/linkedin/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.linkedin",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -13,6 +13,9 @@
         ],
         "2.2.0": [
             "Updated to new LinkedIn API version."
+        ],
+        "2.3.0": [
+            "Added image post support and organization page posting."
         ]
 
     }

--- a/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
+++ b/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const axios = require('axios');
 const { BASE_URL, VERSION_PATH, VERSION_HEADER } = require('../../constants');
 
 /**
@@ -59,13 +58,25 @@ module.exports = {
 
         const { imageUrl, imageFile, specificLink, authorType, organizationId } = context.messages.in.content;
 
-        const author = (authorType === 'Organization' && organizationId)
+        // Validate organizationId when posting as an organization
+        if (authorType === 'ORGANIZATION' && !organizationId) {
+            throw new context.CancelError('Organization ID is required when posting as an organization!');
+        }
+
+        // TODO: Add a ListOrganizations component to let users pick from orgs they administer
+        // (via /v2/organizationalEntityAcls) instead of entering a free-form numeric ID.
+        // See PR review comment — this is tracked as a separate improvement.
+        const author = (authorType === 'ORGANIZATION' && organizationId)
             ? `urn:li:organization:${organizationId}`
             : `urn:li:person:${context.auth.profileInfo.sub}`;
 
         let assetUrn = null;
 
         const useImage = !specificLink && (imageUrl || imageFile);
+
+        if (!useImage && (imageUrl || imageFile)) {
+            context.log('info', 'Image inputs (imageUrl/imageFile) ignored because specificLink is enabled.');
+        }
 
         if (useImage) {
 
@@ -97,11 +108,24 @@ module.exports = {
             ].uploadUrl;
             assetUrn = registerResponse.data.value.asset;
 
+            // Step 2: Fetch image data
             let imageBuffer;
             if (imageUrl) {
                 // URL takes priority — download from URL
-                const imageResponse = await axios.get(imageUrl, { responseType: 'arraybuffer' });
-                imageBuffer = imageResponse.data;
+                // Validate URL scheme to prevent SSRF (only http/https allowed)
+                // TODO: Add DNS-based private IP blocking for full SSRF protection
+                const parsedUrl = new URL(imageUrl);
+                if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+                    throw new context.CancelError('Image URL must use http or https protocol.');
+                }
+                const imageResponse = await context.httpRequest({
+                    method: 'GET',
+                    url: imageUrl,
+                    responseType: 'arraybuffer',
+                    maxContentLength: 20 * 1024 * 1024,
+                    maxBodyLength: 20 * 1024 * 1024
+                });
+                imageBuffer = Buffer.from(imageResponse.data);
             } else {
                 // Fall back to file from Appmixer storage
                 const stream = await context.getFileReadStream(imageFile);
@@ -115,11 +139,16 @@ module.exports = {
             }
 
             // Step 3: Upload image binary to LinkedIn
-            await axios.put(uploadUrl, imageBuffer, {
+            await context.httpRequest({
+                method: 'PUT',
+                url: uploadUrl,
+                data: imageBuffer,
                 headers: {
                     'Authorization': `Bearer ${context.auth.accessToken}`,
                     'Content-Type': 'application/octet-stream'
-                }
+                },
+                maxContentLength: 20 * 1024 * 1024,
+                maxBodyLength: 20 * 1024 * 1024
             });
         }
 

--- a/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
+++ b/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
@@ -39,8 +39,8 @@ function buildPost(context, author, assetUrn) {
 
         shareObject.content = {
             media: {
-                status: 'READY',
-                media: assetUrn
+                id: assetUrn,
+                title: ''
             }
         };
     }
@@ -80,33 +80,25 @@ module.exports = {
 
         if (useImage) {
 
-            // Step 1: Register upload
+            // Step 1: Initialize image upload (versioned Images API)
             const registerResponse = await context.httpRequest({
                 method: 'POST',
-                url: `${BASE_URL}v2/assets?action=registerUpload`,
+                url: `${BASE_URL}${VERSION_PATH}/images?action=initializeUpload`,
                 headers: {
                     'X-Restli-Protocol-Version': '2.0.0',
                     'Authorization': `Bearer ${context.auth.accessToken}`,
+                    'LinkedIn-Version': VERSION_HEADER,
                     'Content-Type': 'application/json'
                 },
                 data: {
-                    registerUploadRequest: {
-                        recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
-                        owner: author,
-                        serviceRelationships: [
-                            {
-                                relationshipType: 'OWNER',
-                                identifier: 'urn:li:userGeneratedContent'
-                            }
-                        ]
+                    initializeUploadRequest: {
+                        owner: author
                     }
                 }
             });
 
-            const uploadUrl = registerResponse.data.value.uploadMechanism[
-                'com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest'
-            ].uploadUrl;
-            assetUrn = registerResponse.data.value.asset;
+            const uploadUrl = registerResponse.data.value.uploadUrl;
+            assetUrn = registerResponse.data.value.image;
 
             // Step 2: Fetch image data
             let imageBuffer;
@@ -125,6 +117,10 @@ module.exports = {
                     maxContentLength: 20 * 1024 * 1024,
                     maxBodyLength: 20 * 1024 * 1024
                 });
+                const contentLength = parseInt(imageResponse.headers['content-length'] || '0', 10);
+                if (contentLength > 20 * 1024 * 1024) {
+                    throw new context.CancelError('Image file exceeds the 20 MB limit.');
+                }
                 imageBuffer = Buffer.from(imageResponse.data);
             } else {
                 // Fall back to file from Appmixer storage
@@ -152,17 +148,27 @@ module.exports = {
             });
         }
 
-        const response = await context.httpRequest({
-            method: 'POST',
-            url: `${BASE_URL}${VERSION_PATH}/posts`,
-            headers: {
-                'X-Restli-Protocol-Version': '2.0.0',
-                'Authorization': `Bearer ${context.auth.accessToken}`,
-                'LinkedIn-Version': VERSION_HEADER,
-                'Content-Type': 'application/json'
-            },
-            data: buildPost(context, author, assetUrn)
-        });
+        let response;
+        try {
+            response = await context.httpRequest({
+                method: 'POST',
+                url: `${BASE_URL}${VERSION_PATH}/posts`,
+                headers: {
+                    'X-Restli-Protocol-Version': '2.0.0',
+                    'Authorization': `Bearer ${context.auth.accessToken}`,
+                    'LinkedIn-Version': VERSION_HEADER,
+                    'Content-Type': 'application/json'
+                },
+                data: buildPost(context, author, assetUrn)
+            });
+        } catch (err) {
+            if (err.response && err.response.status === 403 && authorType === 'ORGANIZATION') {
+                throw new context.CancelError(
+                    `LinkedIn rejected the request (403). Make sure you are an admin of organization ID "${organizationId}" and have granted the w_organization_social scope.`
+                );
+            }
+            throw err;
+        }
         return context.sendJson({ status: response.status, postId: response.headers['x-restli-id'] }, 'out');
     }
 };

--- a/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
+++ b/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
@@ -57,7 +57,7 @@ module.exports = {
 
     async receive(context) {
 
-        const { imageUrl, authorType, organizationId } = context.messages.in.content;
+        const { imageUrl, imageFile, specificLink, authorType, organizationId } = context.messages.in.content;
 
         const author = (authorType === 'Organization' && organizationId)
             ? `urn:li:organization:${organizationId}`
@@ -65,7 +65,9 @@ module.exports = {
 
         let assetUrn = null;
 
-        if (imageUrl) {
+        const useImage = !specificLink && (imageUrl || imageFile);
+
+        if (useImage) {
 
             // Step 1: Register upload
             const registerResponse = await context.httpRequest({
@@ -95,11 +97,25 @@ module.exports = {
             ].uploadUrl;
             assetUrn = registerResponse.data.value.asset;
 
-            // Step 2: Download image bytes
-            const imageResponse = await axios.get(imageUrl, { responseType: 'arraybuffer' });
+            let imageBuffer;
+            if (imageUrl) {
+                // URL takes priority — download from URL
+                const imageResponse = await axios.get(imageUrl, { responseType: 'arraybuffer' });
+                imageBuffer = imageResponse.data;
+            } else {
+                // Fall back to file from Appmixer storage
+                const stream = await context.getFileReadStream(imageFile);
+                const chunks = [];
+                await new Promise((resolve, reject) => {
+                    stream.on('data', chunk => chunks.push(chunk));
+                    stream.on('end', resolve);
+                    stream.on('error', reject);
+                });
+                imageBuffer = Buffer.concat(chunks);
+            }
 
             // Step 3: Upload image binary to LinkedIn
-            await axios.put(uploadUrl, imageResponse.data, {
+            await axios.put(uploadUrl, imageBuffer, {
                 headers: {
                     'Authorization': `Bearer ${context.auth.accessToken}`,
                     'Content-Type': 'application/octet-stream'

--- a/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
+++ b/src/appmixer/linkedin/shares/CreatePost/CreatePost.js
@@ -1,19 +1,21 @@
 'use strict';
 
+const axios = require('axios');
 const { BASE_URL, VERSION_PATH, VERSION_HEADER } = require('../../constants');
 
 /**
  * Build post.
  * @param {Context} context
- * @param {Object} post
+ * @param {string} author
+ * @param {string|null} assetUrn
  * @return {Object} shareObject
  */
-function buildPost(context) {
+function buildPost(context, author, assetUrn) {
 
     const { visibility, text, url, title, description, specificLink } = context.messages.in.content;
 
     const shareObject = {
-        author: `urn:li:person:${context.auth.profileInfo.sub}`,
+        author,
         commentary: text,
         visibility: visibility || 'PUBLIC',
         distribution: {
@@ -34,6 +36,14 @@ function buildPost(context) {
                 description
             }
         };
+    } else if (assetUrn) {
+
+        shareObject.content = {
+            media: {
+                status: 'READY',
+                media: assetUrn
+            }
+        };
     }
 
     return shareObject;
@@ -47,6 +57,56 @@ module.exports = {
 
     async receive(context) {
 
+        const { imageUrl, authorType, organizationId } = context.messages.in.content;
+
+        const author = (authorType === 'Organization' && organizationId)
+            ? `urn:li:organization:${organizationId}`
+            : `urn:li:person:${context.auth.profileInfo.sub}`;
+
+        let assetUrn = null;
+
+        if (imageUrl) {
+
+            // Step 1: Register upload
+            const registerResponse = await context.httpRequest({
+                method: 'POST',
+                url: `${BASE_URL}v2/assets?action=registerUpload`,
+                headers: {
+                    'X-Restli-Protocol-Version': '2.0.0',
+                    'Authorization': `Bearer ${context.auth.accessToken}`,
+                    'Content-Type': 'application/json'
+                },
+                data: {
+                    registerUploadRequest: {
+                        recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
+                        owner: author,
+                        serviceRelationships: [
+                            {
+                                relationshipType: 'OWNER',
+                                identifier: 'urn:li:userGeneratedContent'
+                            }
+                        ]
+                    }
+                }
+            });
+
+            const uploadUrl = registerResponse.data.value.uploadMechanism[
+                'com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest'
+            ].uploadUrl;
+            assetUrn = registerResponse.data.value.asset;
+
+            // Step 2: Download image bytes
+            const imageResponse = await axios.get(imageUrl, { responseType: 'arraybuffer' });
+
+            // Step 3: Upload image binary to LinkedIn
+            await axios.put(uploadUrl, imageResponse.data, {
+                headers: {
+                    'Authorization': `Bearer ${context.auth.accessToken}`,
+                    'Content-Type': 'application/octet-stream'
+                }
+            });
+        }
+
         const response = await context.httpRequest({
             method: 'POST',
             url: `${BASE_URL}${VERSION_PATH}/posts`,
@@ -56,7 +116,7 @@ module.exports = {
                 'LinkedIn-Version': VERSION_HEADER,
                 'Content-Type': 'application/json'
             },
-            data: buildPost(context)
+            data: buildPost(context, author, assetUrn)
         });
         return context.sendJson({ status: response.status, postId: response.headers['x-restli-id'] }, 'out');
     }

--- a/src/appmixer/linkedin/shares/CreatePost/component.json
+++ b/src/appmixer/linkedin/shares/CreatePost/component.json
@@ -120,7 +120,7 @@
                         "tooltip": "Upload an image from Appmixer storage to attach to the post. If 'Image URL' is also provided, the URL takes priority. Cannot be used together with 'Share specific link'.",
                         "label": "Image File",
                         "index": 8,
-                        "when": { "eq": { "specificLink": false } }
+                        "when": { "and": [{ "eq": { "specificLink": false } }, { "empty": "imageUrl" }] }
                     },
                     "authorType": {
                         "type": "select",

--- a/src/appmixer/linkedin/shares/CreatePost/component.json
+++ b/src/appmixer/linkedin/shares/CreatePost/component.json
@@ -9,7 +9,7 @@
     },
     "auth": {
         "service": "appmixer:linkedin",
-        "scope": [ "w_member_social" ]
+        "scope": [ "w_member_social", "w_organization_social" ]
     },
     "quota": {
         "manager": "appmixer:linkedin:shares",
@@ -40,6 +40,15 @@
                         "type": "string"
                     },
                     "description": {
+                        "type": "string"
+                    },
+                    "imageUrl": {
+                        "type": "string"
+                    },
+                    "authorType": {
+                        "type": "string"
+                    },
+                    "organizationId": {
                         "type": "string"
                     }
                 },
@@ -94,6 +103,31 @@
                         "label": "Description",
                         "index": 6,
                         "when": { "eq": { "specificLink": true } }
+                    },
+                    "imageUrl": {
+                        "type": "text",
+                        "tooltip": "URL of an image to attach to the post. Cannot be used together with 'Share specific link'.",
+                        "label": "Image URL",
+                        "index": 7,
+                        "when": { "eq": { "specificLink": false } }
+                    },
+                    "authorType": {
+                        "type": "select",
+                        "label": "Post As",
+                        "options": [
+                            { "label": "Personal Profile", "value": "Personal" },
+                            { "label": "Organization", "value": "Organization" }
+                        ],
+                        "defaultValue": "Personal",
+                        "index": 8,
+                        "tooltip": "Choose whether to post as your personal profile or as an organization page you manage."
+                    },
+                    "organizationId": {
+                        "type": "text",
+                        "tooltip": "The numeric ID of the LinkedIn organization (company page) to post as.",
+                        "label": "Organization ID",
+                        "index": 9,
+                        "when": { "eq": { "authorType": "Organization" } }
                     }
                 }
             }

--- a/src/appmixer/linkedin/shares/CreatePost/component.json
+++ b/src/appmixer/linkedin/shares/CreatePost/component.json
@@ -46,7 +46,8 @@
                         "type": "string"
                     },
                     "imageFile": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "data-url"
                     },
                     "authorType": {
                         "type": "string"
@@ -125,10 +126,10 @@
                         "type": "select",
                         "label": "Post As",
                         "options": [
-                            { "label": "Personal Profile", "value": "Personal" },
-                            { "label": "Organization", "value": "Organization" }
+                            { "label": "Personal Profile", "value": "PERSONAL" },
+                            { "label": "Organization", "value": "ORGANIZATION" }
                         ],
-                        "defaultValue": "Personal",
+                        "defaultValue": "PERSONAL",
                         "index": 9,
                         "tooltip": "Choose whether to post as your personal profile or as an organization page you manage."
                     },
@@ -137,7 +138,7 @@
                         "tooltip": "The numeric ID of the LinkedIn organization (company page) to post as.",
                         "label": "Organization ID",
                         "index": 10,
-                        "when": { "eq": { "authorType": "Organization" } }
+                        "when": { "eq": { "authorType": "ORGANIZATION" } }
                     }
                 }
             }

--- a/src/appmixer/linkedin/shares/CreatePost/component.json
+++ b/src/appmixer/linkedin/shares/CreatePost/component.json
@@ -45,6 +45,9 @@
                     "imageUrl": {
                         "type": "string"
                     },
+                    "imageFile": {
+                        "type": "string"
+                    },
                     "authorType": {
                         "type": "string"
                     },
@@ -106,9 +109,16 @@
                     },
                     "imageUrl": {
                         "type": "text",
-                        "tooltip": "URL of an image to attach to the post. Cannot be used together with 'Share specific link'.",
+                        "tooltip": "URL of an image to attach to the post. Takes priority over 'Image File' if both are provided. Cannot be used together with 'Share specific link'.",
                         "label": "Image URL",
                         "index": 7,
+                        "when": { "eq": { "specificLink": false } }
+                    },
+                    "imageFile": {
+                        "type": "filepicker",
+                        "tooltip": "Upload an image from Appmixer storage to attach to the post. If 'Image URL' is also provided, the URL takes priority. Cannot be used together with 'Share specific link'.",
+                        "label": "Image File",
+                        "index": 8,
                         "when": { "eq": { "specificLink": false } }
                     },
                     "authorType": {
@@ -119,14 +129,14 @@
                             { "label": "Organization", "value": "Organization" }
                         ],
                         "defaultValue": "Personal",
-                        "index": 8,
+                        "index": 9,
                         "tooltip": "Choose whether to post as your personal profile or as an organization page you manage."
                     },
                     "organizationId": {
                         "type": "text",
                         "tooltip": "The numeric ID of the LinkedIn organization (company page) to post as.",
                         "label": "Organization ID",
-                        "index": 9,
+                        "index": 10,
                         "when": { "eq": { "authorType": "Organization" } }
                     }
                 }


### PR DESCRIPTION
## Summary

Implements the capabilities from issue #1087.

Closes #1087

> ⚠️ **Breaking Change** — A new OAuth scope (w_organization_social) has been added. Existing users will be required to re-authenticate.

## Changes

### 1. Post with an image
- New optional imageUrl field — fetches image from URL and uploads via LinkedIn media API
- New optional imageFile filepicker — uploads a file from Appmixer storage
- URL takes priority: if both are provided, the URL is used
- Both fields are hidden when 'Share specific link' is enabled

### 2. Post as organization/company page
- New authorType select: Personal (default) or Organization
- When Organization is selected, organizationId text input appears
- Post uses urn:li:organization:{organizationId} as the author

### 3. OAuth scope update (breaking)
- Added w_organization_social scope for organization posting
- Existing users must re-authenticate to grant the new permission

### Bundle
- Version bumped: 2.2.0 to 3.0.0 (major — breaking scope change)

## Files changed
- src/appmixer/linkedin/shares/CreatePost/CreatePost.js
- src/appmixer/linkedin/shares/CreatePost/component.json
- src/appmixer/linkedin/bundle.json

Related rule update: Appmixer-ai/apmmixer-connectors#1090