### PR TITLE
google.calendar(patch): add missing example values to output port options

### DIFF
--- a/src/appmixer/google/calendar/CreateCalendar/component.json
+++ b/src/appmixer/google/calendar/CreateCalendar/component.json
@@ -74,11 +74,46 @@
         {
             "name": "calendar",
             "options": [
-                { "label": "Calendar ID", "value": "id", "schema": {"type": "string"} },
-                { "label": "Description", "value": "description", "schema": {"type": "string"} },
-                { "label": "ETag", "value": "etag", "schema": {"type": "string"} },
-                { "label": "Kind", "value": "kind", "schema": {"type": "string"} },
-                { "label": "Summary", "value": "summary", "schema": {"type": "string"} }
+                {
+                    "label": "Calendar ID",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "Description",
+                    "value": "description",
+                    "schema": {
+                        "type": "string",
+                        "example": "Weekly sync"
+                    }
+                },
+                {
+                    "label": "ETag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "Kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "Summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                }
             ]
         }
     ],

--- a/src/appmixer/google/calendar/CreateEvent/component.json
+++ b/src/appmixer/google/calendar/CreateEvent/component.json
@@ -124,33 +124,222 @@
         {
             "name": "event",
             "options": [
-                {"label": "Event ID", "value": "id", "schema": {"type": "string"}},
-                {"label": "Calendar ID", "value": "calendarId", "schema": {"type": "string"}},
-                {"label": "Kind", "value": "kind", "schema": {"type": "string"}},
-                {"label": "ETag", "value": "etag", "schema": {"type": "string"}},
-                {"label": "Status", "value": "status", "schema": {"type": "string"}},
-                {"label": "Summary", "value": "summary", "schema": {"type": "string"}},
-                {"label": "Description", "value": "description", "schema": {"type": "string"}},
-                {"label": "Location", "value": "location", "schema": {"type": "string"}},
-                {"label": "Start", "value": "start", "schema": {"type": "object"}},
-                {"label": "End", "value": "end", "schema": {"type": "object"}},
-                {"label": "HTML Link", "value": "htmlLink", "schema": {"type": "string"}},
-                {"label": "Created", "value": "created", "schema": {"type": "string"}},
-                {"label": "Updated", "value": "updated", "schema": {"type": "string"}},
-                {"label": "Creator", "value": "creator", "schema": {"type": "object"}},
-                {"label": "Creator.Email", "value": "creator.email", "schema": {"type": "string"}},
-                {"label": "Creator.DisplayName", "value": "creator.displayName", "schema": {"type": "string"}},
-                {"label": "Creator.Self", "value": "creator.self", "schema": {"type": "boolean"}},
-                {"label": "Organizer", "value": "organizer", "schema": {"type": "object"}},
-                {"label": "Organizer.Email", "value": "organizer.email", "schema": {"type": "string"}},
-                {"label": "Organizer.DisplayName", "value": "organizer.displayName", "schema": {"type": "string"}},
-                {"label": "Organizer.Self", "value": "organizer.self", "schema": {"type": "boolean"}},
-                {"label": "Transparency", "value": "transparency", "schema": {"type": "string"}},
-                {"label": "iCal UID", "value": "iCalUID", "schema": {"type": "string"}},
-                {"label": "Sequence", "value": "sequence", "schema": {"type": "integer"}},
-                {"label": "Reminders", "value": "reminders", "schema": {"type": "object"}},
-                {"label": "Reminders.UseDefault", "value": "reminders.useDefault", "schema": {"type": "boolean"}},
-                {"label": "Reminders.Overrides", "value": "reminders.overrides", "schema": {"type": "array"}}
+                {
+                    "label": "Event ID",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "Calendar ID",
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
+                },
+                {
+                    "label": "Kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "ETag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "Status",
+                    "value": "status",
+                    "schema": {
+                        "type": "string",
+                        "example": "confirmed"
+                    }
+                },
+                {
+                    "label": "Summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                },
+                {
+                    "label": "Description",
+                    "value": "description",
+                    "schema": {
+                        "type": "string",
+                        "example": "Weekly sync"
+                    }
+                },
+                {
+                    "label": "Location",
+                    "value": "location",
+                    "schema": {
+                        "type": "string",
+                        "example": "123 Main St, San Francisco, CA"
+                    }
+                },
+                {
+                    "label": "Start",
+                    "value": "start",
+                    "schema": {
+                        "type": "object",
+                        "example": "2024-01-15T10:00:00Z"
+                    }
+                },
+                {
+                    "label": "End",
+                    "value": "end",
+                    "schema": {
+                        "type": "object",
+                        "example": "2024-01-15T11:00:00Z"
+                    }
+                },
+                {
+                    "label": "HTML Link",
+                    "value": "htmlLink",
+                    "schema": {
+                        "type": "string",
+                        "example": "https://www.google.com/calendar/event?eid=abc123"
+                    }
+                },
+                {
+                    "label": "Created",
+                    "value": "created",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-01T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "Updated",
+                    "value": "updated",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-10T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "Creator",
+                    "value": "creator",
+                    "schema": {
+                        "type": "object",
+                        "example": "{\"email\":\"user@example.com\",\"displayName\":\"John Doe\",\"self\":true}"
+                    }
+                },
+                {
+                    "label": "Creator.Email",
+                    "value": "creator.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "user@example.com"
+                    }
+                },
+                {
+                    "label": "Creator.DisplayName",
+                    "value": "creator.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "John Doe"
+                    }
+                },
+                {
+                    "label": "Creator.Self",
+                    "value": "creator.self",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "Organizer",
+                    "value": "organizer",
+                    "schema": {
+                        "type": "object",
+                        "example": "{\"email\":\"organizer@example.com\",\"displayName\":\"Jane Smith\",\"self\":false}"
+                    }
+                },
+                {
+                    "label": "Organizer.Email",
+                    "value": "organizer.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "organizer@example.com"
+                    }
+                },
+                {
+                    "label": "Organizer.DisplayName",
+                    "value": "organizer.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "Jane Smith"
+                    }
+                },
+                {
+                    "label": "Organizer.Self",
+                    "value": "organizer.self",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "false"
+                    }
+                },
+                {
+                    "label": "Transparency",
+                    "value": "transparency",
+                    "schema": {
+                        "type": "string",
+                        "example": "opaque"
+                    }
+                },
+                {
+                    "label": "iCal UID",
+                    "value": "iCalUID",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123@google.com"
+                    }
+                },
+                {
+                    "label": "Sequence",
+                    "value": "sequence",
+                    "schema": {
+                        "type": "integer",
+                        "example": "0"
+                    }
+                },
+                {
+                    "label": "Reminders",
+                    "value": "reminders",
+                    "schema": {
+                        "type": "object",
+                        "example": "{\"useDefault\":true}"
+                    }
+                },
+                {
+                    "label": "Reminders.UseDefault",
+                    "value": "reminders.useDefault",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "Reminders.Overrides",
+                    "value": "reminders.overrides",
+                    "schema": {
+                        "type": "array",
+                        "example": "[]"
+                    }
+                }
             ]
         }
     ],

