### PR TITLE
docs(instructions): adding OAuth scope is a breaking change requiring major version bump

### DIFF
--- a/.github/instructions/02-authentication.md
+++ b/.github/instructions/02-authentication.md
@@ -114,6 +114,20 @@ module.exports = {
 
 For services using OAuth 2.0 flow.
 
+> ⚠️ **Breaking Change Warning — OAuth Scopes**
+>
+> Adding new OAuth scopes to an existing connector is a **breaking change**. Existing users will need to re-authenticate to grant the new permissions. This must be reflected in the connector's `bundle.json`:
+> - Bump the **major** version (e.g. `2.2.0` → `3.0.0`)
+> - Document the scope change clearly in the changelog entry
+> - Include a note in the PR description warning reviewers that existing users will be asked to re-authenticate
+>
+> Example `bundle.json` changelog entry:
+> ```json
+> "3.0.0": [
+>     "BREAKING: Added w_organization_social OAuth scope to support posting as an organization page. Existing users must re-authenticate."
+> ]
+> ```
+
 #### Simplified URL-Based Format
 
 For services with standard OAuth 2.0 endpoints, you can use a simplified URL-based format where URLs are provided as strings instead of functions:

--- a/.github/instructions/08-best-practices.md
+++ b/.github/instructions/08-best-practices.md
@@ -39,6 +39,11 @@ Intended for AI assistance like Copilot, CodeRabbit, Claude, etc.
 
 ### Critical Restrictions for AI Code Generation
 
+- **OAuth Scope Changes are Breaking Changes**: NEVER add new OAuth scopes to an existing connector's `component.json` `auth.scope` array without treating it as a **major** version bump. Adding a scope forces all existing users to re-authenticate. Always:
+  - Bump the connector `bundle.json` to the next major version (e.g. `2.x.x` → `3.0.0`)
+  - Add a `BREAKING:` prefix to the changelog entry describing the scope addition
+  - Note in the PR description that existing users must re-authenticate
+
 - **Pagination Fields**: NEVER generate `limit` or `offset` fields in Find or List component inputs. Appmixer does not support these pagination controls. Instead, use the maximum available page size from the external API and mention the limit in the component description.
 
 - **Property Name Consistency**: Property names in `component.json` (both schema and inspector) MUST exactly match the property names used in the behavior file's `context.messages.in.content`. Use underscore `_` or camelCase as separator, NOT pipe `|`. For example:


### PR DESCRIPTION
## Summary

Adds a coding rule to the instructions to prevent silent breaking changes when new OAuth scopes are added.

Relates to #1087 — discovered while implementing the LinkedIn connector update: adding `w_organization_social` to the OAuth scope array forces all existing users to re-authenticate, but this was not flagged as a breaking change.

## Changes

### `02-authentication.md`
Added a prominent warning block in the OAuth 2.0 section explaining:
- Adding scopes = breaking change = major version bump required
- Changelog entry must use `BREAKING:` prefix
- PR description must warn reviewers

### `08-best-practices.md`
Added a new "OAuth Scope Changes are Breaking Changes" rule under _Critical Restrictions for AI Code Generation_ with the same guidance, so AI tools (Copilot, Claude, etc.) surface this constraint during code generation.
