### PR TITLE
whatsapp(minor): improvements

### DIFF
--- a/src/appmixer/whatsapp/auth.js
+++ b/src/appmixer/whatsapp/auth.js
@@ -8,19 +8,48 @@ module.exports = {
 
     definition: {
 
+        // The scope is defined inside the Meta Login Configuration (admin sets it
+        // up in Meta App Dashboard → Facebook Login for Business → Configurations).
+        // Keeping `scope` here only as a hint for the engine / docs — the OAuth
+        // request itself uses `config_id` and the Login Config's declared scopes
+        // take precedence, regardless of what we send.
         scope: [
             'whatsapp_business_messaging',
             'whatsapp_business_management'
         ],
 
-        authUrl: context => {
+        authUrl: async context => {
+
+            // configId comes from Backoffice → `appmixer:whatsapp.configId` (the
+            // Login Configuration ID from Meta App Dashboard). When present, we
+            // use the Facebook Login for Business flow which shows the WABA /
+            // Business asset picker. Without it we fall back to plain OAuth.
+            const configId = context.config.configId;
+
+            await context.log({ 'step': 'login', d: { configId, client: context.clientId } });
 
             const params = {
-                'client_id': context.clientId,
                 'redirect_uri': context.callbackUrl,
-                'scope': context.scope.join(','),
+                'response_type': 'code',
                 'state': context.ticket
             };
+
+            if (configId) {
+                // Facebook Login for Business with Login Configuration — Meta
+                // expects `app_id` in this flow (alias of client_id, but the
+                // asset-picker UI specifically looks for app_id). Scopes and
+                // assets are declared in the Login Config itself, do NOT send
+                // the `scope` query parameter — it would silently broaden the
+                // request and confuse Meta's UI.
+                params['app_id'] = context.clientId;
+                params['config_id'] = configId;
+                params['override_default_response_type'] = 'true';
+            } else {
+                // Plain OAuth fallback — client_id + explicit scope.
+                params['client_id'] = context.clientId;
+                params['scope'] = context.scope.join(',');
+            }
+
             return `https://www.facebook.com/${GRAPH_VERSION}/dialog/oauth?` + new URLSearchParams(params).toString();
         },
 
@@ -64,32 +93,58 @@ module.exports = {
             //    Facebook Login for Business returns the WABA IDs the user
             //    granted access to under `granular_scopes[].target_ids` —
             //    accessible without business_management scope, unlike /me/businesses.
+            //
+            //    Behaviour:
+            //    - /debug_token succeeded AND granular_scopes present AND has WABA target_ids
+            //         → auto-discovery succeeded, store on profile
+            //    - /debug_token succeeded AND granular_scopes present AND NO WABA target_ids
+            //         → user authenticated without picking any WABA in the asset picker
+            //           (or their Meta account has no WABA). FAIL auth with a clear
+            //           message so we don't end up with a "connected" but useless account.
+            //    - /debug_token failed OR granular_scopes absent (e.g. plain OAuth fallback
+            //      with no config_id) → can't verify; return profile silently.
+
+            let debugSucceeded = false;
+            let granularScopesPresent = false;
+            const wabaIds = [];
+
             try {
                 const appAccessToken = `${context.clientId}|${context.clientSecret}`;
                 const debugUrl = `https://graph.facebook.com/${GRAPH_VERSION}/debug_token`
                     + `?input_token=${encodeURIComponent(context.accessToken)}`
                     + `&access_token=${encodeURIComponent(appAccessToken)}`;
                 const debug = await context.httpRequest.get(debugUrl);
+                debugSucceeded = true;
 
-                const granular = (debug.data && debug.data.data && debug.data.data.granular_scopes) || [];
-
-                const wabaIds = [];
-                for (const entry of granular) {
-                    if (entry && entry.scope === 'whatsapp_business_management' && Array.isArray(entry.target_ids)) {
-                        for (const id of entry.target_ids) {
-                            if (id && !wabaIds.includes(id)) wabaIds.push(id);
+                const granular = debug && debug.data && debug.data.data && debug.data.data.granular_scopes;
+                if (Array.isArray(granular) && granular.length > 0) {
+                    granularScopesPresent = true;
+                    for (const entry of granular) {
+                        if (entry && entry.scope === 'whatsapp_business_management' && Array.isArray(entry.target_ids)) {
+                            for (const id of entry.target_ids) {
+                                if (id && !wabaIds.includes(id)) wabaIds.push(id);
+                            }
                         }
                     }
                 }
-
-                if (wabaIds.length > 0) {
-                    profile.businessAccountId = wabaIds[0];   // default WABA
-                    profile.wabaIds = wabaIds;                // full list for diagnostics
-                }
-
             } catch (err) {
-                // Best-effort — auth still succeeds even when /debug_token is unavailable.
-                // The user can paste the WABA ID into the inspector field as a fallback.
+                // /debug_token failed (network, app token rejected, …). Continue best-effort.
+            }
+
+            if (debugSucceeded && granularScopesPresent && wabaIds.length === 0) {
+                throw new Error(
+                    'No WhatsApp Business Account selected during authentication. '
+                    + 'Please disconnect and reconnect — when the Meta asset picker appears, '
+                    + 'explicitly select at least one WhatsApp Business Account. '
+                    + 'If your Meta account does not have any WhatsApp Business Account, '
+                    + 'create one in Meta Business Manager (business.facebook.com → Settings → '
+                    + 'Business Settings → Accounts → WhatsApp Accounts → Add) before reconnecting.'
+                );
+            }
+
+            if (wabaIds.length > 0) {
+                profile.businessAccountId = wabaIds[0];   // default WABA
+                profile.wabaIds = wabaIds;                // full list for diagnostics
             }
 
             return profile;

--- a/src/appmixer/whatsapp/bundle.json
+++ b/src/appmixer/whatsapp/bundle.json
@@ -1,10 +1,7 @@
 {
     "name": "appmixer.whatsapp",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "changelog": {
-        "1.0.1": [
-            "Updated Send*Message component descriptions with 24-hour messaging window constraint and delivery guarantee caveat."
-        ],
         "1.0.0": [
             "Initial WhatsApp Business Cloud API connector.",
             "Messages: SendTextMessage, SendTemplateMessage, SendImageMessage, SendVideoMessage, SendAudioMessage, SendDocumentMessage, SendLocationMessage.",
@@ -12,6 +9,12 @@
             "Sender phone numbers: RegisterSenderPhoneNumber (Register Sender), DeregisterPhoneNumber, ListPhoneNumbers, GetPhoneNumber, GetRegistrationStatus, EnsurePhoneNumberRegistered — all operate on YOUR business sender numbers, never on recipients.",
             "Triggers (webhook): NewMessage, MessageStatusUpdated.",
             "Core: MakeApiCall (per #1459 standard)."
+        ],
+        "1.1.0": [
+            "Send*Message component descriptions clarify the 24-hour messaging window and silent-drop behaviour.",
+            "OAuth now uses Facebook Login for Business with a Meta Login Configuration ID (`appmixer:whatsapp.configId` in Backoffice). Customers see the WABA asset picker instead of a plain consent screen. Falls back to plain OAuth when configId is not set.",
+            "Auth fails explicitly when /debug_token returns granular_scopes but no WhatsApp Business Account is selected — prevents 'connected but useless' accounts.",
+            "New ListMessageTemplates component (messages/). Usable standalone and as the dynamic-source dropdown for SendTemplateMessage's Template Name field — customers now pick APPROVED templates from a typeahead."
         ]
     }
 }

--- a/src/appmixer/whatsapp/messages/SendTemplateMessage/component.json
+++ b/src/appmixer/whatsapp/messages/SendTemplateMessage/component.json
@@ -90,7 +90,23 @@
                         "type": "text",
                         "index": 4,
                         "label": "Template Name",
-                        "tooltip": "Name of an approved template in your WABA."
+                        "tooltip": "Pick a pre-approved template from the dropdown \u2014 only APPROVED templates appear. The dropdown loads templates from the WABA above (or your default WABA when blank). You can also type a name manually.",
+                        "source": {
+                            "url": "/component/appmixer/whatsapp/messages/ListMessageTemplates?outPort=out",
+                            "data": {
+                                "properties": {
+                                    "isSource": true
+                                },
+                                "messages": {
+                                    "in/businessAccountId": "inputs/in/businessAccountId",
+                                    "in/phoneNumberId": "any",
+                                    "in/to": "any",
+                                    "in/templateName": "any",
+                                    "in/languageCode": "any"
+                                },
+                                "transform": "./ListMessageTemplates#toSelectArray"
+                            }
+                        }
                     },
                     "languageCode": {
                         "type": "text",


### PR DESCRIPTION
Closes #1109

## Summary

WhatsApp connector improvements focused on OAuth UX and template handling. Bumps `appmixer.whatsapp` to **v1.1.0**.

### Facebook Login for Business — Login Configuration

OAuth now supports Meta's **Login Configuration ID** flow (the one Zapier, Make and other competitors use). When the admin sets `configId` in Backoffice → `appmixer:whatsapp`, end customers see Meta's **WABA asset picker** (explicitly select which WhatsApp Business Account to share) instead of the plain "Continue as X" consent screen.

- `authUrl` now branches:
  - With `configId` → sends `app_id`, `config_id`, `override_default_response_type=true` (no `scope` — declared inside the Login Config)
  - Without `configId` → plain `client_id` + `scope` fallback (legacy mode, backwards-compatible)
- New Backoffice field: `appmixer:whatsapp.configId` (optional; missing it = plain OAuth)

### Stricter WABA discovery — fail loud, not silent

`requestProfileInfo` already calls `/debug_token` to extract WABA IDs from `granular_scopes`. The new behaviour:

- ✅ `/debug_token` succeeded, `granular_scopes` present, ≥1 WABA target_id → store as `profile.businessAccountId`
- ❌ `/debug_token` succeeded, `granular_scopes` present, **0 WABA target_ids** → **THROW** explicit error ("No WhatsApp Business Account selected during authentication … reconnect and select a WABA"). Prevents "connected but useless" accounts.
- 🟡 `/debug_token` failed OR `granular_scopes` absent (legacy plain OAuth) → continue best-effort (can't verify)

### Template Name typeahead on SendTemplateMessage

`templateName` input is now a typeahead backed by a dynamic source. Customers pick from a dropdown of **APPROVED** templates (loaded from the connected WABA) instead of typing names by hand. Source URL: `/component/appmixer/whatsapp/messages/ListMessageTemplates?outPort=out` with `isSource` sentinel + cached calls + standard required-input wiring.

> ⚠️ **Prerequisite for merge:** the dropdown source references `appmixer.whatsapp.messages.ListMessageTemplates`, a new helper component that ships locally but **isn't pushed to this branch yet**. Push it (`messages/ListMessageTemplates/component.json` + `ListMessageTemplates.js`) before merging — otherwise the dropdown will 404 at runtime. Once pushed the PR is functionally complete.

### Changelog (1.1.0)

- Send*Message component descriptions clarify the 24-hour messaging window and silent-drop behaviour
- OAuth uses Facebook Login for Business with Login Configuration ID (`appmixer:whatsapp.configId`)
- Auth fails explicitly when no WABA is selected in the asset picker
- New `ListMessageTemplates` component (dynamic-source dropdown for Template Name)

## Test plan

- [ ] **Admin setup (one-time, qa instance):**
  - [ ] Create Login Configuration in Meta App → Facebook Login for Business → Configurations (Permissions: `whatsapp_business_messaging`, `whatsapp_business_management`; Assets: WhatsApp Business Accounts)
  - [ ] Paste Configuration ID into Backoffice → `appmixer:whatsapp.configId`
- [ ] **Happy path:** disconnect existing WhatsApp account → reconnect → asset picker appears → select WABA → account connects → `profileInfo.businessAccountId` auto-populated
- [ ] **No-WABA path:** in asset picker, click Continue without selecting → auth fails with explicit error (instead of "connected but broken")
- [ ] **Legacy fallback:** clear `configId` in Backoffice → OAuth still works as plain Facebook Login (no asset picker)
- [ ] **SendTemplateMessage dropdown:** open inspector → Template Name dropdown auto-loads APPROVED templates from connected WABA → pick `hello_world` → send to a verified recipient → message delivers
- [ ] Push `ListMessageTemplates` files to branch before merge

## Companion docs PR

Docs reflecting these changes are on branch `wa3` of [appmixer-docs-gitbook](https://github.com/Appmixer-ai/appmixer-docs-gitbook) (`app-registrations/whatsapp.md`):

- New section **1.3.1 Create a Login Configuration**
- Section 1.4 updated with `configId` field
- Section 2.1 includes "What happens if you don't select a WABA"
- Troubleshooting entries for the new error paths