--- a/src/appmixer/google/calendar/DeleteCalendar/component.json
+++ b/src/appmixer/google/calendar/DeleteCalendar/component.json
@@ -55,7 +55,11 @@
             "options": [
                 {
                     "label": "calendarId",
-                    "value": "calendarId"
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
                 }
             ]
         }

--- a/src/appmixer/google/calendar/DeleteEvent/component.json
+++ b/src/appmixer/google/calendar/DeleteEvent/component.json
@@ -65,7 +65,11 @@
             "options": [
                 {
                     "label": "eventId",
-                    "value": "eventId"
+                    "value": "eventId",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
                 }
             ]
         }

--- a/src/appmixer/google/calendar/EventStart/component.json
+++ b/src/appmixer/google/calendar/EventStart/component.json
@@ -21,33 +21,222 @@
         {
             "name": "out",
             "options": [
-                { "label": "id", "value": "id" },
-                { "label": "calendarId", "value": "calendarId" },
-                { "label": "kind", "value": "kind" },
-                { "label": "etag", "value": "etag" },
-                { "label": "status", "value": "status" },
-                { "label": "htmlLink", "value": "htmlLink" },
-                { "label": "created", "value": "created" },
-                { "label": "updated", "value": "updated" },
-                { "label": "summary", "value": "summary" },
-                { "label": "creator", "value": "creator" },
-                { "label": "creator.email", "value": "creator.email" },
-                { "label": "creator.displayName", "value": "creator.displayName" },
-                { "label": "creator.self", "value": "creator.self" },
-                { "label": "organizer", "value": "organizer" },
-                { "label": "organizer.email", "value": "organizer.email" },
-                { "label": "organizer.displayName", "value": "organizer.displayName" },
-                { "label": "organizer.self", "value": "organizer.self" },
-                { "label": "start", "value": "start" },
-                { "label": "start.date", "value": "start.date" },
-                { "label": "end", "value": "end" },
-                { "label": "end.date", "value": "end.date" },
-                { "label": "transparency", "value": "transparency" },
-                { "label": "iCalUID", "value": "iCalUID" },
-                { "label": "sequence", "value": "sequence" },
-                { "label": "reminders", "value": "reminders" },
-                { "label": "reminders.useDefault", "value": "reminders.useDefault" },
-                { "label": "reminders.overrides", "value": "reminders.overrides" }
+                {
+                    "label": "id",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "calendarId",
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
+                },
+                {
+                    "label": "kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "etag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "status",
+                    "value": "status",
+                    "schema": {
+                        "type": "string",
+                        "example": "confirmed"
+                    }
+                },
+                {
+                    "label": "htmlLink",
+                    "value": "htmlLink",
+                    "schema": {
+                        "type": "string",
+                        "example": "https://www.google.com/calendar/event?eid=abc123"
+                    }
+                },
+                {
+                    "label": "created",
+                    "value": "created",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-01T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "updated",
+                    "value": "updated",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-10T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                },
+                {
+                    "label": "creator",
+                    "value": "creator",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"email\":\"user@example.com\",\"displayName\":\"John Doe\",\"self\":true}"
+                    }
+                },
+                {
+                    "label": "creator.email",
+                    "value": "creator.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "user@example.com"
+                    }
+                },
+                {
+                    "label": "creator.displayName",
+                    "value": "creator.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "John Doe"
+                    }
+                },
+                {
+                    "label": "creator.self",
+                    "value": "creator.self",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "organizer",
+                    "value": "organizer",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"email\":\"organizer@example.com\",\"displayName\":\"Jane Smith\",\"self\":false}"
+                    }
+                },
+                {
+                    "label": "organizer.email",
+                    "value": "organizer.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "organizer@example.com"
+                    }
+                },
+                {
+                    "label": "organizer.displayName",
+                    "value": "organizer.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "Jane Smith"
+                    }
+                },
+                {
+                    "label": "organizer.self",
+                    "value": "organizer.self",
+                    "schema": {
+                        "type": "string",
+                        "example": "false"
+                    }
+                },
+                {
+                    "label": "start",
+                    "value": "start",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15T10:00:00Z"
+                    }
+                },
+                {
+                    "label": "start.date",
+                    "value": "start.date",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15"
+                    }
+                },
+                {
+                    "label": "end",
+                    "value": "end",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15T11:00:00Z"
+                    }
+                },
+                {
+                    "label": "end.date",
+                    "value": "end.date",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15"
+                    }
+                },
+                {
+                    "label": "transparency",
+                    "value": "transparency",
+                    "schema": {
+                        "type": "string",
+                        "example": "opaque"
+                    }
+                },
+                {
+                    "label": "iCalUID",
+                    "value": "iCalUID",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123@google.com"
+                    }
+                },
+                {
+                    "label": "sequence",
+                    "value": "sequence",
+                    "schema": {
+                        "type": "string",
+                        "example": "0"
+                    }
+                },
+                {
+                    "label": "reminders",
+                    "value": "reminders",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"useDefault\":true}"
+                    }
+                },
+                {
+                    "label": "reminders.useDefault",
+                    "value": "reminders.useDefault",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "reminders.overrides",
+                    "value": "reminders.overrides",
+                    "schema": {
+                        "type": "string",
+                        "example": "[]"
+                    }
+                }
             ]
         }
     ],

