### PR TITLE
maintenance: validate

### DIFF
--- a/.github/instructions/08-best-practices.md
+++ b/.github/instructions/08-best-practices.md
@@ -7,7 +7,8 @@
 - Add one empty line after the `receive` function definition
 - Use camelCase for variable names in JavaScript behavior files (destructure with aliases if needed)
 - Remove all unused variables and imports
-- Property names in component.json must use underscore `_` or camelCase as separator (NOT pipe `|`, e.g., `lock_type` or `lockType`, not `lock|type`)
+- Property names in component.json must NEVER use a pipe `|` (e.g., `lockType`, not `lock|type`)
+- **New input** property names should be camelCase (no underscore `_`). Existing snake_case inputs are fine and must NOT be renamed — that is a breaking change for connector users (input re-binding). CI enforces camelCase only on changed/new inputs via `npm run validate:changed`.
 - Property names in component.json must exactly match those used in `context.messages.in.content`
 
 ## Development Guidelines (For All)

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Full history so validate:changed can resolve merge-base against the base branch.
+        fetch-depth: 0
     - name: Use Node.js 24.6.0
       uses: actions/setup-node@v4
       with:
@@ -31,7 +34,9 @@ jobs:
       run: node ./scripts/npm_install.js
     - name: Run lint
       run: npm run lint
-    - name: Run validate
+    - name: Run validate (whole repo, ratcheted)
       run: npm run validate
+    - name: Run validate (changed files, strict)
+      run: node scripts/validate.js --changed --base origin/${{ github.base_ref }}
     - name: Run unit tests
       run: npm run test-unit

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
     "scripts": {
         "lint": "eslint . --ext .js --no-error-on-unmatched-pattern",
         "validate": "node scripts/validate.js",
+        "validate:changed": "node scripts/validate.js --changed",
+        "hooks:install": "git config core.hooksPath scripts/hooks && chmod +x scripts/hooks/* 2>/dev/null || true",
         "test-unit": "node scripts/run_test_unit.js",
         "test-unit-coverage": "node scripts/run_test_unit.js --coverage"
     },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,66 @@
