### PR TITLE
whatsapp(patch): update Send*Message component descriptions with 24h window and delivery warning

### DIFF
--- a/src/appmixer/whatsapp/bundle.json
+++ b/src/appmixer/whatsapp/bundle.json
@@ -1,7 +1,10 @@
 {
     "name": "appmixer.whatsapp",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
+        "1.0.1": [
+            "Updated Send*Message component descriptions with 24-hour messaging window constraint and delivery guarantee caveat."
+        ],
         "1.0.0": [
             "Initial WhatsApp Business Cloud API connector.",
             "Messages: SendTextMessage, SendTemplateMessage, SendImageMessage, SendVideoMessage, SendAudioMessage, SendDocumentMessage, SendLocationMessage.",

--- a/src/appmixer/whatsapp/messages/SendAudioMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendAudioMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendAudioMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Audio Message",
-    "description": "Send an audio message via WhatsApp. Provide either a media ID or a public HTTPS link.",
+    "description": "Send an audio message to a WhatsApp user. Provide either a media ID or a public HTTPS link. Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {

--- a/src/appmixer/whatsapp/messages/SendDocumentMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendDocumentMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendDocumentMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Document Message",
-    "description": "Send a document (PDF, DOCX, etc.) via WhatsApp. Provide either a media ID or a public HTTPS link.",
+    "description": "Send a document (PDF, DOCX, etc.) to a WhatsApp user. Provide either a media ID or a public HTTPS link. Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {

--- a/src/appmixer/whatsapp/messages/SendImageMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendImageMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendImageMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Image Message",
-    "description": "Send an image message via WhatsApp. Provide either a media ID (uploaded via UploadMedia) or a public HTTPS link.",
+    "description": "Send an image to a WhatsApp user. Provide either a media ID (uploaded via UploadMedia) or a public HTTPS link. Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {

--- a/src/appmixer/whatsapp/messages/SendLocationMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendLocationMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendLocationMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Location Message",
-    "description": "Send a location pin via WhatsApp.",
+    "description": "Send a location pin to a WhatsApp user. Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {

--- a/src/appmixer/whatsapp/messages/SendTemplateMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendTemplateMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendTemplateMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Template Message",
-    "description": "Send a pre-approved WhatsApp template message. Required for outbound messages outside the 24-hour customer service window.",
+    "description": "Send a pre-approved WhatsApp template message to a WhatsApp user. Use this for outbound messages outside the 24-hour customer service window. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {

--- a/src/appmixer/whatsapp/messages/SendTextMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendTextMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendTextMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Text Message",
-    "description": "Send a plain text message via WhatsApp Business Cloud API.",
+    "description": "Send a text message to a WhatsApp user. Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {

--- a/src/appmixer/whatsapp/messages/SendVideoMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendVideoMessage/component.json
@@ -2,7 +2,7 @@
     "name": "appmixer.whatsapp.messages.SendVideoMessage",
     "author": "Appmixer <info@appmixer.com>",
     "label": "Send Video Message",
-    "description": "Send a video message via WhatsApp. Provide either a media ID or a public HTTPS link.",
+    "description": "Send a video to a WhatsApp user. Provide either a media ID or a public HTTPS link. Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the \"Message Status Updated\" trigger to track delivery status.",
     "version": "1.0.0",
     "private": false,
     "auth": {


### PR DESCRIPTION
## Summary

Updates the `description` field on all 7 WhatsApp Send*Message components to include the 24-hour messaging window constraint and a delivery guarantee caveat.

## Components updated

- `SendAudioMessage`
- `SendDocumentMessage`
- `SendImageMessage`
- `SendLocationMessage`
- `SendTemplateMessage`
- `SendTextMessage`
- `SendVideoMessage`

## Description added

> Can only be sent within 24 hours of the recipient's last message to you. Important: A successful response does NOT guarantee delivery. Use the "Message Status Updated" trigger to track delivery status.

Note: `SendTemplateMessage` gets a slightly different description since templates are specifically designed for use **outside** the 24-hour window.