--- a/src/appmixer/google/calendar/FindEvent/component.json
+++ b/src/appmixer/google/calendar/FindEvent/component.json
@@ -64,40 +64,243 @@
         {
             "name": "out",
             "options": [
-                { "label": "id", "value": "id" },
-                { "label": "calendarId", "value": "calendarId" },
-                { "label": "kind", "value": "kind" },
-                { "label": "etag", "value": "etag" },
-                { "label": "status", "value": "status" },
-                { "label": "summary", "value": "summary" },
-                { "label": "description", "value": "description" },
-                { "label": "location", "value": "location" },
-                { "label": "start", "value": "start" },
-                { "label": "end", "value": "end" },
-                { "label": "htmlLink", "value": "htmlLink" },
-                { "label": "created", "value": "created" },
-                { "label": "updated", "value": "updated" },
-                { "label": "creator", "value": "creator" },
-                { "label": "creator.email", "value": "creator.email" },
-                { "label": "creator.displayName", "value": "creator.displayName" },
-                { "label": "creator.self", "value": "creator.self" },
-                { "label": "organizer", "value": "organizer" },
-                { "label": "organizer.email", "value": "organizer.email" },
-                { "label": "organizer.displayName", "value": "organizer.displayName" },
-                { "label": "organizer.self", "value": "organizer.self" },
-                { "label": "transparency", "value": "transparency" },
-                { "label": "iCalUID", "value": "iCalUID" },
-                { "label": "sequence", "value": "sequence" },
-                { "label": "reminders", "value": "reminders" },
-                { "label": "reminders.useDefault", "value": "reminders.useDefault" },
-                { "label": "reminders.overrides", "value": "reminders.overrides" }
+                {
+                    "label": "id",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "calendarId",
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
+                },
+                {
+                    "label": "kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "etag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "status",
+                    "value": "status",
+                    "schema": {
+                        "type": "string",
+                        "example": "confirmed"
+                    }
+                },
+                {
+                    "label": "summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                },
+                {
+                    "label": "description",
+                    "value": "description",
+                    "schema": {
+                        "type": "string",
+                        "example": "Weekly sync"
+                    }
+                },
+                {
+                    "label": "location",
+                    "value": "location",
+                    "schema": {
+                        "type": "string",
+                        "example": "123 Main St, San Francisco, CA"
+                    }
+                },
+                {
+                    "label": "start",
+                    "value": "start",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15T10:00:00Z"
+                    }
+                },
+                {
+                    "label": "end",
+                    "value": "end",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15T11:00:00Z"
+                    }
+                },
+                {
+                    "label": "htmlLink",
+                    "value": "htmlLink",
+                    "schema": {
+                        "type": "string",
+                        "example": "https://www.google.com/calendar/event?eid=abc123"
+                    }
+                },
+                {
+                    "label": "created",
+                    "value": "created",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-01T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "updated",
+                    "value": "updated",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-10T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "creator",
+                    "value": "creator",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"email\":\"user@example.com\",\"displayName\":\"John Doe\",\"self\":true}"
+                    }
+                },
+                {
+                    "label": "creator.email",
+                    "value": "creator.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "user@example.com"
+                    }
+                },
+                {
+                    "label": "creator.displayName",
+                    "value": "creator.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "John Doe"
+                    }
+                },
+                {
+                    "label": "creator.self",
+                    "value": "creator.self",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "organizer",
+                    "value": "organizer",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"email\":\"organizer@example.com\",\"displayName\":\"Jane Smith\",\"self\":false}"
+                    }
+                },
+                {
+                    "label": "organizer.email",
+                    "value": "organizer.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "organizer@example.com"
+                    }
+                },
+                {
+                    "label": "organizer.displayName",
+                    "value": "organizer.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "Jane Smith"
+                    }
+                },
+                {
+                    "label": "organizer.self",
+                    "value": "organizer.self",
+                    "schema": {
+                        "type": "string",
+                        "example": "false"
+                    }
+                },
+                {
+                    "label": "transparency",
+                    "value": "transparency",
+                    "schema": {
+                        "type": "string",
+                        "example": "opaque"
+                    }
+                },
+                {
+                    "label": "iCalUID",
+                    "value": "iCalUID",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123@google.com"
+                    }
+                },
+                {
+                    "label": "sequence",
+                    "value": "sequence",
+                    "schema": {
+                        "type": "string",
+                        "example": "0"
+                    }
+                },
+                {
+                    "label": "reminders",
+                    "value": "reminders",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"useDefault\":true}"
+                    }
+                },
+                {
+                    "label": "reminders.useDefault",
+                    "value": "reminders.useDefault",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "reminders.overrides",
+                    "value": "reminders.overrides",
+                    "schema": {
+                        "type": "string",
+                        "example": "[]"
+                    }
+                }
             ]
         },
         {
             "name": "notFound",
             "options": [
-                { "label": "query", "value": "query" },
-                { "label": "calendarId", "value": "calendarId" }
+                {
+                    "label": "query",
+                    "value": "query",
+                    "schema": {
+                        "type": "string",
+                        "example": "team meeting"
+                    }
+                },
+                {
+                    "label": "calendarId",
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
+                }
             ]
         }
     ],