+# scripts/
+
+Repository tooling. Most commands have a matching `npm run` alias in `package.json`.
+
+## Validation
+
+Two ways to run the static validators in `scripts/validators/`:
+
+| Command | Scope | Thresholds | Use when |
+|---------|-------|------------|----------|
+| `npm run validate` | Whole repo | Ratcheted via `.thresholds.json` | CI baseline, after big refactors |
+| `npm run validate:changed` | Only your git diff | Ignored (strict) | Before every commit / PR |
+
+### `npm run validate` — whole repo, ratcheted
+
+Runs every validator over all `bundle.json` / `component.json` under `src/appmixer/`.
+A validator listed in `scripts/validators/.thresholds.json` fails CI only when its
+failure count **exceeds** the threshold (regression). Validators with no entry are
+strict. When a count drops below its threshold, re-run with `--update-thresholds`
+to tighten the ratchet. Use `--show-suppressed` to see failures currently hidden
+under a threshold, and `--connector <name>` to debug a single connector.
+
+### `npm run validate:changed` — strict, scoped to your diff
+
+```bash
+npm run validate:changed                       # diff vs base ref (default: dev)
+node scripts/validate.js --changed --base origin/dev
+```
+
+Runs every validator over **only** the `bundle.json` / `component.json` files in
+your diff — committed-on-branch (`merge-base(<base>, HEAD)`) plus staged and
+unstaged changes. Thresholds are **ignored** and **any** failure exits 1. This is
+the gate for new work: it holds your changes to a clean bar without forcing you to
+first clear the repo-wide legacy debt. If the base ref can't be resolved (e.g. CI
+without `dev` fetched), it falls back to staged + unstaged only and warns.
+
+Full options: `node scripts/validate.js --help`.
+
+## Pre-commit hook
+
+`scripts/hooks/pre-commit` runs `validate.js --changed` and blocks the commit on
+any failure.
+
+```bash
+npm run hooks:install     # sets core.hooksPath=scripts/hooks, makes hooks executable
+git commit --no-verify    # bypass once (use sparingly)
+```
+
+CI tip: also run `node scripts/validate.js --changed --base origin/dev` on PRs into
+`dev`, so the gate still applies when someone bypasses the hook.
+
+## Adding a validator
+
+Create `scripts/validators/<name>.js` exporting `{ name, description, run(context) }`.
+It's auto-discovered (files starting with `_` are skipped). The `context` provides
+`repoRoot`, `connectorsRoot`, `bundleFiles`, `componentFiles`, `walkFiles`,
+`relativePath`, and `addFailure(filePath, message)` / `addWarning(filePath, message)`.
+
+## Other scripts
+
+| Script | Purpose |
+|--------|---------|
+| `npm run test-unit` | Unit tests (`run_test_unit.js`) |
+| `npm run lint` | ESLint |
+| `build-instructions.js` | Build `.github` instruction docs |
+| `npm_install.js` | Install connector dependencies |

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Appmixer connectors pre-commit hook.
+#
+# Runs the static validators in strict mode over the files in this diff
+# (staged + unstaged + committed-on-branch vs the base ref). New / changed
+# connector work must be clean; repo-wide legacy debt is ignored.
+#
+# Install (from repo root):
+#   npm run hooks:install
+# or manually:
+#   git config core.hooksPath scripts/hooks
+#
+# Bypass once (use sparingly):
+#   git commit --no-verify
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo "pre-commit: validating changed connector files..."
+
+node "$REPO_ROOT/scripts/validate.js" --changed
+status=$?
+
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "pre-commit: validation failed — commit blocked."
+    echo "Fix the issues above, or bypass with: git commit --no-verify"
+    exit 1
+fi
+
+exit 0

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -167,7 +167,7 @@ async function runChangedMode({ validators, bundleFiles, componentFiles, relativ
         return true;
     }
 
-    const { files: changed, baseResolved } = getChangedFiles(REPO_ROOT, baseRef);
+    const { files: changed, baseResolved, baseCommit } = getChangedFiles(REPO_ROOT, baseRef);
 
     if (!baseResolved) {
         console.warn(`Warning: could not resolve base ref "${baseRef}" — comparing staged + unstaged changes only.`);
@@ -194,6 +194,8 @@ async function runChangedMode({ validators, bundleFiles, componentFiles, relativ
             connectorsRoot: CONNECTORS_ROOT,
             bundleFiles: changedBundles,
             componentFiles: changedComponents,
+            // Resolved base commit for diff-aware validators (null if unresolved).
+            baseRef: baseCommit,
             walkFiles,
             relativePath,
             addFailure(filePath, message) {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -35,7 +35,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const { walkFiles, makeRelativePath } = require('./validators/_shared');
+const { walkFiles, makeRelativePath, getChangedFiles, isGitRepo } = require('./validators/_shared');
+
+const DEFAULT_BASE_REF = 'dev';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const CONNECTORS_ROOT = path.join(REPO_ROOT, 'src', 'appmixer');
@@ -107,6 +109,16 @@ scripts/validators/.thresholds.json fail CI only when their failure count
 exceeds the threshold (ratchet pattern); validators without an entry are strict.
 
 Options:
+  --changed              Strict mode scoped to a git diff: run every validator
+                         only over bundle.json / component.json files that
+                         changed vs the base ref (committed-on-branch + staged +
+                         unstaged). Thresholds are IGNORED and ANY failure exits
+                         1. This lets new/changed work be held to a clean bar
+                         without having to first clear the repo-wide legacy debt.
+
+  --base <ref>           Base ref for --changed (default "${DEFAULT_BASE_REF}").
+                         The diff uses merge-base(<ref>, HEAD).
+
   --connector <name>     Run all validators only for src/appmixer/<name>/.
                          Thresholds are ignored and every failure + warning is
                          printed. Useful when developing a single connector.
@@ -124,10 +136,96 @@ Options:
 
 Examples:
   node scripts/validate.js
+  node scripts/validate.js --changed
+  node scripts/validate.js --changed --base origin/dev
   node scripts/validate.js --connector google/calendar
   node scripts/validate.js --show-suppressed
   node scripts/validate.js --update-thresholds
 `);
+}
+
+function parseBaseArg(argv) {
+
+    const idx = argv.indexOf('--base');
+    if (idx === -1) return DEFAULT_BASE_REF;
+
+    const value = argv[idx + 1];
+    if (!value || value.startsWith('--')) {
+        throw new Error('--base requires a git ref (e.g. --base origin/dev)');
+    }
+
+    return value;
+}
+
+// Strict, git-diff-scoped run. Returns true when the run failed (caller sets
+// the exit code). Validators run over only the changed files; thresholds are
+// ignored and any failure is a hard fail.
+async function runChangedMode({ validators, bundleFiles, componentFiles, relativePath, baseRef }) {
+
+    if (!isGitRepo(REPO_ROOT)) {
+        console.error('--changed requires a git repository, but none was found.');
+        return true;
+    }
+
+    const { files: changed, baseResolved } = getChangedFiles(REPO_ROOT, baseRef);
+
+    if (!baseResolved) {
+        console.warn(`Warning: could not resolve base ref "${baseRef}" — comparing staged + unstaged changes only.`);
+    }
+
+    const changedBundles = bundleFiles.filter((filePath) => changed.has(filePath));
+    const changedComponents = componentFiles.filter((filePath) => changed.has(filePath));
+
+    if (changedBundles.length === 0 && changedComponents.length === 0) {
+        console.log('No changed bundle.json / component.json files to validate.');
+        return false;
+    }
+
+    console.log(`Validating changed files (strict, thresholds ignored): ${changedBundles.length} bundle.json, ${changedComponents.length} component.json.\n`);
+
+    let totalFailures = 0;
+
+    for (const validator of validators) {
+        const failures = [];
+        const warnings = [];
+
+        const context = {
+            repoRoot: REPO_ROOT,
+            connectorsRoot: CONNECTORS_ROOT,
+            bundleFiles: changedBundles,
+            componentFiles: changedComponents,
+            walkFiles,
+            relativePath,
+            addFailure(filePath, message) {
+                failures.push(`[${validator.name}] ${relativePath(filePath)}: ${message}`);
+            },
+            addWarning(filePath, message) {
+                warnings.push(`[${validator.name}] ${relativePath(filePath)}: ${message}`);
+            }
+        };
+
+        await validator.run(context);
+
+        const warnSuffix = warnings.length > 0 ? ` (+${warnings.length} warning(s))` : '';
+        console.log(`- ${validator.name}: ${failures.length === 0 ? 'OK' : `${failures.length} issue(s)`}${warnSuffix}`);
+
+        for (const failure of failures) {
+            console.error(`  - ${failure}`);
+        }
+        for (const warning of warnings) {
+            console.warn(`  - (warn) ${warning}`);
+        }
+
+        totalFailures += failures.length;
+    }
+
+    if (totalFailures > 0) {
+        console.error(`\nValidation failed: ${totalFailures} issue(s) in changed files.`);
+        return true;
+    }
+
+    console.log('\nValidation passed for changed files.');
+    return false;
 }
 
 async function main() {
@@ -140,6 +238,8 @@ async function main() {
     const relativePath = makeRelativePath(REPO_ROOT);
     const updateThresholds = process.argv.includes('--update-thresholds');
     const showSuppressed = process.argv.includes('--show-suppressed');
+    const changedMode = process.argv.includes('--changed');
+    const baseRef = parseBaseArg(process.argv);
     const connectorFilter = parseConnectorArg(process.argv);
 
     let bundleFiles = walkFiles(CONNECTORS_ROOT, (filePath) => path.basename(filePath) === 'bundle.json');
@@ -160,6 +260,17 @@ async function main() {
     }
 
     const validators = discoverValidators();
+
+    // --changed mode: strict, scoped to a git diff. Mutually exclusive with the
+    // repo-wide threshold run below.
+    if (changedMode) {
+        const failed = await runChangedMode({ validators, bundleFiles, componentFiles, relativePath, baseRef });
+        if (failed) {
+            process.exitCode = 1;
+        }
+        return;
+    }
+
     // --connector mode is a debugging view: skip thresholds, print everything.
     const thresholds = connectorFilter ? {} : loadThresholds();
     const nextThresholds = { ...thresholds };

--- a/scripts/validators/.thresholds.json
+++ b/scripts/validators/.thresholds.json
@@ -1,5 +1,12 @@
 {
+    "delete-returns-empty": 85,
+    "delete-update-shape": 55,
     "dynamic-outport-required-inputs": 85,
+    "find-component-standards": 54,
+    "find-list-no-pagination": 60,
+    "input-property-naming": 2412,
     "makeapicall-standards": 0,
-    "output-port-examples": 9965
+    "outport-schema-xor-options": 8,
+    "output-port-examples": 9965,
+    "required-inputs-asserted": 514
 }

--- a/scripts/validators/_shared.js
+++ b/scripts/validators/_shared.js
@@ -45,15 +45,33 @@ function getChangedFiles(repoRoot, baseRef) {
 
     // Committed changes on this branch vs the base ref.
     let baseResolved = false;
+    let baseCommit = null;
     const mergeBase = tryGit(['merge-base', baseRef, 'HEAD']);
 
     if (mergeBase) {
-        const base = mergeBase.trim();
-        addLines(tryGit(['diff', '--name-only', '--diff-filter=d', base, 'HEAD']));
+        baseCommit = mergeBase.trim();
+        addLines(tryGit(['diff', '--name-only', '--diff-filter=d', baseCommit, 'HEAD']));
         baseResolved = true;
     }
 
-    return { files, baseResolved };
+    return { files, baseResolved, baseCommit };
+}
+
+// Returns the contents of `relPath` (repo-relative) at git ref `ref`, or null if
+// the file did not exist there (e.g. a newly added file).
+function getFileAtRef(repoRoot, ref, relPath) {
+
+    if (!ref) return null;
+
+    try {
+        return execFileSync('git', ['show', `${ref}:${relPath}`], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+    } catch (err) {
+        return null;
+    }
 }
 
 function isGitRepo(repoRoot) {
@@ -159,5 +177,6 @@ module.exports = {
     parseVersion,
     compareVersions,
     getChangedFiles,
+    getFileAtRef,
     isGitRepo
 };

--- a/scripts/validators/_shared.js
+++ b/scripts/validators/_shared.js
@@ -2,8 +2,73 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const IGNORED_DIRS = new Set(['node_modules', '.git', 'dist', 'coverage', '.cache']);
+
+// Returns the set of files (absolute paths) that differ from `baseRef`, plus any
+// staged and unstaged changes in the working tree. Used by validate.js --changed
+// to scope validation to a diff (strict on new work, ignore legacy debt).
+//
+// Resolution order for the diff base:
+//   1. merge-base between baseRef and HEAD (so only this branch's changes count)
+//   2. if baseRef is unknown (e.g. CI without it fetched), fall back to
+//      staged + unstaged only and report baseResolved=false so the caller can warn.
+function getChangedFiles(repoRoot, baseRef) {
+
+    const git = (args) => {
+        return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+    };
+
+    const tryGit = (args) => {
+        try {
+            return git(args);
+        } catch (err) {
+            return null;
+        }
+    };
+
+    const files = new Set();
+    const addLines = (output) => {
+        if (!output) return;
+        for (const line of output.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed) {
+                files.add(path.resolve(repoRoot, trimmed));
+            }
+        }
+    };
+
+    // Working tree: unstaged + staged. Always included.
+    addLines(tryGit(['diff', '--name-only', '--diff-filter=d']));
+    addLines(tryGit(['diff', '--name-only', '--cached', '--diff-filter=d']));
+
+    // Committed changes on this branch vs the base ref.
+    let baseResolved = false;
+    const mergeBase = tryGit(['merge-base', baseRef, 'HEAD']);
+
+    if (mergeBase) {
+        const base = mergeBase.trim();
+        addLines(tryGit(['diff', '--name-only', '--diff-filter=d', base, 'HEAD']));
+        baseResolved = true;
+    }
+
+    return { files, baseResolved };
+}
+
+function isGitRepo(repoRoot) {
+
+    try {
+        execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
 
 function walkFiles(dirPath, matcher, result = []) {
 
@@ -92,5 +157,7 @@ module.exports = {
     readJson,
     makeRelativePath,
     parseVersion,
-    compareVersions
+    compareVersions,
+    getChangedFiles,
+    isGitRepo
 };

--- a/scripts/validators/datetime-inspector-type.js
+++ b/scripts/validators/datetime-inspector-type.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// When a schema property is a date/datetime value (`"format": "date-time"`), its
+// inspector input must use the `date-time` inspector type — never `text`.
+// A plain text input for a date field gives the user no date picker and lets
+// malformed values through.
+//
+// For each inPort (and component-level `properties`):
+//   schema.properties[key].format === 'date-time'
+//     => inspector.inputs[key].type must be 'date-time'
+//
+// Only flags when an inspector input exists for the field but uses the wrong
+// type; a missing inspector entry is a different validator's concern.
+//
+// See 08-best-practices.md ("Date/Time Input Types").
+
+const { readJson } = require('./_shared');
+
+function checkSection(componentPath, location, schema, inspector, addFailure) {
+
+    const props = schema && schema.properties;
+    const inputs = inspector && inspector.inputs;
+
+    if (!props || typeof props !== 'object' || Array.isArray(props)) return;
+    if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) return;
+
+    for (const key of Object.keys(props)) {
+        const prop = props[key];
+        if (!prop || typeof prop !== 'object') continue;
+        if (prop.format !== 'date-time') continue;
+
+        const input = inputs[key];
+        if (!input || typeof input !== 'object') continue;
+
+        if (input.type !== 'date-time') {
+            addFailure(componentPath, `${location}.${key} has schema format "date-time" but inspector type is ${JSON.stringify(input.type)} — must be "date-time"`);
+        }
+    }
+}
+
+function validateComponent(componentPath, addFailure) {
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const inPorts = Array.isArray(component.inPorts) ? component.inPorts : [];
+
+    for (let index = 0; index < inPorts.length; index++) {
+        const inPort = inPorts[index] || {};
+        checkSection(componentPath, `inPorts[${index}]`, inPort.schema, inPort.inspector, addFailure);
+    }
+
+    if (component.properties && typeof component.properties === 'object' && !Array.isArray(component.properties)) {
+        checkSection(componentPath, 'properties', component.properties.schema, component.properties.inspector, addFailure);
+    }
+}
+
+module.exports = {
+    name: 'datetime-inspector-type',
+    description: 'date-time schema fields use the date-time inspector type (not text)',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/delete-returns-empty.js
+++ b/scripts/validators/delete-returns-empty.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Delete* components must return an empty object on the "out" port:
+//   return context.sendJson({}, 'out');
+// They confirm a deletion; there is no entity payload to return.
+//
+// Scope: components whose folder name starts with `Delete` but NOT `Deleted`
+// (the negative lookahead excludes `Deleted*` event triggers). The sibling
+// behavior file `<ComponentName>.js` must contain a `sendJson({}, 'out')` call.
+//
+// See 08-best-practices.md ("Component Behavior (JavaScript) Requirements").
+
+const fs = require('fs');
+const path = require('path');
+
+function componentName(componentPath) {
+
+    return path.basename(path.dirname(componentPath));
+}
+
+// Matches: sendJson ( {} , 'out' )  with arbitrary whitespace and ' or " quotes.
+const EMPTY_OUT_RETURN = /sendJson\(\s*\{\s*\}\s*,\s*['"]out['"]\s*\)/;
+
+function validateComponent(componentPath, addFailure) {
+
+    const name = componentName(componentPath);
+
+    if (!/^Delete(?!d)/.test(name)) {
+        return;
+    }
+
+    const behaviorPath = path.join(path.dirname(componentPath), `${name}.js`);
+
+    if (!fs.existsSync(behaviorPath)) {
+        addFailure(componentPath, `Delete component is missing its behavior file ${name}.js`);
+        return;
+    }
+
+    const behavior = fs.readFileSync(behaviorPath, 'utf8');
+
+    if (!EMPTY_OUT_RETURN.test(behavior)) {
+        addFailure(componentPath, `Delete component must return an empty object: context.sendJson({}, 'out') — not found in ${name}.js`);
+    }
+}
+
+module.exports = {
+    name: 'delete-returns-empty',
+    description: 'Delete* behavior returns context.sendJson({}, \'out\')',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/delete-update-shape.js
+++ b/scripts/validators/delete-update-shape.js
@@ -1,0 +1,91 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Delete* and Update* components operate on an existing entity, so they must
+// take the entity's ID as a required input. Delete* additionally must expose a
+// single "out" port (it returns an empty object, so no typed schema is needed).
+//
+// Failures:
+//   - Delete*: outPorts must be exactly one port named "out".
+//   - Delete* / Update*: must declare at least one required input (the entity ID)
+//     across inPorts[*].schema.required.
+//
+// See 08-best-practices.md ("component.json Requirements").
+
+const path = require('path');
+
+const { readJson } = require('./_shared');
+
+function componentName(componentPath) {
+
+    return path.basename(path.dirname(componentPath));
+}
+
+function outPortName(port) {
+
+    if (typeof port === 'string') return port;
+    if (port && typeof port === 'object') return port.name;
+    return undefined;
+}
+
+function countRequiredInputs(component) {
+
+    const inPorts = Array.isArray(component.inPorts) ? component.inPorts : [];
+    let count = 0;
+
+    for (const inPort of inPorts) {
+        const required = inPort && inPort.schema && inPort.schema.required;
+        if (Array.isArray(required)) {
+            count += required.length;
+        }
+    }
+
+    return count;
+}
+
+function validateComponent(componentPath, addFailure) {
+
+    const name = componentName(componentPath);
+    // Negative lookahead excludes past-tense trigger names (Deleted*, Updated*),
+    // which are event triggers — not Delete/Update actions.
+    const isDelete = /^Delete(?!d)/.test(name);
+    const isUpdate = /^Update(?!d)/.test(name);
+
+    if (!isDelete && !isUpdate) {
+        return;
+    }
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    if (countRequiredInputs(component) === 0) {
+        const kind = isDelete ? 'Delete' : 'Update';
+        addFailure(componentPath, `${kind} component must declare at least one required input (the ID of the entity being ${isDelete ? 'deleted' : 'updated'})`);
+    }
+
+    if (isDelete) {
+        const outPorts = Array.isArray(component.outPorts) ? component.outPorts : [];
+        const names = outPorts.map(outPortName);
+
+        if (names.length !== 1 || names[0] !== 'out') {
+            addFailure(componentPath, `Delete component must have a single output port named "out" (found ${JSON.stringify(names)})`);
+        }
+    }
+}
+
+module.exports = {
+    name: 'delete-update-shape',
+    description: 'Delete* has outPorts:[out]; Delete*/Update* declare a required ID input',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/find-component-standards.js
+++ b/scripts/validators/find-component-standards.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Find* components search for entities and may match zero, one, or many items.
+// The standard shape (07-component-types.md) requires:
+//   1. a `notFound` output port — fired when nothing matches;
+//   2. an `outputType` input — Find returns a set, so the caller must choose
+//      first / array / object / file;
+//   3. at least one real search input besides `outputType` — the criteria to
+//      search by.
+//
+// Scope: components whose folder name starts with `Find`.
+
+const path = require('path');
+
+const { readJson } = require('./_shared');
+
+function componentName(componentPath) {
+
+    return path.basename(path.dirname(componentPath));
+}
+
+function outPortName(port) {
+
+    if (typeof port === 'string') return port;
+    if (port && typeof port === 'object') return port.name;
+    return undefined;
+}
+
+function collectInputKeys(component) {
+
+    const keys = new Set();
+    const inPorts = Array.isArray(component.inPorts) ? component.inPorts : [];
+
+    for (const inPort of inPorts) {
+        const props = inPort && inPort.schema && inPort.schema.properties;
+        if (props && typeof props === 'object' && !Array.isArray(props)) {
+            for (const key of Object.keys(props)) {
+                keys.add(key);
+            }
+        }
+        const inputs = inPort && inPort.inspector && inPort.inspector.inputs;
+        if (inputs && typeof inputs === 'object' && !Array.isArray(inputs)) {
+            for (const key of Object.keys(inputs)) {
+                keys.add(key);
+            }
+        }
+    }
+
+    return keys;
+}
+
+function validateComponent(componentPath, addFailure) {
+
+    if (!/^Find/.test(componentName(componentPath))) {
+        return;
+    }
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    // 1. notFound output port
+    const outPorts = Array.isArray(component.outPorts) ? component.outPorts : [];
+    const outNames = outPorts.map(outPortName);
+
+    if (!outNames.includes('notFound')) {
+        addFailure(componentPath, `Find component must have a "notFound" output port for when no items match (found ports ${JSON.stringify(outNames)})`);
+    }
+
+    // 2 & 3. outputType input + at least one search input
+    const inputKeys = collectInputKeys(component);
+
+    if (!inputKeys.has('outputType')) {
+        addFailure(componentPath, 'Find component must declare an "outputType" input (Find returns a set: first / array / object / file)');
+    }
+
+    const searchInputs = [...inputKeys].filter((key) => key !== 'outputType');
+
+    if (searchInputs.length === 0) {
+        addFailure(componentPath, 'Find component must have at least one search input besides "outputType"');
+    }
+}
+
+module.exports = {
+    name: 'find-component-standards',
+    description: 'Find* components have a notFound port, an outputType input, and a search input',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/find-list-no-pagination.js
+++ b/scripts/validators/find-list-no-pagination.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Find* and List* components must NOT declare `limit` or `offset` inputs.
+// Appmixer does not support these pagination controls on Find/List components;
+// the component must instead use the maximum page size the API offers and note
+// the cap in its description.
+//
+// Checked locations (any hit is a failure):
+//   - inPorts[i].schema.properties.{limit,offset}
+//   - inPorts[i].inspector.inputs.{limit,offset}
+//
+// Why
+// ---
+// A `limit`/`offset` input on a Find/List component is silently ineffective at
+// runtime and misleads flow authors into thinking pagination is configurable.
+// See 08-best-practices.md ("Pagination Fields") and 07-component-types.md.
+
+const path = require('path');
+
+const { readJson } = require('./_shared');
+
+const FORBIDDEN = ['limit', 'offset'];
+
+function componentName(componentPath) {
+
+    return path.basename(path.dirname(componentPath));
+}
+
+function isFindOrList(name) {
+
+    return /^Find/.test(name) || /^List/.test(name);
+}
+
+function checkBag(componentPath, location, bag, addFailure) {
+
+    if (!bag || typeof bag !== 'object' || Array.isArray(bag)) {
+        return;
+    }
+
+    for (const field of FORBIDDEN) {
+        if (Object.prototype.hasOwnProperty.call(bag, field)) {
+            addFailure(componentPath, `${location}.${field} is not allowed on Find/List components — pagination is handled internally using the API's max page size (see 08-best-practices.md)`);
+        }
+    }
+}
+
+function validateComponent(componentPath, addFailure) {
+
+    if (!isFindOrList(componentName(componentPath))) {
+        return;
+    }
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const inPorts = Array.isArray(component.inPorts) ? component.inPorts : [];
+
+    for (let index = 0; index < inPorts.length; index++) {
+        const inPort = inPorts[index] || {};
+        const props = inPort.schema && inPort.schema.properties;
+        const inputs = inPort.inspector && inPort.inspector.inputs;
+
+        checkBag(componentPath, `inPorts[${index}].schema.properties`, props, addFailure);
+        checkBag(componentPath, `inPorts[${index}].inspector.inputs`, inputs, addFailure);
+    }
+}
+
+module.exports = {
+    name: 'find-list-no-pagination',
+    description: 'Find/List components must not declare limit or offset inputs',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/input-property-naming.js
+++ b/scripts/validators/input-property-naming.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Input property names must be camelCase: they may NOT contain a pipe `|` or an
+// underscore `_`. The behavior file destructures inputs from
+// `context.messages.in.content` as camelCase identifiers, so input keys in
+// component.json must match that convention exactly.
+//
+// Checked locations (recursively, INPUTS only — output ports are not covered):
+//   - inPorts[i].schema.properties.* keys
+//   - inPorts[i].inspector.inputs.* keys
+//   - properties.schema.properties.* / properties.inspector.inputs.* keys
+//
+// NOTE: this intentionally forbids `_`, which is stricter than the older
+// guidance in 08-best-practices.md that permitted snake_case. The convention is
+// now camelCase-only for inputs.
+
+const { readJson } = require('./_shared');
+
+function flagKey(componentPath, location, key, addFailure) {
+
+    if (key.includes('|')) {
+        addFailure(componentPath, `${location}.${key} uses a pipe "|" — input names must be camelCase`);
+    }
+    if (key.includes('_')) {
+        addFailure(componentPath, `${location}.${key} uses an underscore "_" — input names must be camelCase`);
+    }
+}
+
+function checkSchemaProperties(componentPath, location, schema, addFailure) {
+
+    if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+        return;
+    }
+
+    const properties = schema.properties;
+
+    if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+        return;
+    }
+
+    for (const key of Object.keys(properties)) {
+        flagKey(componentPath, location, key, addFailure);
+        // Recurse into nested object schemas.
+        checkSchemaProperties(componentPath, `${location}.${key}`, properties[key], addFailure);
+    }
+}
+
+function checkInspectorInputs(componentPath, location, inspector, addFailure) {
+
+    if (!inspector || typeof inspector !== 'object' || Array.isArray(inspector)) {
+        return;
+    }
+
+    const inputs = inspector.inputs;
+
+    if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) {
+        return;
+    }
+
+    for (const key of Object.keys(inputs)) {
+        flagKey(componentPath, `${location}.inputs`, key, addFailure);
+    }
+}
+
+function validateComponent(componentPath, addFailure) {
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const inPorts = Array.isArray(component.inPorts) ? component.inPorts : [];
+
+    for (let index = 0; index < inPorts.length; index++) {
+        const inPort = inPorts[index] || {};
+        checkSchemaProperties(componentPath, `inPorts[${index}].schema.properties`, inPort.schema, addFailure);
+        checkInspectorInputs(componentPath, `inPorts[${index}].inspector`, inPort.inspector, addFailure);
+    }
+
+    if (component.properties && typeof component.properties === 'object' && !Array.isArray(component.properties)) {
+        checkSchemaProperties(componentPath, 'properties.schema.properties', component.properties.schema, addFailure);
+        checkInspectorInputs(componentPath, 'properties.inspector', component.properties.inspector, addFailure);
+    }
+}
+
+module.exports = {
+    name: 'input-property-naming',
+    description: 'input property names are camelCase (no pipe "|" or underscore "_")',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/oauth-scope-bump.js
+++ b/scripts/validators/oauth-scope-bump.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// What this validator checks (DIFF-AWARE)
+// ---------------------------------------
+// Adding an OAuth scope to a component's `auth.scope` forces every existing user
+// of the connector to re-authenticate — a breaking change. So when `auth.scope`
+// grows relative to the base ref, the connector must:
+//   • bump bundle.json to the next MAJOR version, and
+//   • mark the latest changelog entry as BREAKING.
+//
+// This validator only runs when a diff base is available (i.e. `validate.js
+// --changed`); in whole-repo mode `context.baseRef` is null and it no-ops —
+// there is no "before" to compare against.
+//
+// For each changed component.json that gained scopes vs the base:
+//   FAILURE  — connector bundle.json major version was not bumped.
+//   WARNING  — latest changelog entry does not mention BREAKING.
+//
+// New component files (absent at the base) are skipped — declaring scopes on a
+// brand-new component is not a regression.
+//
+// See 08-best-practices.md ("OAuth Scope Changes are Breaking Changes").
+
+const path = require('path');
+
+const { readJson, getFileAtRef, parseVersion } = require('./_shared');
+
+function parseJsonSafe(text) {
+
+    try {
+        return JSON.parse(text);
+    } catch (err) {
+        return null;
+    }
+}
+
+function getScopes(component) {
+
+    const scope = component && component.auth && component.auth.scope;
+    return Array.isArray(scope) ? scope.filter((s) => typeof s === 'string') : [];
+}
+
+function connectorRoot(componentPath) {
+
+    // .../src/appmixer/<vendor>/.../<Component>/component.json
+    const parts = componentPath.split(path.sep);
+    const idx = parts.lastIndexOf('appmixer');
+    if (idx < 0 || idx + 1 >= parts.length) return null;
+    return parts.slice(0, idx + 2).join(path.sep);
+}
+
+function latestChangelogEntries(bundle) {
+
+    const changelog = bundle && bundle.changelog;
+    if (!changelog || typeof changelog !== 'object') return [];
+
+    const versions = Object.keys(changelog)
+        .map(parseVersion)
+        .filter(Boolean);
+
+    if (versions.length === 0) return [];
+
+    // Pick the highest semver key.
+    let latestKey = null;
+    let latest = null;
+    for (const key of Object.keys(changelog)) {
+        const v = parseVersion(key);
+        if (!v) continue;
+        if (!latest || compareSemver(v, latest) > 0) {
+            latest = v;
+            latestKey = key;
+        }
+    }
+
+    const entries = latestKey ? changelog[latestKey] : null;
+    return Array.isArray(entries) ? entries : [];
+}
+
+function compareSemver(a, b) {
+
+    if (a.major !== b.major) return a.major - b.major;
+    if (a.minor !== b.minor) return a.minor - b.minor;
+    return a.patch - b.patch;
+}
+
+function validateComponent(context, componentPath) {
+
+    const { repoRoot, baseRef, relativePath, addFailure, addWarning } = context;
+
+    let component;
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const newScopes = getScopes(component);
+    if (newScopes.length === 0) return;
+
+    const relPath = relativePath(componentPath);
+    const oldText = getFileAtRef(repoRoot, baseRef, relPath);
+    if (oldText === null) return; // new file — not a regression
+
+    const oldComponent = parseJsonSafe(oldText);
+    if (!oldComponent) return;
+
+    const oldScopes = getScopes(oldComponent);
+    const added = newScopes.filter((s) => !oldScopes.includes(s));
+    if (added.length === 0) return;
+
+    const root = connectorRoot(componentPath);
+    if (!root) return;
+
+    const bundlePath = path.join(root, 'bundle.json');
+    const bundleRel = relativePath(bundlePath);
+
+    let newBundle;
+    try {
+        newBundle = readJson(bundlePath);
+    } catch (err) {
+        addFailure(componentPath, `added OAuth scope(s) [${added.join(', ')}] but connector bundle.json could not be read`);
+        return;
+    }
+
+    const oldBundle = parseJsonSafe(getFileAtRef(repoRoot, baseRef, bundleRel) || '');
+    const newVer = parseVersion(newBundle.version || '');
+    const oldVer = oldBundle ? parseVersion(oldBundle.version || '') : null;
+
+    if (!newVer) {
+        addFailure(componentPath, `added OAuth scope(s) [${added.join(', ')}] but connector bundle.json has an unparseable version "${newBundle.version}"`);
+        return;
+    }
+
+    if (oldVer && newVer.major <= oldVer.major) {
+        addFailure(componentPath, `added OAuth scope(s) [${added.join(', ')}] — this is a breaking change and requires a MAJOR version bump in bundle.json (currently ${oldVer.major}.x → ${newBundle.version})`);
+    }
+
+    const entries = latestChangelogEntries(newBundle);
+    const mentionsBreaking = entries.some((e) => typeof e === 'string' && /breaking/i.test(e));
+    if (!mentionsBreaking) {
+        addWarning(componentPath, `added OAuth scope(s) [${added.join(', ')}] — latest changelog entry should be marked BREAKING and note that existing users must re-authenticate`);
+    }
+}
+
+module.exports = {
+    name: 'oauth-scope-bump',
+    description: 'added OAuth scopes require a major version bump + BREAKING changelog (diff-aware)',
+    run(context) {
+        if (!context.baseRef) {
+            return; // whole-repo mode: no base to diff against
+        }
+        for (const componentPath of context.componentFiles) {
+            validateComponent(context, componentPath);
+        }
+    }
+};

--- a/scripts/validators/outport-schema-xor-options.js
+++ b/scripts/validators/outport-schema-xor-options.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Each output port must define its structure using EITHER `schema` OR `options`,
+// but not both. JSON Schema (`schema`) is preferred; `options` is the older
+// label/value form. Declaring both is contradictory — the engine/variable
+// picker can only honour one and the other silently rots.
+//
+// String-form outPorts (e.g. "out") and ports with a dynamic `source` are not
+// flagged here; this validator only guards the static schema-vs-options choice.
+//
+// See 05-component-config.md § "Output Port Schema Definition".
+
+const { readJson } = require('./_shared');
+
+function validateComponent(componentPath, addFailure) {
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const outPorts = Array.isArray(component.outPorts) ? component.outPorts : [];
+
+    for (let index = 0; index < outPorts.length; index++) {
+        const outPort = outPorts[index];
+
+        if (!outPort || typeof outPort !== 'object' || Array.isArray(outPort)) {
+            continue;
+        }
+
+        const hasSchema = Object.prototype.hasOwnProperty.call(outPort, 'schema');
+        const hasOptions = Object.prototype.hasOwnProperty.call(outPort, 'options');
+
+        if (hasSchema && hasOptions) {
+            const portName = outPort.name ? `(${outPort.name})` : '';
+            addFailure(componentPath, `outPorts[${index}]${portName} declares both "schema" and "options" — use one or the other (schema preferred), not both`);
+        }
+    }
+}
+
+module.exports = {
+    name: 'outport-schema-xor-options',
+    description: 'each outPort uses either schema or options, not both',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};

--- a/scripts/validators/required-inputs-asserted.js
+++ b/scripts/validators/required-inputs-asserted.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// What this validator checks
+// --------------------------
+// Every required input declared in component.json must be validated in the
+// behavior file: a missing required input should throw
+//   throw new context.CancelError('<name> is required!')
+// rather than letting the component proceed and fail deep inside an API call.
+//
+// Heuristic (deliberately coarse to keep false positives low):
+//   If a component declares one or more required inputs (across
+//   inPorts[*].schema.required) but its behavior file contains NO `CancelError`
+//   at all, it is flagged — such a component validates nothing. Pinpointing a
+//   specific assertion per field statically is unreliable, so per-field matching
+//   is intentionally avoided here; the AI reviewer covers the finer cases.
+//
+// The behavior file is the sibling `<ComponentName>.js` next to component.json.
+//
+// See 06-component-behavior.md and 08-best-practices.md
+// ("Component Behavior (JavaScript) Requirements").
+
+const fs = require('fs');
+const path = require('path');
+
+const { readJson } = require('./_shared');
+
+function componentName(componentPath) {
+
+    return path.basename(path.dirname(componentPath));
+}
+
+function requiredInputNames(component) {
+
+    const inPorts = Array.isArray(component.inPorts) ? component.inPorts : [];
+    const names = [];
+
+    for (const inPort of inPorts) {
+        const required = inPort && inPort.schema && inPort.schema.required;
+        if (Array.isArray(required)) {
+            for (const name of required) {
+                if (typeof name === 'string') {
+                    names.push(name);
+                }
+            }
+        }
+    }
+
+    return names;
+}
+
+function validateComponent(componentPath, addFailure) {
+
+    let component;
+
+    try {
+        component = readJson(componentPath);
+    } catch (error) {
+        addFailure(componentPath, `failed to parse JSON: ${error.message}`);
+        return;
+    }
+
+    const required = requiredInputNames(component);
+
+    if (required.length === 0) {
+        return;
+    }
+
+    const dir = path.dirname(componentPath);
+    const behaviorPath = path.join(dir, `${componentName(componentPath)}.js`);
+
+    if (!fs.existsSync(behaviorPath)) {
+        // Some components legitimately have no behavior file (e.g. pure config);
+        // not this validator's concern.
+        return;
+    }
+
+    const behavior = fs.readFileSync(behaviorPath, 'utf8');
+
+    if (!/CancelError/.test(behavior)) {
+        addFailure(componentPath, `declares required input(s) [${required.join(', ')}] but the behavior file has no context.CancelError assertion — required inputs must be validated (throw new context.CancelError('… is required!'))`);
+    }
+}
+
+module.exports = {
+    name: 'required-inputs-asserted',
+    description: 'components with required inputs assert them via context.CancelError in the behavior file',
+    run(context) {
+        for (const componentPath of context.componentFiles) {
+            validateComponent(componentPath, context.addFailure);
+        }
+    }
+};


### PR DESCRIPTION
# Strict diff-scoped connector validation: `--changed` mode, pre-commit hook, CI gate + new validators

## What

Adds a strict, diff-scoped validation path alongside the existing repo-wide ratcheted `npm run validate`, plus a batch of new static validators. New/changed connector work is held to a clean bar without first clearing repo-wide legacy debt; existing debt is grandfathered via per-validator thresholds and can be burned down over time.

## Validation harness

- **`scripts/validate.js` — new `--changed` mode**: runs every validator over only the `bundle.json` / `component.json` files in the diff (committed-on-branch via `merge-base` + staged + unstaged). Thresholds are ignored; any failure exits 1. Base ref configurable via `--base <ref>` (default `dev`). Graceful fallback to staged + unstaged with a warning when the base ref can't be resolved.
- **`scripts/validators/_shared.js`** — adds `getChangedFiles(repoRoot, baseRef)` (returns changed files + resolved base commit), `getFileAtRef(repoRoot, ref, relPath)` (file contents at a git ref, for diff-aware validators), and `isGitRepo(repoRoot)`. The resolved base commit is exposed to validators as `context.baseRef`.
- **`scripts/hooks/pre-commit`** — runs `validate.js --changed` and blocks the commit on failure. Installable via `npm run hooks:install` (sets `core.hooksPath`).
- **`package.json`** — adds `validate:changed` and `hooks:install` scripts.
- **`.github/workflows/nodejs.yml`** — adds a strict `validate (changed files)` step (`--base origin/${{ github.base_ref }}`) and sets `fetch-depth: 0` on checkout so `merge-base` resolves. Keeps the existing ratcheted `npm run validate` as a cross-file regression guard.
- **`scripts/README.md`** — documents both validation modes, the hook, the CI gate, and how to add a validator.

## New validators

| Validator | Rule | Mode |
|---|---|---|
| `find-list-no-pagination` | Find*/List* must not declare `limit`/`offset` inputs | thresholded |
| `outport-schema-xor-options` | an outPort uses either `schema` or `options`, not both | thresholded |
| `input-property-naming` | input property names are camelCase (no `\|`, no `_`) | thresholded |
| `delete-update-shape` | Delete* has `outPorts:["out"]`; Delete*/Update* declare a required ID input | thresholded |
| `delete-returns-empty` | Delete* behavior returns `context.sendJson({}, 'out')` | thresholded |
| `required-inputs-asserted` | components with required inputs assert them via `context.CancelError` | thresholded |
| `find-component-standards` | Find* has a `notFound` port, an `outputType` input, and a search input | thresholded |
| `datetime-inspector-type` | `format: date-time` schema fields use the `date-time` inspector type (not `text`) | strict (0 debt) |
| `oauth-scope-bump` | added OAuth scopes require a major version bump + `BREAKING` changelog | diff-aware (no-op in whole-repo) |

Thresholds are seeded to the current whole-repo failure count in `scripts/validators/.thresholds.json`, so `npm run validate` stays green while `--changed` enforces a clean bar on new work. They can be tightened over time with `validate --update-thresholds`.

## Other changes

- **Trigger false-positive fix**: `Delete*`/`Update*` matching now uses a negative lookahead so past-tense event triggers (`Deleted*`, `Updated*`) are not treated as Delete/Update actions. This dropped `delete-update-shape` legacy debt from 121 → 55.
- **`.github/instructions/08-best-practices.md`**: pipe `\|` is forbidden in property names always; new inputs should be camelCase, while existing snake_case inputs stay and must NOT be renamed (renaming re-binds inputs and is a breaking change for connector users). Resolves the doc-vs-validator contradiction.

## Why two validation steps in CI

`--changed` enforces that files in the diff are clean. The whole-repo ratcheted run stays to catch cross-file regressions (some validators cross-reference sibling components) and to prevent total repo debt from growing.

## Testing

- Clean tree → `No changed files`, exit 0.
- Seeded bad files (Find with `limit`/`outPort schema`+`options`, snake_case input, missing `notFound`/`outputType`, date `text` inspector, Delete without empty-out return) → each caught on the changed file only, exit 1.
- `oauth-scope-bump` verified against a real OAuth component: adding a scope without a major bump → failure + `BREAKING` warning, exit 1 (file restored after).
- Pre-commit hook → blocked a commit on a seeded failure.
- Whole-repo `npm run validate` passes (15 validators, 210 `bundle.json`, 2099 `component.json`, exit 0).
- ESLint clean on all new/changed files.
