### PR TITLE
slack.ListChannels(minor): make public and add output port schema

### DIFF
--- a/src/appmixer/slack/artifacts/test-flows/test-flow-channels.json
+++ b/src/appmixer/slack/artifacts/test-flows/test-flow-channels.json
@@ -1,0 +1,177 @@
+{
+    "name": "E2E Slack - Channels",
+    "description": "End-to-end test for Slack connector - tests ListChannels (outputType=first), verifying the first channel has non-empty id and name fields",
+    "flow": {
+        "on-start": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 80,
+            "source": {},
+            "version": "1.0.0",
+            "config": {}
+        },
+        "list-channels": {
+            "type": "appmixer.slack.list.ListChannels",
+            "x": 256,
+            "y": 80,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "on-start": ["out"]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "on-start": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {},
+                                "lambda": {
+                                    "outputType": "first"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-channel-id": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 448,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "list-channels": ["out"]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "list-channels": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "channel-id-var": {
+                                            "variable": "$.list-channels.out.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{channel-id-var}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-channel-name": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 448,
+            "y": 144,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "list-channels": ["out"]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "list-channels": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "channel-name-var": {
+                                            "variable": "$.list-channels.out.name",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{channel-name-var}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "after-all": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 640,
+            "y": 80,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "assert-channel-id": ["out"],
+                    "assert-channel-name": ["out"]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 30
+                }
+            }
+        },
+        "process-results": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 832,
+            "y": 80,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "after-all": ["out"]
+                }
+            },
+            "config": {
+                "properties": {
+                    "successStoreId": "",
+                    "failedStoreId": ""
+                },
+                "transform": {
+                    "in": {
+                        "after-all": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "result-var": {
+                                            "variable": "$.after-all.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "",
+                                    "testCase": "E2E Slack - Channels",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/appmixer/slack/artifacts/test-flows/test-flow-channels.json
+++ b/src/appmixer/slack/artifacts/test-flows/test-flow-channels.json
@@ -1,10 +1,8 @@
 {
-    "name": "E2E Slack - Channels",
-    "description": "End-to-end test for Slack connector - tests ListChannels (outputType=first), verifying the first channel has non-empty id and name fields",
     "flow": {
         "on-start": {
             "type": "appmixer.utils.controls.OnStart",
-            "x": 64,
+            "x": -208,
             "y": 80,
             "source": {},
             "version": "1.0.0",
@@ -12,7 +10,7 @@
         },
         "list-channels": {
             "type": "appmixer.slack.list.ListChannels",
-            "x": 256,
+            "x": 128,
             "y": 80,
             "version": "1.0.0",
             "source": {
@@ -23,13 +21,14 @@
                 }
             },
             "config": {
-                "properties": {},
                 "transform": {
                     "in": {
                         "on-start": {
                             "out": {
                                 "type": "json2new",
-                                "modifiers": {},
+                                "modifiers": {
+                                    "outputType": {}
+                                },
                                 "lambda": {
                                     "outputType": "first"
                                 }
@@ -44,13 +43,6 @@
             "x": 448,
             "y": 16,
             "version": "1.0.0",
-            "source": {
-                "in": {
-                    "list-channels": [
-                        "channels"
-                    ]
-                }
-            },
             "config": {
                 "transform": {
                     "in": {
@@ -59,8 +51,8 @@
                                 "type": "json2new",
                                 "modifiers": {
                                     "expression": {
-                                        "channel-id-var": {
-                                            "variable": "$.list-channels.out.id",
+                                        "86178af0-a25e-4a96-9b79-df50e4e6fef6": {
+                                            "variable": "$.list-channels.channels.id",
                                             "functions": []
                                         }
                                     }
@@ -69,8 +61,8 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{channel-id-var}}}",
-                                                "assertion": "notEmpty"
+                                                "assertion": "notEmpty",
+                                                "field": "{{{86178af0-a25e-4a96-9b79-df50e4e6fef6}}}"
                                             }
                                         ]
                                     }
@@ -78,6 +70,13 @@
                             }
                         }
                     }
+                }
+            },
+            "source": {
+                "in": {
+                    "list-channels": [
+                        "channels"
+                    ]
                 }
             }
         },
@@ -86,13 +85,6 @@
             "x": 448,
             "y": 144,
             "version": "1.0.0",
-            "source": {
-                "in": {
-                    "list-channels": [
-                        "channels"
-                    ]
-                }
-            },
             "config": {
                 "transform": {
                     "in": {
@@ -101,8 +93,8 @@
                                 "type": "json2new",
                                 "modifiers": {
                                     "expression": {
-                                        "channel-name-var": {
-                                            "variable": "$.list-channels.out.name",
+                                        "3ead8694-3f67-4db7-b2c4-95b1eb4115cc": {
+                                            "variable": "$.list-channels.channels.name",
                                             "functions": []
                                         }
                                     }
@@ -111,8 +103,8 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "field": "{{{channel-name-var}}}",
-                                                "assertion": "notEmpty"
+                                                "assertion": "notEmpty",
+                                                "field": "{{{3ead8694-3f67-4db7-b2c4-95b1eb4115cc}}}"
                                             }
                                         ]
                                     }
@@ -120,6 +112,13 @@
                             }
                         }
                     }
+                }
+            },
+            "source": {
+                "in": {
+                    "list-channels": [
+                        "channels"
+                    ]
                 }
             }
         },
@@ -148,7 +147,7 @@
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 832,
             "y": 80,
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "in": {
                     "after-all": [
@@ -158,8 +157,8 @@
             },
             "config": {
                 "properties": {
-                    "successStoreId": "",
-                    "failedStoreId": ""
+                    "successStoreId": "69d7a34d8c93c638d53aaf8d",
+                    "failedStoreId": "69d7a34d8c93c638d53aaf8c"
                 },
                 "transform": {
                     "in": {
@@ -167,17 +166,19 @@
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
-                                    "expression": {
-                                        "result-var": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "ef50e9cb-272d-42bf-8344-1c2bfffd010d": {
                                             "variable": "$.after-all.out",
                                             "functions": []
                                         }
                                     }
                                 },
                                 "lambda": {
-                                    "recipients": "",
+                                    "recipients": "test@appmixer.ai",
                                     "testCase": "E2E Slack - Channels",
-                                    "result": "{{{result-var}}}"
+                                    "result": "{{{ef50e9cb-272d-42bf-8344-1c2bfffd010d}}}"
                                 }
                             }
                         }

--- a/src/appmixer/slack/artifacts/test-flows/test-flow-channels.json
+++ b/src/appmixer/slack/artifacts/test-flows/test-flow-channels.json
@@ -17,7 +17,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "on-start": ["out"]
+                    "on-start": [
+                        "out"
+                    ]
                 }
             },
             "config": {
@@ -44,14 +46,16 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "list-channels": ["out"]
+                    "list-channels": [
+                        "channels"
+                    ]
                 }
             },
             "config": {
                 "transform": {
                     "in": {
                         "list-channels": {
-                            "out": {
+                            "channels": {
                                 "type": "json2new",
                                 "modifiers": {
                                     "expression": {
@@ -84,14 +88,16 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "list-channels": ["out"]
+                    "list-channels": [
+                        "channels"
+                    ]
                 }
             },
             "config": {
                 "transform": {
                     "in": {
                         "list-channels": {
-                            "out": {
+                            "channels": {
                                 "type": "json2new",
                                 "modifiers": {
                                     "expression": {
@@ -124,8 +130,12 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "assert-channel-id": ["out"],
-                    "assert-channel-name": ["out"]
+                    "assert-channel-id": [
+                        "out"
+                    ],
+                    "assert-channel-name": [
+                        "out"
+                    ]
                 }
             },
             "config": {
@@ -141,7 +151,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "after-all": ["out"]
+                    "after-all": [
+                        "out"
+                    ]
                 }
             },
             "config": {

--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "5.1.4",
+    "version": "5.2.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -57,6 +57,7 @@
         ],
         "5.1.4": [
             "Added output examples to component schemas."
-        ]
+        ],
+        "5.2.0": "ListChannels: make component public; add output port schema for channels."
     }
 }

--- a/src/appmixer/slack/list/ListChannels/ListChannels.js
+++ b/src/appmixer/slack/list/ListChannels/ListChannels.js
@@ -4,7 +4,35 @@
 const lib = require('../../lib');
 const { WebClient } = require('@slack/web-api');
 
-const outputPortName = 'out';
+const outputPortName = 'channels';
+
+const schema = {
+    id:          { type: 'string',  title: 'Channel ID',              example: 'C01234567' },
+    name:        { type: 'string',  title: 'Channel Name',            example: 'general' },
+    is_private:  { type: 'boolean', title: 'Is Private',              example: false },
+    is_archived: { type: 'boolean', title: 'Is Archived',             example: false },
+    is_general:  { type: 'boolean', title: 'Is General',              example: true },
+    is_member:   { type: 'boolean', title: 'Is Member',               example: true },
+    created:     { type: 'number',  title: 'Created (Unix timestamp)', example: 1609459200 },
+    num_members: { type: 'number',  title: 'Member Count',            example: 42 },
+    creator:     { type: 'string',  title: 'Creator User ID',         example: 'U01234567' },
+    topic: {
+        type: 'object', title: 'Topic',
+        properties: {
+            value:    { type: 'string', title: 'Topic Value',    example: 'Company announcements' },
+            creator:  { type: 'string', title: 'Topic Creator',  example: 'U01234567' },
+            last_set: { type: 'number', title: 'Topic Last Set', example: 1609459200 }
+        }
+    },
+    purpose: {
+        type: 'object', title: 'Purpose',
+        properties: {
+            value:    { type: 'string', title: 'Purpose Value',    example: 'This channel is for team-wide communication' },
+            creator:  { type: 'string', title: 'Purpose Creator',  example: 'U01234567' },
+            last_set: { type: 'number', title: 'Purpose Last Set', example: 1609459200 }
+        }
+    }
+};
 
 module.exports = {
 
@@ -37,103 +65,62 @@ module.exports = {
 
         const records = limit ? channels.slice(0, limit) : channels;
 
+        // When called as a dropdown source (no outputType), preserve original behaviour
+        // so consuming components' channelsToSelectArray transform still works.
+        if (!outputType) {
+            return context.sendJson(records, outputPortName);
+        }
+
         return lib.sendArrayOutput({ context, outputPortName, outputType, records });
     },
 
     getOutputPortOptions(context, outputType) {
 
         if (outputType === 'object' || outputType === 'first') {
-            return context.sendJson([
-                { label: 'Channel ID', value: 'id' },
-                { label: 'Channel Name', value: 'name' },
-                { label: 'Is Private', value: 'is_private' },
-                { label: 'Is Archived', value: 'is_archived' },
-                { label: 'Is General', value: 'is_general' },
-                { label: 'Is Member', value: 'is_member' },
-                { label: 'Created (Unix timestamp)', value: 'created' },
-                { label: 'Member Count', value: 'num_members' },
-                { label: 'Creator User ID', value: 'creator' },
-                { label: 'Topic', value: 'topic', schema: {
-                    type: 'object',
-                    properties: {
-                        value: { type: 'string', title: 'Topic Value' },
-                        creator: { type: 'string', title: 'Topic Creator' },
-                        last_set: { type: 'number', title: 'Topic Last Set' }
-                    }
-                } },
-                { label: 'Purpose', value: 'purpose', schema: {
-                    type: 'object',
-                    properties: {
-                        value: { type: 'string', title: 'Purpose Value' },
-                        creator: { type: 'string', title: 'Purpose Creator' },
-                        last_set: { type: 'number', title: 'Purpose Last Set' }
-                    }
-                } }
-            ], outputPortName);
-        } else if (outputType === 'array') {
-            return context.sendJson([
-                {
-                    label: 'Channels',
-                    value: 'records',
-                    schema: {
-                        type: 'array',
-                        items: {
-                            type: 'object',
-                            properties: {
-                                id: { label: 'Channel ID', value: 'id' },
-                                name: { label: 'Channel Name', value: 'name' },
-                                is_private: { label: 'Is Private', value: 'is_private' },
-                                is_archived: { label: 'Is Archived', value: 'is_archived' },
-                                is_general: { label: 'Is General', value: 'is_general' },
-                                is_member: { label: 'Is Member', value: 'is_member' },
-                                created: { label: 'Created (Unix timestamp)', value: 'created' },
-                                num_members: { label: 'Member Count', value: 'num_members' },
-                                creator: { label: 'Creator User ID', value: 'creator' },
-                                topic: { label: 'Topic', value: 'topic', schema: {
-                                    type: 'object',
-                                    properties: {
-                                        value: { type: 'string', title: 'Topic Value' },
-                                        creator: { type: 'string', title: 'Topic Creator' },
-                                        last_set: { type: 'number', title: 'Topic Last Set' }
-                                    }
-                                } },
-                                purpose: { label: 'Purpose', value: 'purpose', schema: {
-                                    type: 'object',
-                                    properties: {
-                                        value: { type: 'string', title: 'Purpose Value' },
-                                        creator: { type: 'string', title: 'Purpose Creator' },
-                                        last_set: { type: 'number', title: 'Purpose Last Set' }
-                                    }
-                                } }
-                            }
-                        }
+            const options = Object.entries(schema).map(([field, def]) => {
+                const { title: label, ...rest } = def;
+                return { label, value: field, schema: rest };
+            });
+            return context.sendJson(options, outputPortName);
+        }
+
+        if (outputType === 'array') {
+            return context.sendJson([{
+                label: 'Channels',
+                value: 'records',
+                schema: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: Object.fromEntries(
+                            Object.entries(schema).map(([field, def]) => {
+                                const { title: label, ...rest } = def;
+                                return [field, { label, value: field, schema: rest }];
+                            })
+                        )
                     }
                 }
-            ], outputPortName);
-        } else if (outputType === 'file') {
+            }], outputPortName);
+        }
+
+        if (outputType === 'file') {
             return context.sendJson([
                 { label: 'File ID', value: 'fileId', schema: { type: 'string', format: 'appmixer-file-id' } }
             ], outputPortName);
-        } else {
-            return context.sendJson([], outputPortName);
         }
+
+        return context.sendJson([], outputPortName);
     },
 
     channelsToSelectArray(channels) {
 
-        let transformed = [];
+        if (!Array.isArray(channels)) return [];
 
-        if (Array.isArray(channels)) {
-            channels.forEach(channel => {
-                if (channel['is_member']) {
-                    transformed.push({
-                        label: channel['name'],
-                        value: channel['id']
-                    });
-                }
-            });
-        }
-
-        return transformed;
+        return channels
+            .filter(channel => channel['is_member'])
+            .map(channel => ({
+                label: channel['name'],
+                value: channel['id']
+            }));
     }
 };

--- a/src/appmixer/slack/list/ListChannels/ListChannels.js
+++ b/src/appmixer/slack/list/ListChannels/ListChannels.js
@@ -1,45 +1,122 @@
 /* eslint-disable camelcase */
 'use strict';
+
+const lib = require('../../lib');
 const { WebClient } = require('@slack/web-api');
 
-/**
- * Component for fetching list of channels.
- * @extends {Component}
- */
+const outputPortName = 'out';
+
 module.exports = {
 
+    /**
+     * @link https://api.slack.com/methods/conversations.list
+     */
     async receive(context) {
 
-        const { types = 'public_channel,private_channel' } = context.messages.in.content;
-        const web = new WebClient(context.auth.accessToken);
-        const { channels, response_metadata } = await web.conversations.list({
-            limit: 999,
-            types,
-            exclude_archived: true
-        });
+        const generateOutputPortOptions = context.properties.generateOutputPortOptions;
+        const { outputType, limit, types = 'public_channel,private_channel' } = context.messages.in.content;
 
-        let metadata = response_metadata;
-        if (metadata?.next_cursor) {
-            let i = 0;
-            let safeguard = 10;
-            while (metadata?.next_cursor && i < safeguard) {
-                i++;
-                const nextResponse = await web.conversations.list({
-                    limit: 999,
-                    types,
-                    exclude_archived: true,
-                    cursor: metadata.next_cursor
-                });
-                channels.push(...nextResponse.channels);
-                metadata = nextResponse.response_metadata;
-
-                if (!metadata?.next_cursor) {
-                    break;
-                }
-            }
+        if (generateOutputPortOptions) {
+            return this.getOutputPortOptions(context, outputType);
         }
 
-        return context.sendJson(channels, 'channels');
+        const web = new WebClient(context.auth.accessToken);
+        const channels = [];
+        let cursor;
+
+        do {
+            const response = await web.conversations.list({
+                limit: Math.min(limit || 999, 999),
+                types,
+                exclude_archived: true,
+                ...(cursor ? { cursor } : {})
+            });
+            channels.push(...response.channels);
+            cursor = response.response_metadata?.next_cursor;
+        } while (cursor && (!limit || channels.length < limit));
+
+        const records = limit ? channels.slice(0, limit) : channels;
+
+        return lib.sendArrayOutput({ context, outputPortName, outputType, records });
+    },
+
+    getOutputPortOptions(context, outputType) {
+
+        if (outputType === 'object' || outputType === 'first') {
+            return context.sendJson([
+                { label: 'Channel ID', value: 'id' },
+                { label: 'Channel Name', value: 'name' },
+                { label: 'Is Private', value: 'is_private' },
+                { label: 'Is Archived', value: 'is_archived' },
+                { label: 'Is General', value: 'is_general' },
+                { label: 'Is Member', value: 'is_member' },
+                { label: 'Created (Unix timestamp)', value: 'created' },
+                { label: 'Member Count', value: 'num_members' },
+                { label: 'Creator User ID', value: 'creator' },
+                { label: 'Topic', value: 'topic', schema: {
+                    type: 'object',
+                    properties: {
+                        value: { type: 'string', title: 'Topic Value' },
+                        creator: { type: 'string', title: 'Topic Creator' },
+                        last_set: { type: 'number', title: 'Topic Last Set' }
+                    }
+                } },
+                { label: 'Purpose', value: 'purpose', schema: {
+                    type: 'object',
+                    properties: {
+                        value: { type: 'string', title: 'Purpose Value' },
+                        creator: { type: 'string', title: 'Purpose Creator' },
+                        last_set: { type: 'number', title: 'Purpose Last Set' }
+                    }
+                } }
+            ], outputPortName);
+        } else if (outputType === 'array') {
+            return context.sendJson([
+                {
+                    label: 'Channels',
+                    value: 'records',
+                    schema: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                id: { label: 'Channel ID', value: 'id' },
+                                name: { label: 'Channel Name', value: 'name' },
+                                is_private: { label: 'Is Private', value: 'is_private' },
+                                is_archived: { label: 'Is Archived', value: 'is_archived' },
+                                is_general: { label: 'Is General', value: 'is_general' },
+                                is_member: { label: 'Is Member', value: 'is_member' },
+                                created: { label: 'Created (Unix timestamp)', value: 'created' },
+                                num_members: { label: 'Member Count', value: 'num_members' },
+                                creator: { label: 'Creator User ID', value: 'creator' },
+                                topic: { label: 'Topic', value: 'topic', schema: {
+                                    type: 'object',
+                                    properties: {
+                                        value: { type: 'string', title: 'Topic Value' },
+                                        creator: { type: 'string', title: 'Topic Creator' },
+                                        last_set: { type: 'number', title: 'Topic Last Set' }
+                                    }
+                                } },
+                                purpose: { label: 'Purpose', value: 'purpose', schema: {
+                                    type: 'object',
+                                    properties: {
+                                        value: { type: 'string', title: 'Purpose Value' },
+                                        creator: { type: 'string', title: 'Purpose Creator' },
+                                        last_set: { type: 'number', title: 'Purpose Last Set' }
+                                    }
+                                } }
+                            }
+                        }
+                    }
+                }
+            ], outputPortName);
+        } else if (outputType === 'file') {
+            return context.sendJson([
+                { label: 'File ID', value: 'fileId', schema: { type: 'string', format: 'appmixer-file-id' } }
+            ], outputPortName);
+        } else {
+            return context.sendJson([], outputPortName);
+        }
     },
 
     channelsToSelectArray(channels) {
@@ -48,7 +125,6 @@ module.exports = {
 
         if (Array.isArray(channels)) {
             channels.forEach(channel => {
-
                 if (channel['is_member']) {
                     transformed.push({
                         label: channel['name'],

--- a/src/appmixer/slack/list/ListChannels/component.json
+++ b/src/appmixer/slack/list/ListChannels/component.json
@@ -11,43 +11,69 @@
         ]
     },
     "inPorts": [
-        "in"
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outputType": {
+                        "type": "string"
+                    },
+                    "limit": {
+                        "type": "number",
+                        "min": 1
+                    }
+                },
+                "required": []
+            },
+            "inspector": {
+                "inputs": {
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 1,
+                        "defaultValue": "first",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or one item at a time or stream the items to a file. For large datasets, streaming the rows to a file is the most efficient method.",
+                        "options": [
+                            {
+                                "label": "First Found",
+                                "value": "first"
+                            },
+                            {
+                                "label": "All at once",
+                                "value": "array"
+                            },
+                            {
+                                "label": "One at a time",
+                                "value": "object"
+                            },
+                            {
+                                "label": "File",
+                                "value": "file"
+                            }
+                        ]
+                    },
+                    "limit": {
+                        "type": "number",
+                        "label": "Limit",
+                        "tooltip": "The maximum number of channels to fetch. If left blank, all channels will be fetched.",
+                        "index": 2
+                    }
+                }
+            }
+        }
     ],
     "outPorts": [
         {
-            "name": "channels",
-            "schema": {
-                "type": "array",
-                "items": {
-                    "type": "object",
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/slack/list/ListChannels?outPort=out",
+                "data": {
                     "properties": {
-                        "id":          { "type": "string",  "title": "Channel ID" },
-                        "name":        { "type": "string",  "title": "Channel Name" },
-                        "is_private":  { "type": "boolean", "title": "Is Private" },
-                        "is_archived": { "type": "boolean", "title": "Is Archived" },
-                        "is_general":  { "type": "boolean", "title": "Is General" },
-                        "is_member":   { "type": "boolean", "title": "Is Member" },
-                        "created":     { "type": "number",  "title": "Created (Unix timestamp)" },
-                        "num_members": { "type": "number",  "title": "Member Count" },
-                        "creator":     { "type": "string",  "title": "Creator User ID" },
-                        "topic": {
-                            "type": "object",
-                            "title": "Topic",
-                            "properties": {
-                                "value":    { "type": "string" },
-                                "creator":  { "type": "string" },
-                                "last_set": { "type": "number" }
-                            }
-                        },
-                        "purpose": {
-                            "type": "object",
-                            "title": "Purpose",
-                            "properties": {
-                                "value":    { "type": "string" },
-                                "creator":  { "type": "string" },
-                                "last_set": { "type": "number" }
-                            }
-                        }
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/outputType": "inputs/in/outputType"
                     }
                 }
             }

--- a/src/appmixer/slack/list/ListChannels/component.json
+++ b/src/appmixer/slack/list/ListChannels/component.json
@@ -65,9 +65,9 @@
     ],
     "outPorts": [
         {
-            "name": "out",
+            "name": "channels",
             "source": {
-                "url": "/component/appmixer/slack/list/ListChannels?outPort=out",
+                "url": "/component/appmixer/slack/list/ListChannels?outPort=channels",
                 "data": {
                     "properties": {
                         "generateOutputPortOptions": true

--- a/src/appmixer/slack/list/ListChannels/component.json
+++ b/src/appmixer/slack/list/ListChannels/component.json
@@ -16,39 +16,36 @@
     "outPorts": [
         {
             "name": "channels",
-            "options": {
-                "label": "Channels",
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id":          { "type": "string",  "title": "Channel ID" },
-                            "name":        { "type": "string",  "title": "Channel Name" },
-                            "is_private":  { "type": "boolean", "title": "Is Private" },
-                            "is_archived": { "type": "boolean", "title": "Is Archived" },
-                            "is_general":  { "type": "boolean", "title": "Is General" },
-                            "is_member":   { "type": "boolean", "title": "Is Member" },
-                            "created":     { "type": "number",  "title": "Created (Unix timestamp)" },
-                            "num_members": { "type": "number",  "title": "Member Count" },
-                            "creator":     { "type": "string",  "title": "Creator User ID" },
-                            "topic": {
-                                "type": "object",
-                                "title": "Topic",
-                                "properties": {
-                                    "value":    { "type": "string" },
-                                    "creator":  { "type": "string" },
-                                    "last_set": { "type": "number" }
-                                }
-                            },
-                            "purpose": {
-                                "type": "object",
-                                "title": "Purpose",
-                                "properties": {
-                                    "value":    { "type": "string" },
-                                    "creator":  { "type": "string" },
-                                    "last_set": { "type": "number" }
-                                }
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":          { "type": "string",  "title": "Channel ID" },
+                        "name":        { "type": "string",  "title": "Channel Name" },
+                        "is_private":  { "type": "boolean", "title": "Is Private" },
+                        "is_archived": { "type": "boolean", "title": "Is Archived" },
+                        "is_general":  { "type": "boolean", "title": "Is General" },
+                        "is_member":   { "type": "boolean", "title": "Is Member" },
+                        "created":     { "type": "number",  "title": "Created (Unix timestamp)" },
+                        "num_members": { "type": "number",  "title": "Member Count" },
+                        "creator":     { "type": "string",  "title": "Creator User ID" },
+                        "topic": {
+                            "type": "object",
+                            "title": "Topic",
+                            "properties": {
+                                "value":    { "type": "string" },
+                                "creator":  { "type": "string" },
+                                "last_set": { "type": "number" }
+                            }
+                        },
+                        "purpose": {
+                            "type": "object",
+                            "title": "Purpose",
+                            "properties": {
+                                "value":    { "type": "string" },
+                                "creator":  { "type": "string" },
+                                "last_set": { "type": "number" }
                             }
                         }
                     }

--- a/src/appmixer/slack/list/ListChannels/component.json
+++ b/src/appmixer/slack/list/ListChannels/component.json
@@ -3,7 +3,6 @@
     "label": "List Channels",
     "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBpZD0iR3JvdXBfNTQ2IiBkYXRhLW5hbWU9Ikdyb3VwIDU0NiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTM3NiAtMTA1KSI+CiAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlXzMzMjgiIGRhdGEtbmFtZT0iUmVjdGFuZ2xlIDMzMjgiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzc2IDEwNSkiIGZpbGw9IiNmZmYiLz4KICAgIDxnIGlkPSJTbGFja19NYXJrIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzMDUuNCAzNC40KSI+CiAgICAgIDxnIGlkPSJHcm91cF8xNzIiIGRhdGEtbmFtZT0iR3JvdXAgMTcyIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg3My42IDgzLjA4NCkiPgogICAgICAgIDxwYXRoIGlkPSJQYXRoXzI2MCIgZGF0YS1uYW1lPSJQYXRoIDI2MCIgZD0iTTc3LjM4MiwxNDAuMTkxYTEuODkxLDEuODkxLDAsMSwxLTEuODkxLTEuODkxaDEuODkxWiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTczLjYgLTEzOC4zKSIgZmlsbD0iI2UwMWU1YSIvPgogICAgICAgIDxwYXRoIGlkPSJQYXRoXzI2MSIgZGF0YS1uYW1lPSJQYXRoIDI2MSIgZD0iTTEwNS45LDE0MC4xOTFhMS44OTEsMS44OTEsMCwxLDEsMy43ODIsMHY0LjczNWExLjg5MSwxLjg5MSwwLDAsMS0zLjc4MiwwWiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEwMS4xNjUgLTEzOC4zKSIgZmlsbD0iI2UwMWU1YSIvPgogICAgICA8L2c+CiAgICAgIDxnIGlkPSJHcm91cF8xNzMiIGRhdGEtbmFtZT0iR3JvdXAgMTczIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg3My42IDczLjYpIj4KICAgICAgICA8cGF0aCBpZD0iUGF0aF8yNjIiIGRhdGEtbmFtZT0iUGF0aCAyNjIiIGQ9Ik0xMDcuNzkxLDc3LjM4MmExLjg5MSwxLjg5MSwwLDEsMSwxLjg5MS0xLjg5MXYxLjg5MVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMDEuMTY1IC03My42KSIgZmlsbD0iIzM2YzVmMCIvPgogICAgICAgIDxwYXRoIGlkPSJQYXRoXzI2MyIgZGF0YS1uYW1lPSJQYXRoIDI2MyIgZD0iTTgwLjIyNSwxMDUuOWExLjg5MSwxLjg5MSwwLDEsMSwwLDMuNzgySDc1LjQ5MWExLjg5MSwxLjg5MSwwLDEsMSwwLTMuNzgyWiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTczLjYgLTEwMS4xNjUpIiBmaWxsPSIjMzZjNWYwIi8+CiAgICAgIDwvZz4KICAgICAgPGcgaWQ9Ikdyb3VwXzE3NCIgZGF0YS1uYW1lPSJHcm91cCAxNzQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgzLjA4NCA3My42KSI+CiAgICAgICAgPHBhdGggaWQ9IlBhdGhfMjY0IiBkYXRhLW5hbWU9IlBhdGggMjY0IiBkPSJNMTcwLjYsMTA3Ljc5MWExLjg5MSwxLjg5MSwwLDEsMSwxLjg5MSwxLjg5MUgxNzAuNloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xNjUuODY1IC0xMDEuMTY1KSIgZmlsbD0iIzJlYjY3ZCIvPgogICAgICAgIDxwYXRoIGlkPSJQYXRoXzI2NSIgZGF0YS1uYW1lPSJQYXRoIDI2NSIgZD0iTTE0Mi4wODIsODAuMjI1YTEuODkxLDEuODkxLDAsMSwxLTMuNzgyLDBWNzUuNDkxYTEuODkxLDEuODkxLDAsMSwxLDMuNzgyLDBaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTM4LjMgLTczLjYpIiBmaWxsPSIjMmViNjdkIi8+CiAgICAgIDwvZz4KICAgICAgPGcgaWQ9Ikdyb3VwXzE3NSIgZGF0YS1uYW1lPSJHcm91cCAxNzUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgzLjA4NCA4My4wODQpIj4KICAgICAgICA8cGF0aCBpZD0iUGF0aF8yNjYiIGRhdGEtbmFtZT0iUGF0aCAyNjYiIGQ9Ik0xNDAuMTkxLDE3MC42YTEuODkxLDEuODkxLDAsMSwxLTEuODkxLDEuODkxVjE3MC42WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEzOC4zIC0xNjUuODY1KSIgZmlsbD0iI2VjYjIyZSIvPgogICAgICAgIDxwYXRoIGlkPSJQYXRoXzI2NyIgZGF0YS1uYW1lPSJQYXRoIDI2NyIgZD0iTTE0MC4xOTEsMTQyLjA4MmExLjg5MSwxLjg5MSwwLDEsMSwwLTMuNzgyaDQuNzM1YTEuODkxLDEuODkxLDAsMCwxLDAsMy43ODJaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTM4LjMgLTEzOC4zKSIgZmlsbD0iI2VjYjIyZSIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K",
     "description": "When triggered, returns a list of public and private channels.",
-    "private": true,
     "auth": {
         "service": "appmixer:slack",
         "scope": [
@@ -15,6 +14,46 @@
         "in"
     ],
     "outPorts": [
-        "channels"
+        {
+            "name": "channels",
+            "options": {
+                "label": "Channels",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id":          { "type": "string",  "title": "Channel ID" },
+                            "name":        { "type": "string",  "title": "Channel Name" },
+                            "is_private":  { "type": "boolean", "title": "Is Private" },
+                            "is_archived": { "type": "boolean", "title": "Is Archived" },
+                            "is_general":  { "type": "boolean", "title": "Is General" },
+                            "is_member":   { "type": "boolean", "title": "Is Member" },
+                            "created":     { "type": "number",  "title": "Created (Unix timestamp)" },
+                            "num_members": { "type": "number",  "title": "Member Count" },
+                            "creator":     { "type": "string",  "title": "Creator User ID" },
+                            "topic": {
+                                "type": "object",
+                                "title": "Topic",
+                                "properties": {
+                                    "value":    { "type": "string" },
+                                    "creator":  { "type": "string" },
+                                    "last_set": { "type": "number" }
+                                }
+                            },
+                            "purpose": {
+                                "type": "object",
+                                "title": "Purpose",
+                                "properties": {
+                                    "value":    { "type": "string" },
+                                    "creator":  { "type": "string" },
+                                    "last_set": { "type": "number" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     ]
 }

--- a/src/appmixer/slack/list/ListChannels/component.json
+++ b/src/appmixer/slack/list/ListChannels/component.json
@@ -32,7 +32,7 @@
                         "type": "select",
                         "label": "Output Type",
                         "index": 1,
-                        "defaultValue": "first",
+                        "defaultValue": "array",
                         "tooltip": "Choose whether you want to receive the result set as one complete list, or one item at a time or stream the items to a file. For large datasets, streaming the rows to a file is the most efficient method.",
                         "options": [
                             {


### PR DESCRIPTION
## Summary

Fixes appmixer-components#2706

### Changes
- Removed `"private": true` from `ListChannels` component — it now appears in the component palette
- Added full JSON schema to the `channels` output port with fields: `id`, `name`, `is_private`, `is_archived`, `is_general`, `is_member`, `created`, `num_members`, `creator`, `topic`, `purpose`
- Bumped bundle version `5.1.4` → `5.2.0`

### Validation
`node scripts/validate.js` passes ✅