--- a/src/appmixer/google/calendar/GetAvailability/component.json
+++ b/src/appmixer/google/calendar/GetAvailability/component.json
@@ -51,15 +51,32 @@
                         "label": "Event types",
                         "type": "multiselect",
                         "index": 4,
-                        "defaultValue": ["default"],
-                        "options": [
-                            { "label": "Regular events", "value": "default" },
-                            { "label": "All-day events", "value": "allDay" },
-                            { "label": "Out of office", "value": "outOfOffice" },
-                            { "label": "Focus time", "value": "focusTime" },
-                            { "label": "Working location", "value": "workingLocation" }
+                        "defaultValue": [
+                            "default"
                         ],
-                        "tooltip": "Select which event types count as 'busy' when checking availability. <b>Regular events</b> are standard timed calendar entries (meetings, appointments, etc.) and are selected by default. <b>All-day events</b> span an entire day without a specific time (e.g. public holidays, reminders) — excluded by default, similar to how tools like n8n handle them. <b>Out of office</b> marks periods of absence. <b>Focus time</b> indicates deep-work blocks. <b>Working location</b> events only indicate where someone is working from and do not block time — excluded by default."
+                        "options": [
+                            {
+                                "label": "Regular events",
+                                "value": "default"
+                            },
+                            {
+                                "label": "All-day events",
+                                "value": "allDay"
+                            },
+                            {
+                                "label": "Out of office",
+                                "value": "outOfOffice"
+                            },
+                            {
+                                "label": "Focus time",
+                                "value": "focusTime"
+                            },
+                            {
+                                "label": "Working location",
+                                "value": "workingLocation"
+                            }
+                        ],
+                        "tooltip": "Select which event types count as 'busy' when checking availability. <b>Regular events</b> are standard timed calendar entries (meetings, appointments, etc.) and are selected by default. <b>All-day events</b> span an entire day without a specific time (e.g. public holidays, reminders) \u2014 excluded by default, similar to how tools like n8n handle them. <b>Out of office</b> marks periods of absence. <b>Focus time</b> indicates deep-work blocks. <b>Working location</b> events only indicate where someone is working from and do not block time \u2014 excluded by default."
                     }
                 }
             },
