### PR TITLE
fix(bundle): revert unnecessary major bumps to MakeApiCall (50 connectors)

### DIFF
--- a/src/appmixer/activecampaign/bundle.json
+++ b/src/appmixer/activecampaign/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.activecampaign",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -17,17 +17,10 @@
         "1.0.5": [
             "NewTask has been renamed to DealTaskAdded and the tooltip updated."
         ],
-        "1.0.6": [
-            "Added validation for required fields in components."
-        ],
-        "1.0.7": [
-            "Removed Bluebird dependency."
-        ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "Added validation for required fields in components.",
+            "Removed Bluebird dependency.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/apify/bundle.json
+++ b/src/appmixer/apify/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.apify",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
-        "1.0.2": [
-            "Added validation for required fields in components."
-        ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "Added validation for required fields in components.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/azuredocumentintelligence/bundle.json
+++ b/src/appmixer/azuredocumentintelligence/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.azuredocumentintelligence",
-    "version": "3.0.0",
+    "version": "2.1.0",
     "changelog": {
         "1.0.2": [
             "Initial version."
@@ -9,17 +9,10 @@
             "(breaking change) ClassifyDocument split into ClassifyDocument and ClassifyDocumentFromStream. ClassifyDocumentFromStream is using only the File ID parameter, ClassifyDocument is using either File URL or Base64Source.",
             "ClassifyDocument and ClassifyDocumentFromStream: added supported file extensions to the tooltip of either File ID or File URL."
         ],
-        "2.0.1": [
-            "Added validation for required fields in components."
-        ],
         "2.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.1.1": [
+            "Added validation for required fields in components.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "3.0.0": [
-            "(breaking change) Added MakeApiCall component with key-value array inputs for headers and parameters and textarea/JSON for body per standard #1459"
         ]
     }
 }

--- a/src/appmixer/beehiiv/bundle.json
+++ b/src/appmixer/beehiiv/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.beehiiv",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial release."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/betterstack/bundle.json
+++ b/src/appmixer/betterstack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.betterstack",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial release with Uptime monitor CRUD components."
@@ -9,10 +9,7 @@
             "Fix quota resource identifiers for status page components."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/bigCommerce/bundle.json
+++ b/src/appmixer/bigCommerce/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.bigCommerce",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
-        "1.0.3": [
+        "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/brevo/bundle.json
+++ b/src/appmixer/brevo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.brevo",
-    "version": "2.0.0",
+    "version": "1.3.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -28,13 +28,8 @@
             "Enhanced JSON parameter parsing in SendEmail component to handle non-string values."
         ],
         "1.3.0": [
-            "add MakeApiCall component"
-        ],
-        "1.3.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/clearbit/bundle.json
+++ b/src/appmixer/clearbit/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.clearbit",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
-        "1.0.2": [
-            "Added validation for required fields in components."
-        ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "Added validation for required fields in components.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/cloudflare/bundle.json
+++ b/src/appmixer/cloudflare/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.cloudflare",
-    "version": "2.0.0",
+    "version": "1.4.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -17,14 +17,9 @@
         "1.3.0": [
             "Authentication: add support for Account API Token."
         ],
-        "1.3.1": [
-            "Added validation for required fields in components."
-        ],
         "1.4.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "Added validation for required fields in components.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/cloudflareWAF/bundle.json
+++ b/src/appmixer/cloudflareWAF/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.cloudflareWAF",
-    "version": "2.0.0",
+    "version": "1.3.0",
     "changelog": {
         "1.0.10": [
             "Initial version."
@@ -18,10 +18,7 @@
             "CreateCustomRules now prevents overwriting existing connector rules. It only updates rules created by the connector itself."
         ],
         "1.3.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/elevenlabs/bundle.json
+++ b/src/appmixer/elevenlabs/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.elevenlabs",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/everart/bundle.json
+++ b/src/appmixer/everart/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.everart",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/gohighlevel/bundle.json
+++ b/src/appmixer/gohighlevel/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.gohighlevel",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial release."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/imperva/bundle.json
+++ b/src/appmixer/imperva/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.imperva",
-    "version": "2.0.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.2": [
             "Imperva"
@@ -14,14 +14,9 @@
         "1.1.2": [
             "Fixed an issue when the Block IPs did not fail properly when error response was received from Imperva."
         ],
-        "1.1.3": [
-            "Fixed an issue when filter for `ClientIP` contained '&' character instead of '|' character when there were multiple IPs."
-        ],
         "1.2.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "Fixed an issue when filter for `ClientIP` contained '&' character instead of '|' character when there were multiple IPs.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/kit/bundle.json
+++ b/src/appmixer/kit/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.kit",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/klaviyo/bundle.json
+++ b/src/appmixer/klaviyo/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.klaviyo",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/leadspicker/bundle.json
+++ b/src/appmixer/leadspicker/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.leadspicker",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "NinjaAPI"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/lemonsqueezy/bundle.json
+++ b/src/appmixer/lemonsqueezy/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.lemonsqueezy",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -9,13 +9,8 @@
             "Corrected icons on components: Create Customer, Cancel Subscription, Update Customer, Generate Order Invoice, Issue Refund, Update Subscription."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/logscale/bundle.json
+++ b/src/appmixer/logscale/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.logscale",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial release with SendEvent and SendEvents components for Falcon LogScale ingestion."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/mailerlite/bundle.json
+++ b/src/appmixer/mailerlite/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.mailerlite",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/mandrill/bundle.json
+++ b/src/appmixer/mandrill/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.mandrill",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/merk/bundle.json
+++ b/src/appmixer/merk/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.merk",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/monday/bundle.json
+++ b/src/appmixer/monday/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.monday",
-    "version": "4.0.0",
+    "version": "3.1.0",
     "changelog": {
         "1.0.1": [
             "Fixed FindItems component.",
@@ -69,13 +69,8 @@
             "Fixed an issue where fetching boards in ListBoards component could exceed internal timeout for accounts with a large number of boards."
         ],
         "3.1.0": [
-            "add MakeApiCall component"
-        ],
-        "3.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "4.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/naxai/bundle.json
+++ b/src/appmixer/naxai/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.naxai",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.3": [
             "Naxai"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/nexl/bundle.json
+++ b/src/appmixer/nexl/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.nexl",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/ntfy/bundle.json
+++ b/src/appmixer/ntfy/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.ntfy",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version: PublishNotification component with support for message, title, priority, tags, click URL, icon URL, and attachment URL."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/onesignal/bundle.json
+++ b/src/appmixer/onesignal/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.onesignal",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/openai/bundle.json
+++ b/src/appmixer/openai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.openai",
-    "version": "2.0.0",
+    "version": "1.3.0",
     "changelog": {
         "1.1.0": [
             "OpenAI API"
@@ -26,13 +26,8 @@
             "Fixed an issue with the `CreateTranslation` and `CreateTranscription` components where the `response_format` parameter `vtt` was causing an 'Invalid obj param.' error."
         ],
         "1.3.0": [
-            "add MakeApiCall component"
-        ],
-        "1.3.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/pdfco/bundle.json
+++ b/src/appmixer/pdfco/bundle.json
@@ -1,21 +1,14 @@
 {
     "name": "appmixer.pdfco",
-    "version": "2.0.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
-        "1.1.0": [
-            "Implemented multiselect input normalization for types field in ReadBarcode component."
-        ],
         "1.2.0": [
-            "add MakeApiCall component"
-        ],
-        "1.2.1": [
+            "Implemented multiselect input normalization for types field in ReadBarcode component.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/perplexity/bundle.json
+++ b/src/appmixer/perplexity/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.perplexity",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -12,13 +12,8 @@
             "Reduced icon size for better performance."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/pinecone/bundle.json
+++ b/src/appmixer/pinecone/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pinecone",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -15,13 +15,8 @@
             "QueryVectors: Fixed example for the 'Result Transformation JSONata' field."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/pipedrive/bundle.json
+++ b/src/appmixer/pipedrive/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.pipedrive",
-    "version": "3.0.0",
+    "version": "2.3.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -44,13 +44,8 @@
             "Reduced icon size for better performance."
         ],
         "2.3.0": [
-            "add MakeApiCall component"
-        ],
-        "2.3.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "3.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/plivo/bundle.json
+++ b/src/appmixer/plivo/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.plivo",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version."
@@ -12,10 +12,7 @@
             "Moved ListFromNumbers component to sms folder to match component name."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/ragieai/bundle.json
+++ b/src/appmixer/ragieai/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.ragieai",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.2": [
             "Initial release with document management components."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/railway/bundle.json
+++ b/src/appmixer/railway/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.railway",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/redmine/bundle.json
+++ b/src/appmixer/redmine/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.redmine",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.3": [
             "Redmine"
@@ -9,13 +9,8 @@
             "Improved error handling during account connection."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/replicate/bundle.json
+++ b/src/appmixer/replicate/bundle.json
@@ -1,21 +1,14 @@
 {
     "name": "appmixer.replicate",
-    "version": "2.0.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
-        "1.1.0": [
-            "Implemented multiselect input normalization for webhookEventsFilter field in CreatePrediction component."
-        ],
         "1.2.0": [
-            "add MakeApiCall component"
-        ],
-        "1.2.1": [
+            "Implemented multiselect input normalization for webhookEventsFilter field in CreatePrediction component.",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/resend/bundle.json
+++ b/src/appmixer/resend/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.resend",
-    "version": "2.0.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.3": [
             "Initial version"
@@ -9,13 +9,8 @@
             "Added scheduledAt parameter to SendEmail action for scheduling emails up to 72 hours in advance."
         ],
         "1.2.0": [
-            "add MakeApiCall component"
-        ],
-        "1.2.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/servicenow/bundle.json
+++ b/src/appmixer/servicenow/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.servicenow",
-    "version": "4.0.0",
+    "version": "3.1.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -34,10 +34,7 @@
             "Reduced icon size for better performance."
         ],
         "3.1.0": [
-            "add MakeApiCall component"
-        ],
-        "4.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/sonarqube/bundle.json
+++ b/src/appmixer/sonarqube/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.sonarqube",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.2": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/tally/bundle.json
+++ b/src/appmixer/tally/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.tally",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.twilio",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version."
@@ -9,13 +9,8 @@
             "Make Call: Added response statuses of initiated and answered and updated output port options."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/unkey/bundle.json
+++ b/src/appmixer/unkey/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.unkey",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial release with key management components: CreateKey, GetKey, UpdateKey, DeleteKey, VerifyKey, ListKeys, GetAPI, and UpdateKeyRemaining."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/userengage/bundle.json
+++ b/src/appmixer/userengage/bundle.json
@@ -1,15 +1,12 @@
 {
     "name": "appmixer.userengage",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/vapi/bundle.json
+++ b/src/appmixer/vapi/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.vapi",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial release with assistants and squads components."
@@ -11,13 +11,8 @@
             "FindSquads, FindAssistants: fixed date filter fields showing one day earlier than selected."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/verifyemail/bundle.json
+++ b/src/appmixer/verifyemail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.verifyemail",
-    "version": "3.0.0",
+    "version": "2.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -11,10 +11,7 @@
             "Removed the deprecated component of GetCredits"
         ],
         "2.1.0": [
-            "add MakeApiCall component"
-        ],
-        "3.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/virustotal/bundle.json
+++ b/src/appmixer/virustotal/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.virustotal",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "1.1.1": [
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
         ]
     }
 }

--- a/src/appmixer/voys/bundle.json
+++ b/src/appmixer/voys/bundle.json
@@ -1,18 +1,13 @@
 {
     "name": "appmixer.voys",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
         ],
-        "1.0.1": [
-            "re-generate using the OpenAPI Generator 2.1.2"
-        ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "re-generate using the OpenAPI Generator 2.1.2",
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/webflow/bundle.json
+++ b/src/appmixer/webflow/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.webflow",
-    "version": "3.0.0",
+    "version": "2.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -12,10 +12,7 @@
             "Updated the NewFormSubmission trigger."
         ],
         "2.1.0": [
-            "add MakeApiCall component"
-        ],
-        "3.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }

--- a/src/appmixer/xtremepush/bundle.json
+++ b/src/appmixer/xtremepush/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.xtremepush",
-    "version": "2.0.0",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -12,10 +12,7 @@
             "AddUser - fixed typo."
         ],
         "1.1.0": [
-            "add MakeApiCall component"
-        ],
-        "2.0.0": [
-            "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+            "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
         ]
     }
 }


### PR DESCRIPTION
## Summary

For 50 connectors the `X.0.0` version bump labelled as a `(breaking change)` for MakeApiCall is unnecessary, because the intermediate `add MakeApiCall component` versions were never released. End users never saw the old JSON-string headers/parameters form, so there's nothing to "break" from.

This PR collapses the unreleased changelog entries into a single minor bump, keeps the `#1459` key-value standard note on the add-entry, and drops the redundant `X.0.0` breaking-change entry.

### Version changes

| Connector | Before | After |
|---|---|---|
| activecampaign | 2.0.0 | 1.1.0 |
| apify | 2.0.0 | 1.1.0 |
| azuredocumentintelligence | 3.0.0 | 2.1.0 |
| beehiiv | 2.0.0 | 1.1.0 |
| betterstack | 2.0.0 | 1.1.0 |
| bigCommerce | 2.0.0 | 1.1.0 |
| brevo | 2.0.0 | 1.3.0 |
| clearbit | 2.0.0 | 1.1.0 |
| cloudflare | 2.0.0 | 1.4.0 |
| cloudflareWAF | 2.0.0 | 1.3.0 |
| elevenlabs | 2.0.0 | 1.1.0 |
| everart | 2.0.0 | 1.1.0 |
| gohighlevel | 2.0.0 | 1.1.0 |
| imperva | 2.0.0 | 1.2.0 |
| kit | 2.0.0 | 1.1.0 |
| klaviyo | 2.0.0 | 1.1.0 |
| leadspicker | 2.0.0 | 1.1.0 |
| lemonsqueezy | 2.0.0 | 1.1.0 |
| logscale | 2.0.0 | 1.1.0 |
| mailerlite | 2.0.0 | 1.1.0 |
| mandrill | 2.0.0 | 1.1.0 |
| merk | 2.0.0 | 1.1.0 |
| monday | 4.0.0 | 3.1.0 |
| naxai | 2.0.0 | 1.1.0 |
| nexl | 2.0.0 | 1.1.0 |
| ntfy | 2.0.0 | 1.1.0 |
| onesignal | 2.0.0 | 1.1.0 |
| openai | 2.0.0 | 1.3.0 |
| pdfco | 2.0.0 | 1.2.0 |
| perplexity | 2.0.0 | 1.1.0 |
| pinecone | 2.0.0 | 1.1.0 |
| pipedrive | 3.0.0 | 2.3.0 |
| plivo | 2.0.0 | 1.1.0 |
| ragieai | 2.0.0 | 1.1.0 |
| railway | 2.0.0 | 1.1.0 |
| redmine | 2.0.0 | 1.1.0 |
| replicate | 2.0.0 | 1.2.0 |
| resend | 2.0.0 | 1.2.0 |
| servicenow | 4.0.0 | 3.1.0 |
| sonarqube | 2.0.0 | 1.1.0 |
| tally | 2.0.0 | 1.1.0 |
| twilio | 2.0.0 | 1.1.0 |
| unkey | 2.0.0 | 1.1.0 |
| userengage | 2.0.0 | 1.1.0 |
| vapi | 2.0.0 | 1.1.0 |
| verifyemail | 3.0.0 | 2.1.0 |
| virustotal | 2.0.0 | 1.1.0 |
| voys | 2.0.0 | 1.1.0 |
| webflow | 3.0.0 | 2.1.0 |
| xtremepush | 2.0.0 | 1.1.0 |

### Per-bundle changes

- Removed the `X.0.0` "(breaking change) MakeApiCall…" entry.
- Merged unreleased entries (everything with a version strictly higher than the currently-released version in `appmixer-components-RELEASE`) into a single minor bump.
- Updated the "add MakeApiCall component" entry text to: `add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459`.
- `bigCommerce` additionally: fixed a pre-existing duplicate "Initial version" entry that was mis-numbered at `1.0.3` in dev (released version was `1.0.1`).

## Test plan

- [x] `npm run validate` passes (warnings present are pre-existing and unrelated)
- [ ] Spot-check a few connectors visually to confirm changelog ordering and content
- [ ] Confirm no downstream tooling assumes the `X.0.0` versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)