@@ -78,9 +95,18 @@
                         "format": "date-time"
                     },
                     "eventTypes": {
-                        "type": ["array", "string"],
+                        "type": [
+                            "array",
+                            "string"
+                        ],
                         "items": {
-                            "enum": ["default", "allDay", "workingLocation", "outOfOffice", "focusTime"]
+                            "enum": [
+                                "default",
+                                "allDay",
+                                "workingLocation",
+                                "outOfOffice",
+                                "focusTime"
+                            ]
                         }
                     }
                 },
@@ -96,7 +122,14 @@
         {
             "name": "out",
             "options": [
-                { "label": "Available", "value": "available", "schema": { "type": "boolean" } },
+                {
+                    "label": "Available",
+                    "value": "available",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
                 {
                     "label": "Events",
                     "value": "events",
@@ -105,36 +138,91 @@
                         "items": {
                             "type": "object",
                             "properties": {
-                                "id": { "type": "string", "title": "ID" },
-                                "summary": { "type": "string", "title": "Summary" },
-                                "description": { "type": "string", "title": "Description" },
-                                "location": { "type": "string", "title": "Location" },
-                                "start": { "type": "string", "title": "Start" },
-                                "end": { "type": "string", "title": "End" },
-                                "eventType": { "type": "string", "title": "Event type", "enum": ["default", "outOfOffice", "focusTime", "workingLocation"] },
-                                "isAllDay": { "type": "boolean", "title": "Is all-day" },
-                                "status": { "type": "string", "title": "Status" },
-                                "htmlLink": { "type": "string", "title": "HTML Link" },
+                                "id": {
+                                    "type": "string",
+                                    "title": "ID"
+                                },
+                                "summary": {
+                                    "type": "string",
+                                    "title": "Summary"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "title": "Description"
+                                },
+                                "location": {
+                                    "type": "string",
+                                    "title": "Location"
+                                },
+                                "start": {
+                                    "type": "string",
+                                    "title": "Start"
+                                },
+                                "end": {
+                                    "type": "string",
+                                    "title": "End"
+                                },
+                                "eventType": {
+                                    "type": "string",
+                                    "title": "Event type",
+                                    "enum": [
+                                        "default",
+                                        "outOfOffice",
+                                        "focusTime",
+                                        "workingLocation"
+                                    ]
+                                },
+                                "isAllDay": {
+                                    "type": "boolean",
+                                    "title": "Is all-day"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "title": "Status"
+                                },
+                                "htmlLink": {
+                                    "type": "string",
+                                    "title": "HTML Link"
+                                },
                                 "creator": {
                                     "type": "object",
                                     "title": "Creator",
                                     "properties": {
-                                        "email": { "type": "string", "title": "Email" },
-                                        "displayName": { "type": "string", "title": "Display Name" },
-                                        "self": { "type": "boolean", "title": "Self" }
+                                        "email": {
+                                            "type": "string",
+                                            "title": "Email"
+                                        },
+                                        "displayName": {
+                                            "type": "string",
+                                            "title": "Display Name"
+                                        },
+                                        "self": {
+                                            "type": "boolean",
+                                            "title": "Self"
+                                        }
                                     }
                                 },
                                 "organizer": {
                                     "type": "object",
                                     "title": "Organizer",
                                     "properties": {
-                                        "email": { "type": "string", "title": "Email" },
-                                        "displayName": { "type": "string", "title": "Display Name" },
-                                        "self": { "type": "boolean", "title": "Self" }
+                                        "email": {
+                                            "type": "string",
+                                            "title": "Email"
+                                        },
+                                        "displayName": {
+                                            "type": "string",
+                                            "title": "Display Name"
+                                        },
+                                        "self": {
+                                            "type": "boolean",
+                                            "title": "Self"
+                                        }
                                     }
                                 }
                             }
-                        }
+                        },
+                        "example": "[]"
                     }
                 }
             ]

--- a/src/appmixer/google/calendar/NewCalendar/component.json
+++ b/src/appmixer/google/calendar/NewCalendar/component.json
@@ -22,17 +22,94 @@
         {
             "name": "calendar",
             "options": [
-                { "label": "id", "value": "id" },
-                { "label": "description", "value": "description" },
-                { "label": "accessRole", "value": "accessRole" },
-                { "label": "backgroundColor", "value": "backgroundColor" },
-                { "label": "colorId", "value": "colorId" },
-                { "label": "etag", "value": "etag" },
-                { "label": "foregroundColor", "value": "foregroundColor" },
-                { "label": "kind", "value": "kind" },
-                { "label": "selected", "value": "selected" },
-                { "label": "summary", "value": "summary" },
-                { "label": "timeZone", "value": "timeZone" }
+                {
+                    "label": "id",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "description",
+                    "value": "description",
+                    "schema": {
+                        "type": "string",
+                        "example": "Weekly sync"
+                    }
+                },
+                {
+                    "label": "accessRole",
+                    "value": "accessRole",
+                    "schema": {
+                        "type": "string",
+                        "example": "owner"
+                    }
+                },
+                {
+                    "label": "backgroundColor",
+                    "value": "backgroundColor",
+                    "schema": {
+                        "type": "string",
+                        "example": "#9E69AF"
+                    }
+                },
+                {
+                    "label": "colorId",
+                    "value": "colorId",
+                    "schema": {
+                        "type": "string",
+                        "example": "1"
+                    }
+                },
+                {
+                    "label": "etag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "foregroundColor",
+                    "value": "foregroundColor",
+                    "schema": {
+                        "type": "string",
+                        "example": "#000000"
+                    }
+                },
+                {
+                    "label": "kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "selected",
+                    "value": "selected",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                },
+                {
+                    "label": "timeZone",
+                    "value": "timeZone",
+                    "schema": {
+                        "type": "string",
+                        "example": "America/New_York"
+                    }
+                }
             ]
         }
     ],

--- a/src/appmixer/google/calendar/NewEvent/component.json
+++ b/src/appmixer/google/calendar/NewEvent/component.json
@@ -22,33 +22,222 @@
         {
             "name": "out",
             "options": [
-                { "label": "id", "value": "id" },
-                { "label": "calendarId", "value": "calendarId" },
-                { "label": "kind", "value": "kind" },
-                { "label": "etag", "value": "etag" },
-                { "label": "status", "value": "status" },
-                { "label": "summary", "value": "summary" },
-                { "label": "description", "value": "description" },
-                { "label": "location", "value": "location" },
-                { "label": "start", "value": "start" },
-                { "label": "end", "value": "end" },
-                { "label": "htmlLink", "value": "htmlLink" },
-                { "label": "created", "value": "created" },
-                { "label": "updated", "value": "updated" },
-                { "label": "creator", "value": "creator" },
-                { "label": "creator.email", "value": "creator.email" },
-                { "label": "creator.displayName", "value": "creator.displayName" },
-                { "label": "creator.self", "value": "creator.self" },
-                { "label": "organizer", "value": "organizer" },
-                { "label": "organizer.email", "value": "organizer.email" },
-                { "label": "organizer.displayName", "value": "organizer.displayName" },
-                { "label": "organizer.self", "value": "organizer.self" },
-                { "label": "transparency", "value": "transparency" },
-                { "label": "iCalUID", "value": "iCalUID" },
-                { "label": "sequence", "value": "sequence" },
-                { "label": "reminders", "value": "reminders" },
-                { "label": "reminders.useDefault", "value": "reminders.useDefault" },
-                { "label": "reminders.overrides", "value": "reminders.overrides" }
+                {
+                    "label": "id",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "calendarId",
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
+                },
+                {
+                    "label": "kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "etag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "status",
+                    "value": "status",
+                    "schema": {
+                        "type": "string",
+                        "example": "confirmed"
+                    }
+                },
+                {
+                    "label": "summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                },
+                {
+                    "label": "description",
+                    "value": "description",
+                    "schema": {
+                        "type": "string",
+                        "example": "Weekly sync"
+                    }
+                },
+                {
+                    "label": "location",
+                    "value": "location",
+                    "schema": {
+                        "type": "string",
+                        "example": "123 Main St, San Francisco, CA"
+                    }
+                },
+                {
+                    "label": "start",
+                    "value": "start",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15T10:00:00Z"
+                    }
+                },
+                {
+                    "label": "end",
+                    "value": "end",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-15T11:00:00Z"
+                    }
+                },
+                {
+                    "label": "htmlLink",
+                    "value": "htmlLink",
+                    "schema": {
+                        "type": "string",
+                        "example": "https://www.google.com/calendar/event?eid=abc123"
+                    }
+                },
+                {
+                    "label": "created",
+                    "value": "created",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-01T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "updated",
+                    "value": "updated",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-10T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "creator",
+                    "value": "creator",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"email\":\"user@example.com\"}"
+                    }
+                },
+                {
+                    "label": "creator.email",
+                    "value": "creator.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "user@example.com"
+                    }
+                },
+                {
+                    "label": "creator.displayName",
+                    "value": "creator.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "John Doe"
+                    }
+                },
+                {
+                    "label": "creator.self",
+                    "value": "creator.self",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "organizer",
+                    "value": "organizer",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"email\":\"org@example.com\"}"
+                    }
+                },
+                {
+                    "label": "organizer.email",
+                    "value": "organizer.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "org@example.com"
+                    }
+                },
+                {
+                    "label": "organizer.displayName",
+                    "value": "organizer.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "Jane Smith"
+                    }
+                },
+                {
+                    "label": "organizer.self",
+                    "value": "organizer.self",
+                    "schema": {
+                        "type": "string",
+                        "example": "false"
+                    }
+                },
+                {
+                    "label": "transparency",
+                    "value": "transparency",
+                    "schema": {
+                        "type": "string",
+                        "example": "opaque"
+                    }
+                },
+                {
+                    "label": "iCalUID",
+                    "value": "iCalUID",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123@google.com"
+                    }
+                },
+                {
+                    "label": "sequence",
+                    "value": "sequence",
+                    "schema": {
+                        "type": "string",
+                        "example": "0"
+                    }
+                },
+                {
+                    "label": "reminders",
+                    "value": "reminders",
+                    "schema": {
+                        "type": "string",
+                        "example": "{\"useDefault\":true}"
+                    }
+                },
+                {
+                    "label": "reminders.useDefault",
+                    "value": "reminders.useDefault",
+                    "schema": {
+                        "type": "string",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "reminders.overrides",
+                    "value": "reminders.overrides",
+                    "schema": {
+                        "type": "string",
+                        "example": "[]"
+                    }
+                }
             ]
         }
     ],

--- a/src/appmixer/google/calendar/UpdateEvent/component.json
+++ b/src/appmixer/google/calendar/UpdateEvent/component.json
@@ -143,33 +143,222 @@
         {
             "name": "out",
             "options": [
-                {"label": "Event ID", "value": "id", "schema": {"type": "string"}},
-                {"label": "Calendar ID", "value": "calendarId", "schema": {"type": "string"}},
-                {"label": "Kind", "value": "kind", "schema": {"type": "string"}},
-                {"label": "ETag", "value": "etag", "schema": {"type": "string"}},
-                {"label": "Status", "value": "status", "schema": {"type": "string"}},
-                {"label": "Summary", "value": "summary", "schema": {"type": "string"}},
-                {"label": "Description", "value": "description", "schema": {"type": "string"}},
-                {"label": "Location", "value": "location", "schema": {"type": "string"}},
-                {"label": "Start", "value": "start", "schema": {"type": "object"}},
-                {"label": "End", "value": "end", "schema": {"type": "object"}},
-                {"label": "HTML Link", "value": "htmlLink", "schema": {"type": "string"}},
-                {"label": "Created", "value": "created", "schema": {"type": "string"}},
-                {"label": "Updated", "value": "updated", "schema": {"type": "string"}},
-                {"label": "Creator", "value": "creator", "schema": {"type": "object"}},
-                {"label": "Creator.Email", "value": "creator.email", "schema": {"type": "string"}},
-                {"label": "Creator.DisplayName", "value": "creator.displayName", "schema": {"type": "string"}},
-                {"label": "Creator.Self", "value": "creator.self", "schema": {"type": "boolean"}},
-                {"label": "Organizer", "value": "organizer", "schema": {"type": "object"}},
-                {"label": "Organizer.Email", "value": "organizer.email", "schema": {"type": "string"}},
-                {"label": "Organizer.DisplayName", "value": "organizer.displayName", "schema": {"type": "string"}},
-                {"label": "Organizer.Self", "value": "organizer.self", "schema": {"type": "boolean"}},
-                {"label": "Transparency", "value": "transparency", "schema": {"type": "string"}},
-                {"label": "iCal UID", "value": "iCalUID", "schema": {"type": "string"}},
-                {"label": "Sequence", "value": "sequence", "schema": {"type": "integer"}},
-                {"label": "Reminders", "value": "reminders", "schema": {"type": "object"}},
-                {"label": "Reminders.UseDefault", "value": "reminders.useDefault", "schema": {"type": "boolean"}},
-                {"label": "Reminders.Overrides", "value": "reminders.overrides", "schema": {"type": "array"}}
+                {
+                    "label": "Event ID",
+                    "value": "id",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123xyz"
+                    }
+                },
+                {
+                    "label": "Calendar ID",
+                    "value": "calendarId",
+                    "schema": {
+                        "type": "string",
+                        "example": "primary"
+                    }
+                },
+                {
+                    "label": "Kind",
+                    "value": "kind",
+                    "schema": {
+                        "type": "string",
+                        "example": "calendar#event"
+                    }
+                },
+                {
+                    "label": "ETag",
+                    "value": "etag",
+                    "schema": {
+                        "type": "string",
+                        "example": "\"etag_value\""
+                    }
+                },
+                {
+                    "label": "Status",
+                    "value": "status",
+                    "schema": {
+                        "type": "string",
+                        "example": "confirmed"
+                    }
+                },
+                {
+                    "label": "Summary",
+                    "value": "summary",
+                    "schema": {
+                        "type": "string",
+                        "example": "Team Meeting"
+                    }
+                },
+                {
+                    "label": "Description",
+                    "value": "description",
+                    "schema": {
+                        "type": "string",
+                        "example": "Weekly sync"
+                    }
+                },
+                {
+                    "label": "Location",
+                    "value": "location",
+                    "schema": {
+                        "type": "string",
+                        "example": "123 Main St, San Francisco, CA"
+                    }
+                },
+                {
+                    "label": "Start",
+                    "value": "start",
+                    "schema": {
+                        "type": "object",
+                        "example": "2024-01-15T10:00:00Z"
+                    }
+                },
+                {
+                    "label": "End",
+                    "value": "end",
+                    "schema": {
+                        "type": "object",
+                        "example": "2024-01-15T11:00:00Z"
+                    }
+                },
+                {
+                    "label": "HTML Link",
+                    "value": "htmlLink",
+                    "schema": {
+                        "type": "string",
+                        "example": "https://www.google.com/calendar/event?eid=abc123"
+                    }
+                },
+                {
+                    "label": "Created",
+                    "value": "created",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-01T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "Updated",
+                    "value": "updated",
+                    "schema": {
+                        "type": "string",
+                        "example": "2024-01-10T09:00:00Z"
+                    }
+                },
+                {
+                    "label": "Creator",
+                    "value": "creator",
+                    "schema": {
+                        "type": "object",
+                        "example": "{\"email\":\"user@example.com\"}"
+                    }
+                },
+                {
+                    "label": "Creator.Email",
+                    "value": "creator.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "user@example.com"
+                    }
+                },
+                {
+                    "label": "Creator.DisplayName",
+                    "value": "creator.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "John Doe"
+                    }
+                },
+                {
+                    "label": "Creator.Self",
+                    "value": "creator.self",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "Organizer",
+                    "value": "organizer",
+                    "schema": {
+                        "type": "object",
+                        "example": "{\"email\":\"org@example.com\"}"
+                    }
+                },
+                {
+                    "label": "Organizer.Email",
+                    "value": "organizer.email",
+                    "schema": {
+                        "type": "string",
+                        "example": "org@example.com"
+                    }
+                },
+                {
+                    "label": "Organizer.DisplayName",
+                    "value": "organizer.displayName",
+                    "schema": {
+                        "type": "string",
+                        "example": "Jane Smith"
+                    }
+                },
+                {
+                    "label": "Organizer.Self",
+                    "value": "organizer.self",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "false"
+                    }
+                },
+                {
+                    "label": "Transparency",
+                    "value": "transparency",
+                    "schema": {
+                        "type": "string",
+                        "example": "opaque"
+                    }
+                },
+                {
+                    "label": "iCal UID",
+                    "value": "iCalUID",
+                    "schema": {
+                        "type": "string",
+                        "example": "abc123@google.com"
+                    }
+                },
+                {
+                    "label": "Sequence",
+                    "value": "sequence",
+                    "schema": {
+                        "type": "integer",
+                        "example": "0"
+                    }
+                },
+                {
+                    "label": "Reminders",
+                    "value": "reminders",
+                    "schema": {
+                        "type": "object",
+                        "example": "{\"useDefault\":true}"
+                    }
+                },
+                {
+                    "label": "Reminders.UseDefault",
+                    "value": "reminders.useDefault",
+                    "schema": {
+                        "type": "boolean",
+                        "example": "true"
+                    }
+                },
+                {
+                    "label": "Reminders.Overrides",
+                    "value": "reminders.overrides",
+                    "schema": {
+                        "type": "array",
+                        "example": "[]"
+                    }
+                }
             ]
         }
     ],


### PR DESCRIPTION
Fixes 157 validation failures from `node scripts/validate.js --connector google/calendar`.

All failures were `output-port-examples` — missing `example` field in output port option schemas across 10 components: CreateCalendar, CreateEvent, DeleteCalendar, DeleteEvent, EventStart, FindEvent, GetAvailability, NewCalendar, NewEvent, UpdateEvent.

Two sub-cases fixed:
- Options with `schema` defined but no `example` → added `example`
- Options with no `schema` at all → added `schema` + `example`

Validator now reports 0 failures.