### PR TITLE
feat: add test() (Flow Test Mode) to all triggers — freshdesk, gmail, slack, calendly, utils + connector-test-method skill

### DIFF
--- a/.claude/commands/connector-test-method.md
+++ b/.claude/commands/connector-test-method.md
@@ -1,0 +1,52 @@
+---
+description: Add a test(context) method to an Appmixer trigger for Flow Test Mode
+argument-hint: <connector> [trigger-component]
+---
+
+# Add `test(context)` to a trigger
+
+Add a `test(context)` method to a trigger component so the designer's **Flow Test Mode** can
+emit one realistic, fetchable item without starting the flow or waiting for a real event.
+
+## Arguments
+Arguments provided: $ARGUMENTS
+
+- First argument ($1): connector name — `$1`
+- Second argument ($2): trigger component name (optional) — `$2`
+  - If omitted, list the connector's triggers and ask which one(s) to do.
+
+## Instructions
+
+**First, read the full guide** at `.claude/skills/connector-test-method/SKILL.md` and follow it.
+That file is the source of truth — the steps below are just the entry point. The single most
+important rule: **`test()` must share the request + mapping code with `tick()`/`receive()`** so
+its output is byte-for-byte identical to production. `test()` is a thin wrapper, never a parallel
+implementation.
+
+1. **Locate the trigger(s)** under `src/appmixer/$1/`. A trigger has `properties` (not `inPorts`)
+   in `component.json` and a `tick()` or `start()/receive()/stop()` behavior file. If `$2` is
+   given, target that component; otherwise list the triggers and confirm scope with the user.
+
+2. **Identify the group** (see the skill's "Trigger groups" table):
+   - **A** polling list+dedup → reuse the fetch+map path, queried newest-first.
+   - **B** per-flow webhook → add a connector-level `fetchLatestExample()` + reshape to the
+     webhook body; `receive()` has nothing to share, so reuse is across the webhook triggers.
+   - **C** plugin / `addListener` → fetch one recent event via REST in the exact shape the
+     listener delivers.
+   - **D** generic webhook → do NOT implement.
+   - **E** scheduler → synthetic well-formed payload.
+   - **F** form → synthesize a value per field type.
+
+3. **Refactor the production path into shared helpers FIRST**, then verify `tick()`/`receive()`
+   still behaves identically (lint + existing tests). Only then write `test()` as a thin wrapper.
+
+4. **Obey the hard rules** (from the skill): read-only upstream, **no state writes** of any scope,
+   honor `context.properties` filters, emit exactly one item via `context.sendJson(item, '<port>')`
+   with the same shape and port name as production, and `throw` when no example exists.
+
+5. **Verify** per the skill's "Verifying your test() method" section: `npm run lint` +
+   `npm run validate`, then invoke `test()` via `appmixer test component <path> --test`
+   (requires a CLI version with the `--test` flag and stored auth via `appmixer test auth login`)
+   or via Flow Test Mode on a live instance.
+
+6. **Report** per trigger: group, what was extracted/shared, and the verification results.

--- a/.claude/skills/connector-test-method/SKILL.md
+++ b/.claude/skills/connector-test-method/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: connector-test-method
+description: Add a test(context) method to an Appmixer trigger component so Flow Test Mode can emit one realistic, fetchable item. Use when a user wants to implement test(), make a trigger testable in the designer, or roll out Flow Test Mode support across triggers.
+---
+
+# Connector `test(context)` method
+
+Adds a `test(context)` method to **trigger** components so the designer's Flow Test Mode
+can produce a representative output **without** starting the flow and **without** waiting
+for a real event.
+
+## What `test()` is
+
+When a flow is run in **Test Mode** with no explicit `payload`/`inputData`, the trigger's
+`start()`/`stop()`/`tick()` are **skipped**. The engine resolves test data via a fallback chain:
+
+1. the component's `test(context)` method — **this method**, called first
+2. a search of recent run logs for an output from this component/flow
+3. deterministic samples generated from the outPort JSON Schema
+4. empty `receive()` / error
+
+Steps 2–3 are weak: logs exist only after a production run, and schema samples produce
+synthetic IDs (`"sample"`, `0`) that downstream API components reject on the first hop.
+So `test()` is what makes Test Mode actually useful.
+
+Key facts about how the engine calls it:
+- The context is created from the component (with an **empty message**), so it carries the
+  component's config — **`context.auth` and `context.properties` are fully available**.
+- `test()` runs inside a `try/catch`. If it **throws**, the error is logged and the chain
+  falls through to the log/schema fallbacks. **Throw on "no example available" — never
+  return null or send nothing.**
+
+## Core principle: `test()` and `tick()`/`receive()` must share code
+
+This is the most important rule and the reason this skill exists. `test()` only has value if
+its output is **byte-for-byte the same shape** as what the trigger emits in production. The way
+to guarantee that — and to keep it true as the connector evolves — is to make `test()` and
+`tick()`/`receive()` **call the same functions**, not re-implement the same logic side by side.
+
+**Maximize shared code. `test()` should be a thin wrapper, not a parallel implementation.**
+
+Factor the production path into helpers that both entry points reuse:
+- **the upstream request** (URL, auth, headers, query building, pagination parsing), and
+- **the record→output mapping** (`fields` object).
+
+Ideally `test()` adds only: a different query (newest-first, single item), a "take the first
+record" line, and a `throw` when empty. Everything else flows through the shared helpers.
+
+❌ **Anti-pattern** (current risk): `test()` re-declares the base URL, auth config, `include`
+param logic and the axios call, duplicating `tick()`. The two **will** drift — someone fixes a
+header or a mapped field in `tick()` and forgets `test()`, and the test silently emits a
+stale/wrong shape.
+
+✅ **Pattern:** one `requestX(context, query, opts)` helper does the fetch + map and returns
+mapped records (+ next page); `tick()` loops/dedups/saves state around it, `test()` calls it
+once with a newest-first query and emits `records[0]`.
+
+```javascript
+// shared by BOTH tick() and test() — request shape + mapping live in one place
+async function requestTickets(context, urlOrParams, normalizedEmbed) {
+    const { auth } = context;
+    const url = typeof urlOrParams === 'string'
+        ? urlOrParams
+        : `https://${auth.domain}.freshdesk.com/api/v2/tickets?${urlOrParams.toString()}`;
+    const res = await axios.get(url, { auth: { username: auth.apiKey, password: 'X' } });
+    const records = (res.data || []).map(t => mapTicket(t, normalizedEmbed));
+    const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
+    return { records, nextUrl: match ? match[1] : null };
+}
+```
+
+If the connector already exposes a polling helper (`lib.listNewMessages`, etc.), reuse it
+directly with empty state instead of writing a new request. Only extract a new helper when the
+logic is inlined in `tick()`/`receive()`.
+
+## Hard rules
+
+1. **Read-only against upstream.** Only `GET`/list. No `POST`/`PUT`/`PATCH`/`DELETE`, no
+   `markAsRead`, `acknowledge`, `commit`, or anything that mutates remote state.
+2. **No state writes — any scope.** Do NOT call `context.saveState`/`stateSet`/`stateUnset`/
+   `stateClear`/`stateInc`/`stateAddToSet`/`stateRemoveFromSet`, nor the `context.flow.*` or
+   `context.service.*` variants. Test Mode keeps the flow `stopped` and runs no shutdown
+   cleanup, so any write leaks (component state lingers — worse for `"state": {"persistent": true}`
+   triggers; service state leaks into other users' production runs). Use local variables for
+   any dedup/cursor logic. When reusing a polling helper that takes state, pass `{ known: [] }`
+   or `{ cursor: null }` so it returns the freshest item.
+3. **Respect `context.properties`.** If the trigger filters (query, channelId, …), `test()`
+   must return an item matching the same filters, or the test is misleading.
+4. **Emit exactly one item** via `context.sendJson(item, '<port>')`, shaped **identically** to
+   what `tick()`/`receive()` emits. Never use `sendArray`/`sendArrayOutput`.
+5. **Throw on no example** (empty inbox, new channel) so the fallback chain takes over.
+6. **No quota abuse.** Reuse the same lib helpers `tick()` uses so the call goes through the
+   same quota manager and rate limiter.
+
+## Procedure
+
+1. **Confirm it's a trigger.** `component.json` has `properties` (not `inPorts`) and the
+   behavior file has `tick()` or `start()/receive()/stop()`. Actions are out of scope (they
+   are tested via `inputData` → `receive()`).
+2. **Find the outPort name** in `component.json` `outPorts[].name` (e.g. freshdesk → `ticket`,
+   slack → `message`). `sendJson` must use this exact name.
+3. **Refactor the production path into shared helpers FIRST** (see Core principle). Read
+   `tick()`/`receive()` and pull out (a) the upstream **request** (URL/auth/query/pagination)
+   and (b) the record→`fields` **mapping** into functions, then make `tick()`/`receive()` call
+   them. Do this even if it means touching working code — the shared seam is the whole point.
+   If a connector polling helper already exists, skip this and reuse it.
+4. **Verify `tick()`/`receive()` still behaves identically** after the refactor (lint + the
+   existing tests/E2E). `test()` is worthless if the refactor changed production output.
+5. **Write `async test(context)` as a thin wrapper:** resolve properties with the same helper,
+   call the shared request with a **newest-first, single-item** query (`per_page=1`/`limit=1`,
+   `order_by=<created>` `desc`) honoring `context.properties` filters, then `sendJson(records[0],
+   '<port>')`. **No cursor, no `saveState`.** `throw` if empty.
+6. **Verify:** `appmixer test component ./src/appmixer/<connector>/core/<Component> --test`
+   (the `--test` flag invokes `test()` directly), then `npm run lint` and `npm run validate`.
+
+## Trigger groups
+
+| Group | Description | `test()` approach |
+|-------|-------------|-------------------|
+| **A** Polling list+dedup | `tick()` lists latest, dedups vs state (e.g. `freshdesk.NewTicket`, `gmail.NewEmail`, `github.NewIssue`, `wordpress.*`) | Reuse the same fetch+map path, queried newest-first (`desc` + `limit 1`), emit first item. ⚠️ If the polling helper has a baseline/init phase that suppresses first-run output (e.g. gmail), don't call it with empty state — add a small `fetchLatest` helper that shares the mapping. |
+| **B** Per-flow webhook | `start()` registers a per-flow webhook (e.g. `calendly`, `shopify`, `xero`, `hubspot`, `microsoft.mail`) | Do NOT register. Add a shared `lib.fetchLatestExample(context, type, properties)` once per connector, fetch newest record via REST, reshape into the webhook payload. |
+| **C** Plugin-based (global URL + `addListener`) | app-level webhook, `plugin.js`/`routes.js` fan out (e.g. `slack`, `whatsapp`, `meta.*`) | Skip `addListener`, fetch one recent matching event via REST, return it in the exact shape `routes.js` puts on the wire. |
+| **D** Generic webhook (`utils.http.Webhook*`) | no schema/upstream | **Do not implement.** Rely on log search or user-provided `payload`; document in the description. |
+| **E** Scheduler/timer (`utils.timers.SchedulerTrigger`) | no external API | Return a synthetic well-formed payload (current/next dates). |
+| **F** Form (`utils.forms.FormTrigger`) | dynamic schema from `properties.fields.ADD` | Walk fields, synthesize a plausible value per `field.type`. |
+
+### Group A example (canonical — `freshdesk.NewTicket`)
+
+Note how `tick()` and `test()` both go through `getNormalizedEmbed()` + `requestTickets()`
+(which itself calls `mapTicket()`). `test()` adds only the newest-first query and `records[0]`.
+See `src/appmixer/freshdesk/tickets/NewTicket/NewTicket.js` for the full file.
+
+```javascript
+function getNormalizedEmbed(context) {
+    const { embed } = context.properties;
+    return embed ? normalizeMultiselectInput(embed, context, 'Embed fields') : [];
+}
+
+// Shared request + mapping + pagination — the single source of truth for output shape.
+async function requestTickets(context, urlOrParams, normalizedEmbed) {
+    const { auth } = context;
+    const url = typeof urlOrParams === 'string'
+        ? urlOrParams
+        : `https://${auth.domain}.freshdesk.com/api/v2/tickets?${urlOrParams.toString()}`;
+    const res = await axios.get(url, { auth: { username: auth.apiKey, password: 'X' } });
+    const records = (res.data || []).map(t => mapTicket(t, normalizedEmbed));
+    const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
+    return { records, nextUrl: match ? match[1] : null };
+}
+
+async test(context) {
+    const normalizedEmbed = getNormalizedEmbed(context);
+
+    const params = new URLSearchParams({
+        order_by: 'created_at', order_type: 'desc', per_page: '1'
+    });
+    if (normalizedEmbed.length > 0) {
+        params.set('include', normalizedEmbed.join(','));
+    }
+
+    const { records } = await requestTickets(context, params, normalizedEmbed);
+    if (!records.length) {
+        throw new Error('No recent tickets to use as test data.');
+    }
+    return context.sendJson(records[0], 'ticket');
+}
+```
+
+### Group B example (`calendly.events.InviteeCreated`)
+
+The production `receive()` just forwards the webhook body, so there's no fetch+map to share with
+it — instead the reuse is **across the connector's webhook triggers**. Add `fetchLatestExample()`
++ `toWebhookShape()` to the connector commons once; each trigger's `test()` is a thin wrapper.
+See `src/appmixer/calendly/calendly-commons.js` + `events/InviteeCreated/InviteeCreated.js`.
+
+```javascript
+// calendly-commons.js — shared by every Calendly webhook trigger's test()
+async fetchLatestExample(context) {
+    const { accessToken, profileInfo: { resource } } = context.auth;
+    const headers = { 'Authorization': `Bearer ${accessToken}` };
+    const events = await context.httpRequest({
+        method: 'GET', url: 'https://api.calendly.com/scheduled_events', headers,
+        params: { user: resource.uri, sort: 'start_time:desc', count: 1 }
+    });
+    const event = (events.data.collection || [])[0];
+    if (!event) return null;
+    const invitees = await context.httpRequest({
+        method: 'GET', url: `${event.uri}/invitees`, headers, params: { count: 1 }
+    });
+    return (invitees.data.collection || [])[0] || null;
+}
+// toWebhookShape(context, invitee, 'invitee.created') -> the exact body the webhook delivers
+
+// InviteeCreated.js
+async test(context) {
+    const invitee = await commons.fetchLatestExample(context);
+    if (!invitee) throw new Error('No recent invitees to use as test data.');
+    return context.sendJson(commons.toWebhookShape(context, invitee, 'invitee.created'), 'out');
+}
+```
+
+### Group C example (`slack.list.NewChannelMessageRT`)
+
+Plugin trigger: events normally arrive via `context.addListener`. `test()` skips that and reuses
+the **same `conversations.history` call the polling `slack.list.NewChannelMessage` trigger uses**,
+honoring the same `ignoreBotMessages` filter as `receive()`.
+See `src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js`.
+
+```javascript
+const { WebClient } = require('@slack/web-api');
+const Entities = require('html-entities').AllHtmlEntities;
+
+async test(context) {
+    const { channelId, ignoreBotMessages } = context.properties;
+    const web = new WebClient(context.auth.accessToken);
+    const { messages } = await web.conversations.history({ channel: channelId, limit: 1 });
+    const sample = (messages || [])[0];
+    if (!sample) throw new Error('No recent messages in the channel to use as test data.');
+    if (ignoreBotMessages && sample.subtype === 'bot_message') {
+        throw new Error('The most recent message is a bot message.');
+    }
+    sample.text = new Entities().decode(sample.text);
+    return context.sendJson(sample, 'message');
+}
+```
+
+## Per-trigger checklist
+
+- [ ] **`test()` shares the request + mapping path with `tick()`/`receive()`** — no duplicated
+      URL/auth/query/mapping. `test()` is a thin wrapper; the production path was refactored into
+      shared helpers and still behaves identically.
+- [ ] No state writes (component / flow / service), no upstream mutations
+- [ ] Honors `context.properties` filters
+- [ ] Emits exactly one item, shape matches `tick()`/`receive()` exactly, correct port name
+- [ ] Throws (not returns null) when no example exists
+- [ ] `appmixer test component …`, `npm run lint`, `npm run validate` all pass
+
+## Reference connectors
+
+Worked examples across the groups:
+
+**Group A — polling list+dedup:**
+- **`freshdesk.NewTicket`** (`src/appmixer/freshdesk/tickets/NewTicket/`) — *extract from inlined
+  logic.* `tick()` had the request + mapping inlined, so they were pulled into `lib.requestTickets()`
+  + `lib.mapTicket()` and now `tick()` and `test()` both call them. Also has **dynamic** outPorts
+  (via `GenerateTicketsOutput`), so the schema fallback is weak and `test()` carries real value.
+  The sibling triggers `UpdatedTicket` (cursor on `updated_at`) and `DeletedTicket`
+  (`filter=deleted`, own mapping) follow the same shape; `NewConversation` shares
+  fetch/filter/emit helpers between `tick()` and `test()`.
+- **`google.gmail.NewEmail`** (`src/appmixer/google/gmail/NewEmail/` + `../lib.js`) — *reuse an
+  existing lib helper.* The per-message fetch+normalize was factored into `lib.fetchMessage()`
+  (reused by both `listNewMessages()` and a new `lib.fetchLatestExample()`); `test()` is a 4-line
+  wrapper. Note the gotcha: `listNewMessages()` suppresses output on first run (baseline-only
+  init phase), so `test()` could **not** just call it with empty state — it needed the dedicated
+  `fetchLatestExample()` that lists newest-first and honors `query`. Watch for this whenever the
+  polling helper has init/baseline semantics.
+
+**Group B — per-flow webhook:**
+- **`calendly.events.InviteeCreated`** (`src/appmixer/calendly/events/InviteeCreated/` +
+  `../../calendly-commons.js`) — `receive()` only forwards the webhook body, so the reuse is
+  *across the connector's webhook triggers*: `fetchLatestExample()` (REST, newest invitee) +
+  `toWebhookShape()` live in commons; `test()` is a thin wrapper that reshapes the REST record
+  into the exact body the webhook delivers.
+
+**Group C — plugin-based (global URL + `addListener`):**
+- **`slack.list.NewChannelMessageRT`** (`src/appmixer/slack/list/NewChannelMessageRT/`) — `test()`
+  skips `addListener` and reuses the same `conversations.history` call the polling
+  `slack.list.NewChannelMessage` trigger uses, honoring the same `ignoreBotMessages` filter as
+  `receive()`.

--- a/.claude/skills/connector-test-method/SKILL.md
+++ b/.claude/skills/connector-test-method/SKILL.md
@@ -26,9 +26,28 @@ So `test()` is what makes Test Mode actually useful.
 Key facts about how the engine calls it:
 - The context is created from the component (with an **empty message**), so it carries the
   component's config — **`context.auth` and `context.properties` are fully available**.
+- **`context.state` is empty** — the flow was never started, so no `tick()` has ever saved a
+  cursor. `test()` must not rely on reading state (and must not write it, see Hard rules).
 - `test()` runs inside a `try/catch`. If it **throws**, the error is logged and the chain
   falls through to the log/schema fallbacks. **Throw on "no example available" — never
   return null or send nothing.**
+
+## Where `test()` lives
+
+`test()` is just another exported method in the trigger's behavior file, next to
+`tick()`/`receive()`. **No `component.json` change is needed** — the engine detects the method
+automatically:
+
+```javascript
+'use strict';
+
+module.exports = {
+
+    async tick(context) { /* production polling logic */ },
+
+    async test(context) { /* one read-only fetch + sendJson, see below */ }
+};
+```
 
 ## Core principle: `test()` and `tick()`/`receive()` must share code
 
@@ -46,14 +65,17 @@ Factor the production path into helpers that both entry points reuse:
 Ideally `test()` adds only: a different query (newest-first, single item), a "take the first
 record" line, and a `throw` when empty. Everything else flows through the shared helpers.
 
-❌ **Anti-pattern** (current risk): `test()` re-declares the base URL, auth config, `include`
-param logic and the axios call, duplicating `tick()`. The two **will** drift — someone fixes a
-header or a mapped field in `tick()` and forgets `test()`, and the test silently emits a
-stale/wrong shape.
+❌ **Anti-pattern**: `test()` re-declares the base URL, auth config, query param logic and the
+HTTP call, duplicating `tick()`. The two **will** drift — someone fixes a header or a mapped
+field in `tick()` and forgets `test()`, and the test silently emits a stale/wrong shape.
 
 ✅ **Pattern:** one `requestX(context, query, opts)` helper does the fetch + map and returns
 mapped records (+ next page); `tick()` loops/dedups/saves state around it, `test()` calls it
 once with a newest-first query and emits `records[0]`.
+
+Use the built-in **`context.httpRequest`** for the HTTP call (axios-compatible options/response:
+`{ method, url, params, data, headers }` → `{ data, status, headers }`). It needs no extra
+dependency in your connector's `package.json` and goes through the platform's HTTP stack.
 
 ```javascript
 // shared by BOTH tick() and test() — request shape + mapping live in one place
@@ -61,8 +83,11 @@ async function requestTickets(context, urlOrParams, normalizedEmbed) {
     const { auth } = context;
     const url = typeof urlOrParams === 'string'
         ? urlOrParams
-        : `https://${auth.domain}.freshdesk.com/api/v2/tickets?${urlOrParams.toString()}`;
-    const res = await axios.get(url, { auth: { username: auth.apiKey, password: 'X' } });
+        : `https://${auth.domain}.example.com/api/v2/tickets?${urlOrParams.toString()}`;
+    const credentials = Buffer.from(`${auth.apiKey}:X`).toString('base64');
+    const res = await context.httpRequest({
+        url, headers: { Authorization: `Basic ${credentials}` }
+    });
     const records = (res.data || []).map(t => mapTicket(t, normalizedEmbed));
     const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
     return { records, nextUrl: match ? match[1] : null };
@@ -110,8 +135,38 @@ logic is inlined in `tick()`/`receive()`.
    call the shared request with a **newest-first, single-item** query (`per_page=1`/`limit=1`,
    `order_by=<created>` `desc`) honoring `context.properties` filters, then `sendJson(records[0],
    '<port>')`. **No cursor, no `saveState`.** `throw` if empty.
-6. **Verify:** `appmixer test component ./src/appmixer/<connector>/core/<Component> --test`
-   (the `--test` flag invokes `test()` directly), then `npm run lint` and `npm run validate`.
+6. **Verify** (see "Verifying your test() method" below): run lint/validate, then invoke
+   `test()` either via the CLI `--test` flag or via Flow Test Mode on a live instance.
+
+## Verifying your `test()` method
+
+Always run the static checks first:
+
+```bash
+npm run lint
+npm run validate
+```
+
+Then verify the method actually emits a realistic item. Two options:
+
+**Option 1 — Appmixer CLI** (requires a CLI version that supports the `--test` flag; check with
+`appmixer test component --help`):
+
+```bash
+# one-time: store auth credentials for the connector
+appmixer test auth login ./src/appmixer/<connector>/auth.js
+
+# invoke test() directly (skips start/stop/tick/receive, exactly like Flow Test Mode)
+appmixer test component ./src/appmixer/<connector>/<path-to-trigger> --test
+```
+
+Without stored auth data the CLI fails before `test()` is even called.
+
+**Option 2 — live instance** (works with any CLI version): pack & publish the connector
+(`appmixer pack` + `appmixer publish`), build a small flow with the trigger connected to a
+downstream component, and run **Test** in the designer without starting the flow. The trigger's
+output in the test run should show a real, fetchable item (not `"sample"` / `0` placeholders —
+those mean the engine fell back to schema samples because `test()` threw or is missing).
 
 ## Trigger groups
 
@@ -126,28 +181,34 @@ logic is inlined in `tick()`/`receive()`.
 
 ### Group A example (canonical — `freshdesk.NewTicket`)
 
-Note how `tick()` and `test()` both go through `getNormalizedEmbed()` + `requestTickets()`
-(which itself calls `mapTicket()`). `test()` adds only the newest-first query and `records[0]`.
-See `src/appmixer/freshdesk/tickets/NewTicket/NewTicket.js` for the full file.
+The shared pieces live in the connector's `lib.js` so every component issues requests the same
+way: `apiCall()` (auth + base URL on top of `context.httpRequest`), `mapTicket()` (raw ticket →
+output `fields`) and `requestTickets()` (one page: fetch + map + pagination parsing). `tick()`
+and `test()` both go through `requestTickets()`; `test()` adds only the newest-first query and
+`records[0]`. See `src/appmixer/freshdesk/lib.js` + `tickets/NewTicket/NewTicket.js`.
 
 ```javascript
-function getNormalizedEmbed(context) {
-    const { embed } = context.properties;
-    return embed ? normalizeMultiselectInput(embed, context, 'Embed fields') : [];
+// lib.js — single source of truth for request shape, mapping and pagination
+async function apiCall(context, { method = 'GET', url, params, data, headers = {} } = {}) {
+    const baseUrl = `https://${context.auth.domain}.freshdesk.com/api/v2`;
+    const credentials = Buffer.from(`${context.auth.apiKey}:X`).toString('base64');
+    return context.httpRequest({
+        method,
+        url: /^https?:\/\//.test(url) ? url : `${baseUrl}${url}`,
+        headers: { Authorization: `Basic ${credentials}`, ...headers },
+        params, data
+    });
 }
 
-// Shared request + mapping + pagination — the single source of truth for output shape.
-async function requestTickets(context, urlOrParams, normalizedEmbed) {
-    const { auth } = context;
-    const url = typeof urlOrParams === 'string'
-        ? urlOrParams
-        : `https://${auth.domain}.freshdesk.com/api/v2/tickets?${urlOrParams.toString()}`;
-    const res = await axios.get(url, { auth: { username: auth.apiKey, password: 'X' } });
-    const records = (res.data || []).map(t => mapTicket(t, normalizedEmbed));
+async function requestTickets(context, urlOrParams, normalizedEmbed = []) {
+    const url = typeof urlOrParams === 'string' ? urlOrParams : `/tickets?${urlOrParams.toString()}`;
+    const res = await apiCall(context, { url });
+    const records = (res.data || []).map(ticket => mapTicket(ticket, normalizedEmbed));
     const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
     return { records, nextUrl: match ? match[1] : null };
 }
 
+// NewTicket.js
 async test(context) {
     const normalizedEmbed = getNormalizedEmbed(context);
 
@@ -224,6 +285,76 @@ async test(context) {
 }
 ```
 
+### Group E example (`utils.timers.SchedulerTrigger`)
+
+No external API — `test()` returns a synthetic but well-formed payload. The key is still code
+sharing: the schedule computation (`getNextRun()`) is the same function `start()`/`receive()`
+use, so the emitted dates respect the user's configured schedule, timezone and end date.
+See `src/appmixer/utils/timers/SchedulerTrigger/SchedulerTrigger.js`.
+
+```javascript
+async test(context) {
+    const { timezone = 'GMT' } = context.properties;
+    if (timezone && !isValidTimezone(timezone)) {
+        throw new context.CancelError('Invalid timezone');
+    }
+
+    const now = moment().toISOString();
+    // Same computation start()/receive() use — no timeout set, no state touched.
+    const nextDate = this.getNextRun(context, { now, previousDate: null, firstTime: true });
+    if (!nextDate) {
+        throw new Error('No next run within the configured schedule (end date reached).');
+    }
+
+    return context.sendJson({
+        previousDate: null,
+        nextDateGMT: nextDate.toISOString(),
+        nextDateLocal: moment(nextDate).tz(timezone).format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        timezone
+    }, 'out');
+}
+```
+
+### Group F example (`utils.forms.FormTrigger`)
+
+The output schema is dynamic (defined by `context.properties.fields.ADD`), so `test()` walks the
+configured fields and synthesizes a plausible value per `field.type`. Match what a real
+submission produces: HTML forms submit **strings** (only checkbox is normalized to a boolean by
+`receive()`), and prefer the field's configured `defaultValue` for realism.
+See `src/appmixer/utils/forms/FormTrigger/FormTrigger.js`.
+
+```javascript
+test(context) {
+    const fields = (context.properties.fields && context.properties.fields.ADD) || [];
+    if (!fields.length) {
+        throw new Error('No form fields defined.');
+    }
+
+    const entry = {};
+    fields.forEach((field, index) => {
+        const name = 'field_' + index;
+        if (field.type === 'checkbox') {
+            entry[name] = true;
+            return;
+        }
+        if (field.defaultValue) {
+            entry[name] = field.defaultValue;
+            return;
+        }
+        switch (field.type) {
+            case 'number': entry[name] = '42'; break;
+            case 'date': entry[name] = '2026-01-01'; break;
+            case 'email': entry[name] = 'user@example.com'; break;
+            case 'color': entry[name] = '#336699'; break;
+            case 'password': entry[name] = 'secret'; break;
+            default: entry[name] = field.label || 'Sample text';
+        }
+    });
+
+    return context.sendJson(entry, 'entry');
+}
+```
+
 ## Per-trigger checklist
 
 - [ ] **`test()` shares the request + mapping path with `tick()`/`receive()`** — no duplicated
@@ -233,7 +364,8 @@ async test(context) {
 - [ ] Honors `context.properties` filters
 - [ ] Emits exactly one item, shape matches `tick()`/`receive()` exactly, correct port name
 - [ ] Throws (not returns null) when no example exists
-- [ ] `appmixer test component …`, `npm run lint`, `npm run validate` all pass
+- [ ] `npm run lint` + `npm run validate` pass, and `test()` verified via CLI `--test` or
+      Flow Test Mode on a live instance (see "Verifying your test() method")
 
 ## Reference connectors
 
@@ -267,3 +399,13 @@ Worked examples across the groups:
   skips `addListener` and reuses the same `conversations.history` call the polling
   `slack.list.NewChannelMessage` trigger uses, honoring the same `ignoreBotMessages` filter as
   `receive()`.
+
+**Group E — scheduler/timer:**
+- **`utils.timers.SchedulerTrigger`** (`src/appmixer/utils/timers/SchedulerTrigger/`) — `test()`
+  reuses the same `getNextRun()` computation as `start()`/`receive()` and emits the next-run
+  payload without setting any timeout or touching state.
+
+**Group F — form (dynamic schema):**
+- **`utils.forms.FormTrigger`** (`src/appmixer/utils/forms/FormTrigger/`) — `test()` synthesizes
+  one entry from `properties.fields.ADD`, matching the exact shape a real POST submission
+  produces (`field_<index>` keys, string values, checkbox → boolean, `defaultValue` preferred).

--- a/src/appmixer/calendly/bundle.json
+++ b/src/appmixer/calendly/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.calendly",
-    "version": "3.0.4",
+    "version": "3.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -25,6 +25,9 @@
         ],
         "3.0.4": [
             "Added output examples to component schemas."
+        ],
+        "3.1.0": [
+            "Added test() (Flow Test Mode) to all triggers: InviteeCreated, InviteeCanceled, InviteeNoShowCreated, InviteeNoShowDeleted — fetch the newest matching invitee via REST and reshape it into the exact webhook payload, without registering a webhook."
         ]
     }
 }

--- a/src/appmixer/calendly/calendly-commons.js
+++ b/src/appmixer/calendly/calendly-commons.js
@@ -60,6 +60,90 @@ module.exports = {
     },
 
     /**
+     * Fetch the most recent invitee for the authenticated user via the REST API.
+     * Used by the webhook triggers' test() methods (Flow Test Mode) to produce a realistic
+     * example without registering a webhook. Read-only, touches no state. Returns null if no
+     * matching invitee exists.
+     * @param {Context} context
+     * @param {object} [options]
+     * @param {string} [options.status] - invitee status filter (e.g. 'canceled')
+     * @param {function} [options.find] - predicate to pick a specific invitee (e.g. has no_show)
+     * @returns {Promise<object|null>} raw Calendly invitee resource
+     */
+    async fetchLatestExample(context, { status, find } = {}) {
+        const { accessToken, profileInfo: { resource } } = context.auth;
+        const headers = { 'Authorization': `Bearer ${accessToken}` };
+
+        // When filtering (canceled / no-show), the newest event may not contain a match —
+        // scan a few recent events. Plain newest-invitee lookups stay at a single event.
+        const eventsResponse = await context.httpRequest({
+            method: 'GET',
+            url: 'https://api.calendly.com/scheduled_events',
+            headers,
+            params: { user: resource.uri, sort: 'start_time:desc', count: (status || find) ? 10 : 1 }
+        });
+        const events = eventsResponse.data.collection || [];
+
+        for (const event of events) {
+            const inviteesResponse = await context.httpRequest({
+                method: 'GET',
+                url: `${event.uri}/invitees`,
+                headers,
+                params: Object.assign(
+                    { count: find ? 100 : 1, sort: 'created_at:desc' },
+                    status ? { status } : {}
+                )
+            });
+            const invitees = inviteesResponse.data.collection || [];
+            const match = find ? invitees.find(find) : invitees[0];
+            if (match) {
+                return match;
+            }
+        }
+        return null;
+    },
+
+    /**
+     * Reshape a REST invitee resource into the exact body Calendly delivers to the webhook —
+     * the shape the triggers' receive() forwards on the 'out' port. Single source of truth for
+     * the webhook payload shape, shared by every Calendly webhook trigger's test().
+     * @param {Context} context
+     * @param {object} invitee - raw invitee resource from fetchLatestExample()
+     * @param {string} event - e.g. 'invitee.created'
+     * @returns {object}
+     */
+    toWebhookShape(context, invitee, event) {
+        return {
+            created_at: invitee.created_at,
+            created_by: context.auth.profileInfo.resource.uri,
+            event,
+            payload: invitee
+        };
+    },
+
+    /**
+     * Reshape an invitee that was marked as a no-show into the body Calendly delivers for
+     * invitee_no_show.* webhooks — the payload there is the no-show resource, not the invitee.
+     * The invitee must have its `no_show` field set.
+     * @param {Context} context
+     * @param {object} invitee - raw invitee resource with `no_show` set
+     * @param {string} event - 'invitee_no_show.created' or 'invitee_no_show.deleted'
+     * @returns {object}
+     */
+    toNoShowWebhookShape(context, invitee, event) {
+        return {
+            created_at: invitee.no_show.created_at,
+            created_by: context.auth.profileInfo.resource.uri,
+            event,
+            payload: {
+                uri: invitee.no_show.uri,
+                invitee: invitee.uri,
+                created_at: invitee.no_show.created_at
+            }
+        };
+    },
+
+    /**
      * DELETE request for calendly to remove webhook subscription.
      * @param {string} webhookUri
      * @param {Context} context

--- a/src/appmixer/calendly/events/InviteeCanceled/InviteeCanceled.js
+++ b/src/appmixer/calendly/events/InviteeCanceled/InviteeCanceled.js
@@ -35,6 +35,16 @@ module.exports = {
         }
     },
 
+    // Flow Test Mode: emit one realistic invitee.canceled payload without registering a webhook.
+    // Reuses the connector-level helpers shared by every Calendly webhook trigger.
+    async test(context) {
+        const invitee = await commons.fetchLatestExample(context, { status: 'canceled' });
+        if (!invitee) {
+            throw new Error('No recent canceled invitees to use as test data.');
+        }
+        return context.sendJson(commons.toWebhookShape(context, invitee, 'invitee.canceled'), 'out');
+    },
+
     /**
      * Register webhook in Calendly API.
      * @param {Context} context

--- a/src/appmixer/calendly/events/InviteeCreated/InviteeCreated.js
+++ b/src/appmixer/calendly/events/InviteeCreated/InviteeCreated.js
@@ -34,6 +34,17 @@ module.exports = {
         }
     },
 
+    // Flow Test Mode: emit one realistic invitee.created payload without registering a webhook.
+    // Reuses the connector-level helpers shared by every Calendly webhook trigger: fetch the most
+    // recent invitee via REST and reshape it into the exact body the webhook would deliver.
+    async test(context) {
+        const invitee = await commons.fetchLatestExample(context);
+        if (!invitee) {
+            throw new Error('No recent invitees to use as test data.');
+        }
+        return context.sendJson(commons.toWebhookShape(context, invitee, 'invitee.created'), 'out');
+    },
+
     /**
      * Register webhook in Calendly API.
      * @param {Context} context

--- a/src/appmixer/calendly/events/InviteeNoShowCreated/InviteeNoShowCreated.js
+++ b/src/appmixer/calendly/events/InviteeNoShowCreated/InviteeNoShowCreated.js
@@ -34,6 +34,18 @@ module.exports = {
         }
     },
 
+    // Flow Test Mode: emit one realistic invitee_no_show.created payload without registering
+    // a webhook. Finds a recent invitee marked as no-show and reshapes it into the no-show
+    // webhook body via the shared connector-level helpers.
+    async test(context) {
+        const invitee = await commons.fetchLatestExample(context, { find: i => !!i.no_show });
+        if (!invitee) {
+            throw new Error('No recent invitees marked as no-show to use as test data.');
+        }
+        return context.sendJson(
+            commons.toNoShowWebhookShape(context, invitee, 'invitee_no_show.created'), 'out');
+    },
+
     /**
      * Register webhook in Calendly API.
      * @param {Context} context

--- a/src/appmixer/calendly/events/InviteeNoShowDeleted/InviteeNoShowDeleted.js
+++ b/src/appmixer/calendly/events/InviteeNoShowDeleted/InviteeNoShowDeleted.js
@@ -34,6 +34,18 @@ module.exports = {
         }
     },
 
+    // Flow Test Mode: emit one realistic invitee_no_show.deleted payload without registering
+    // a webhook. The deleted-webhook payload refers to a no-show record, so an existing no-show
+    // is the closest realistic example — reshaped via the shared connector-level helpers.
+    async test(context) {
+        const invitee = await commons.fetchLatestExample(context, { find: i => !!i.no_show });
+        if (!invitee) {
+            throw new Error('No recent invitees marked as no-show to use as test data.');
+        }
+        return context.sendJson(
+            commons.toNoShowWebhookShape(context, invitee, 'invitee_no_show.deleted'), 'out');
+    },
+
     /**
      * Register webhook in Calendly API.
      * @param {Context} context

--- a/src/appmixer/freshdesk/agents/ListAgents/ListAgents.js
+++ b/src/appmixer/freshdesk/agents/ListAgents/ListAgents.js
@@ -1,25 +1,17 @@
 'use strict';
-const request = require('request-promise');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         let agents;
         try {
-            agents = await request({
-                method: 'GET',
-                url: `https://${auth.domain}.freshdesk.com/api/v2/agents`,
-                auth: {
-                    user: auth.apiKey,
-                    password: 'X'
-                },
-                json: true
-            });
+            const { data } = await apiCall(context, { url: '/agents' });
+            agents = data;
         } catch (e) {
-            const body = e.response.body;
-            if (body.code === 'access_denied') {
+            const code = e.response?.data?.code || e.response?.body?.code;
+            if (code === 'access_denied') {
                 agents = [];
             } else {
                 throw e;

--- a/src/appmixer/freshdesk/auth.js
+++ b/src/appmixer/freshdesk/auth.js
@@ -1,5 +1,4 @@
 'use strict';
-const request = require('request-promise');
 
 module.exports = {
 
@@ -28,28 +27,27 @@ module.exports = {
 
             // curl https://mydomain.freshdesk.com/api/v2/agents/me \
             //  -u myApiKey:X'
-            return request({
+            const encoded = Buffer.from(`${context.apiKey}:X`).toString('base64');
+            const { data } = await context.httpRequest({
                 method: 'GET',
                 url: `https://${context.domain}.freshdesk.com/api/v2/agents/me`,
-                auth: {
-                    user: context.apiKey,
-                    password: 'X'
-                },
-                json: true
+                headers: {
+                    Authorization: `Basic ${encoded}`
+                }
             });
+            return data;
         },
 
         validate: async context => {
 
             // curl https://mydomain.freshdesk.com/api/v2/agents/me \
             //  -u myApiKey:X'
-            const credentials = `${context.apiKey}:X`;
-            const encoded = (new Buffer(credentials)).toString('base64');
-            await request({
+            const encoded = Buffer.from(`${context.apiKey}:X`).toString('base64');
+            await context.httpRequest({
                 method: 'GET',
                 url: `https://${context.domain}.freshdesk.com/api/v2/agents/me`,
                 headers: {
-                    'Authorization': `Basic ${encoded}`
+                    Authorization: `Basic ${encoded}`
                 }
             });
             // if the request doesn't fail, return true (exception will be captured in caller)

--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -43,6 +43,10 @@
         ],
         "2.0.0": [
             "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ],
+        "2.1.0": [
+            "Added test() (Flow Test Mode) to all triggers: NewTicket, UpdatedTicket, DeletedTicket, NewConversation — emit one realistic item via a read-only call, reusing the same fetch/mapping path as tick().",
+            "Replaced the axios/request/request-promise dependencies with a shared lib.apiCall helper built on context.httpRequest; no behavior change to existing components."
         ]
     }
 }

--- a/src/appmixer/freshdesk/companies/CreateCompany/CreateCompany.js
+++ b/src/appmixer/freshdesk/companies/CreateCompany/CreateCompany.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const axios = require('axios');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const content = context.messages.in.content;
 
         const body = trimUndefined({
@@ -21,16 +19,11 @@ module.exports = {
             industry: content.industry
         });
 
-        const response = await axios.post(
-            `https://${auth.domain}.freshdesk.com/api/v2/companies`,
-            body,
-            {
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        const response = await apiCall(context, {
+            method: 'POST',
+            url: '/companies',
+            data: body
+        });
 
         const data = response.data;
         return context.sendJson(mapCompany(data), 'company');

--- a/src/appmixer/freshdesk/companies/DeleteCompany/DeleteCompany.js
+++ b/src/appmixer/freshdesk/companies/DeleteCompany/DeleteCompany.js
@@ -1,23 +1,17 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const companyId = parseInt(context.messages.in.content.companyId, 10);
 
-        await axios.delete(
-            `https://${auth.domain}.freshdesk.com/api/v2/companies/${companyId}`,
-            {
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        await apiCall(context, {
+            method: 'DELETE',
+            url: `/companies/${companyId}`
+        });
 
         return context.sendJson({ companyId }, 'out');
     }

--- a/src/appmixer/freshdesk/companies/FindCompanies/FindCompanies.js
+++ b/src/appmixer/freshdesk/companies/FindCompanies/FindCompanies.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const axios = require('axios');
-const { sendArrayOutput } = require('../../lib');
+const { apiCall, sendArrayOutput } = require('../../lib');
 
 const DEFAULT_PREFIX = 'freshdesk-companies-export';
 
@@ -58,7 +57,6 @@ module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const content = context.messages.in.content;
         const { outputType = 'array' } = content;
 
@@ -66,14 +64,11 @@ module.exports = {
             return getOutputPortOptions(context, outputType);
         }
 
-        const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2`;
-        const authConfig = { username: auth.apiKey, password: 'X' };
-
         // Search by name via autocomplete
         if (content.searchName) {
-            const response = await axios.get(`${baseUrl}/companies/autocomplete`, {
-                params: { name: content.searchName },
-                auth: authConfig
+            const response = await apiCall(context, {
+                url: '/companies/autocomplete',
+                params: { name: content.searchName }
             });
             const companies = Array.isArray(response.data) ? response.data : [];
             if (companies.length === 0) return context.sendJson({}, 'notFound');
@@ -83,9 +78,9 @@ module.exports = {
         // Filter query via search API
         if (content.query) {
             const searchQuery = content.query.startsWith('"') ? content.query : `"${content.query}"`;
-            const response = await axios.get(`${baseUrl}/search/companies`, {
-                params: { query: searchQuery },
-                auth: authConfig
+            const response = await apiCall(context, {
+                url: '/search/companies',
+                params: { query: searchQuery }
             });
             const companies = Array.isArray(response.data) ? response.data : (response.data.results || []);
             if (companies.length === 0) return context.sendJson({}, 'notFound');
@@ -93,12 +88,7 @@ module.exports = {
         }
 
         // List all companies
-        const params = {};
-
-        const response = await axios.get(`${baseUrl}/companies`, {
-            params,
-            auth: authConfig
-        });
+        const response = await apiCall(context, { url: '/companies' });
         const companies = response.data || [];
         if (companies.length === 0) return context.sendJson({}, 'notFound');
         return sendArrayOutput({ context, records: companies, outputType, defaultPrefix: DEFAULT_PREFIX });

--- a/src/appmixer/freshdesk/companies/GetCompany/GetCompany.js
+++ b/src/appmixer/freshdesk/companies/GetCompany/GetCompany.js
@@ -1,25 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const companyId = parseInt(context.messages.in.content.companyId, 10);
 
         let data;
         try {
-            const response = await axios.get(
-                `https://${auth.domain}.freshdesk.com/api/v2/companies/${companyId}`,
-                {
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
-                }
-            );
+            const response = await apiCall(context, { url: `/companies/${companyId}` });
             data = response.data;
         } catch (err) {
             if (err.response?.status === 404) {

--- a/src/appmixer/freshdesk/companies/UpdateCompany/UpdateCompany.js
+++ b/src/appmixer/freshdesk/companies/UpdateCompany/UpdateCompany.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const axios = require('axios');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const content = context.messages.in.content;
 
         const body = trimUndefined({
@@ -22,16 +20,11 @@ module.exports = {
         });
 
         const companyId = parseInt(content.companyId, 10);
-        const response = await axios.put(
-            `https://${auth.domain}.freshdesk.com/api/v2/companies/${companyId}`,
-            body,
-            {
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        const response = await apiCall(context, {
+            method: 'PUT',
+            url: `/companies/${companyId}`,
+            data: body
+        });
 
         const data = response.data;
         return context.sendJson({

--- a/src/appmixer/freshdesk/contacts/CreateContact/CreateContact.js
+++ b/src/appmixer/freshdesk/contacts/CreateContact/CreateContact.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const axios = require('axios');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const content = context.messages.in.content;
 
         const body = trimUndefined({
@@ -26,16 +24,11 @@ module.exports = {
             address: content.address
         });
 
-        const response = await axios.post(
-            `https://${auth.domain}.freshdesk.com/api/v2/contacts`,
-            body,
-            {
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        const response = await apiCall(context, {
+            method: 'POST',
+            url: '/contacts',
+            data: body
+        });
 
         const data = response.data;
         return context.sendJson({

--- a/src/appmixer/freshdesk/contacts/DeleteContact/DeleteContact.js
+++ b/src/appmixer/freshdesk/contacts/DeleteContact/DeleteContact.js
@@ -1,23 +1,17 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { contactId } = context.messages.in.content;
 
-        await axios.delete(
-            `https://${auth.domain}.freshdesk.com/api/v2/contacts/${contactId}`,
-            {
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        await apiCall(context, {
+            method: 'DELETE',
+            url: `/contacts/${contactId}`
+        });
 
         return context.sendJson({ contactId }, 'out');
     }

--- a/src/appmixer/freshdesk/contacts/ExportContacts/ExportContacts.js
+++ b/src/appmixer/freshdesk/contacts/ExportContacts/ExportContacts.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 const POLL_INTERVAL_MS = 30000;   // re-check every 30s
 const MAX_POLLS = 60;             // up to 30 minutes total (60 × 30s)
@@ -9,12 +9,10 @@ module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
-
         // ── Resumed from a timeout (polling tick) ───────────────────────────
         if (context.messages.timeout) {
             const { exportId, polls } = context.messages.timeout.content;
-            return poll(context, auth, exportId, polls);
+            return poll(context, exportId, polls);
         }
 
         // ── First invocation ─────────────────────────────────────────────────
@@ -31,14 +29,11 @@ module.exports = {
             throw new context.CancelError('At least one of Default Fields or Custom Fields must be provided.');
         }
 
-        const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2`;
-        const authConfig = { username: auth.apiKey, password: 'X' };
-
-        const exportResponse = await axios.post(
-            `${baseUrl}/contacts/export`,
-            { fields },
-            { auth: authConfig }
-        );
+        const exportResponse = await apiCall(context, {
+            method: 'POST',
+            url: '/contacts/export',
+            data: { fields }
+        });
 
         const exportId = exportResponse.data && exportResponse.data.id;
         if (!exportId) {
@@ -66,19 +61,13 @@ function parseList(str) {
  * Called on each timeout tick — checks export status and either schedules
  * the next poll, streams the file, or throws on failure/timeout.
  */
-async function poll(context, auth, exportId, polls) {
+async function poll(context, exportId, polls) {
 
     if (polls >= MAX_POLLS) {
         throw new Error(`Freshdesk contact export timed out after ${(MAX_POLLS * POLL_INTERVAL_MS) / 1000}s (id: ${exportId}).`);
     }
 
-    const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2`;
-    const authConfig = { username: auth.apiKey, password: 'X' };
-
-    const statusResponse = await axios.get(
-        `${baseUrl}/contacts/export/${exportId}`,
-        { auth: authConfig }
-    );
+    const statusResponse = await apiCall(context, { url: `/contacts/export/${exportId}` });
 
     const responseData = statusResponse.data;
     const status = responseData.status;
@@ -91,8 +80,9 @@ async function poll(context, auth, exportId, polls) {
     }
 
     if (downloadUrl) {
-        // Stream the file directly into Appmixer file storage — no buffering
-        const downloadResponse = await axios.get(downloadUrl, { responseType: 'stream' });
+        // Stream the file directly into Appmixer file storage — no buffering.
+        // downloadUrl is a pre-signed external URL, so it needs no Freshdesk auth.
+        const downloadResponse = await context.httpRequest({ url: downloadUrl, responseType: 'stream' });
         const fileName = `freshdesk-contacts-export-${exportId}.csv`;
         const savedFile = await context.saveFileStream(fileName, downloadResponse.data);
 

--- a/src/appmixer/freshdesk/contacts/FindContacts/FindContacts.js
+++ b/src/appmixer/freshdesk/contacts/FindContacts/FindContacts.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const axios = require('axios');
-const { sendArrayOutput } = require('../../lib');
+const { apiCall, sendArrayOutput } = require('../../lib');
 
 const DEFAULT_PREFIX = 'freshdesk-contacts-export';
 
@@ -74,7 +73,6 @@ module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const content = context.messages.in.content;
         const { outputType = 'array' } = content;
 
@@ -86,16 +84,10 @@ module.exports = {
 
         // Search by name using the autocomplete endpoint
         if (content.searchName) {
-            const response = await axios.get(
-                `https://${auth.domain}.freshdesk.com/api/v2/contacts/autocomplete`,
-                {
-                    params: { term: content.searchName },
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
-                }
-            );
+            const response = await apiCall(context, {
+                url: '/contacts/autocomplete',
+                params: { term: content.searchName }
+            });
             const contacts = Array.isArray(response.data) ? response.data : [];
 
             if (contacts.length === 0) {
@@ -114,16 +106,10 @@ module.exports = {
         // Freshdesk search API requires the query wrapped in double quotes, e.g. "email:'test@example.com'"
         if (content.query) {
             const searchQuery = content.query.startsWith('"') ? content.query : `"${content.query}"`;
-            const response = await axios.get(
-                `https://${auth.domain}.freshdesk.com/api/v2/search/contacts`,
-                {
-                    params: { query: searchQuery },
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
-                }
-            );
+            const response = await apiCall(context, {
+                url: '/search/contacts',
+                params: { query: searchQuery }
+            });
             const contacts = Array.isArray(response.data) ? response.data : (response.data.results || []);
 
             if (contacts.length === 0) {
@@ -138,16 +124,7 @@ module.exports = {
         if (content.companyId) params.company_id = content.companyId;
         if (content.tag) params.tag = content.tag;
 
-        const response = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/contacts`,
-            {
-                params,
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        const response = await apiCall(context, { url: '/contacts', params });
 
         const contacts = response.data || [];
 

--- a/src/appmixer/freshdesk/contacts/GetContact/GetContact.js
+++ b/src/appmixer/freshdesk/contacts/GetContact/GetContact.js
@@ -1,25 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { contactId } = context.messages.in.content;
 
         let data;
         try {
-            const response = await axios.get(
-                `https://${auth.domain}.freshdesk.com/api/v2/contacts/${contactId}`,
-                {
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
-                }
-            );
+            const response = await apiCall(context, { url: `/contacts/${contactId}` });
             data = response.data;
         } catch (err) {
             if (err.response?.status === 404) {

--- a/src/appmixer/freshdesk/contacts/ListContacts/ListContacts.js
+++ b/src/appmixer/freshdesk/contacts/ListContacts/ListContacts.js
@@ -1,26 +1,18 @@
 'use strict';
-const request = require('request-promise');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         let contacts;
 
         try {
-            contacts = await request({
-                method: 'GET',
-                url: `https://${auth.domain}.freshdesk.com/api/v2/contacts`,
-                auth: {
-                    user: auth.apiKey,
-                    password: 'X'
-                },
-                json: true
-            });
+            const { data } = await apiCall(context, { url: '/contacts' });
+            contacts = data;
         } catch (e) {
-            const body = e.response.body;
-            if (body.code === 'access_denied') {
+            const code = e.response?.data?.code || e.response?.body?.code;
+            if (code === 'access_denied') {
                 contacts = [];
             } else {
                 throw e;

--- a/src/appmixer/freshdesk/contacts/UpdateContact/UpdateContact.js
+++ b/src/appmixer/freshdesk/contacts/UpdateContact/UpdateContact.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const axios = require('axios');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const content = context.messages.in.content;
 
         const body = trimUndefined({
@@ -26,16 +24,11 @@ module.exports = {
             address: content.address
         });
 
-        const response = await axios.put(
-            `https://${auth.domain}.freshdesk.com/api/v2/contacts/${content.contactId}`,
-            body,
-            {
-                auth: {
-                    username: auth.apiKey,
-                    password: 'X'
-                }
-            }
-        );
+        const response = await apiCall(context, {
+            method: 'PUT',
+            url: `/contacts/${content.contactId}`,
+            data: body
+        });
 
         const data = response.data;
         return context.sendJson({

--- a/src/appmixer/freshdesk/lib.js
+++ b/src/appmixer/freshdesk/lib.js
@@ -3,6 +3,108 @@
 const pathModule = require('path');
 
 /**
+ * Authenticated Freshdesk API request via context.httpRequest (replaces the axios dependency).
+ * Centralizes base URL, Basic auth (apiKey:X) and default JSON content type so every component
+ * issues requests the same way. Returns the raw response ({ data, status, headers }) — the same
+ * shape call sites previously consumed from axios.
+ * @param {object} context - Appmixer component context
+ * @param {object} opts
+ * @param {string} [opts.method='GET'] - HTTP method
+ * @param {string} opts.url - absolute URL, or a path starting with '/' appended to the /api/v2 base
+ * @param {object} [opts.params] - query params
+ * @param {*} [opts.data] - request body (plain object or a form-data instance)
+ * @param {object} [opts.headers] - extra headers (e.g. formData.getHeaders())
+ * @param {string} [opts.responseType] - e.g. 'stream'
+ * @returns {Promise<object>} response with { data, status, headers }
+ */
+async function apiCall(context, { method = 'GET', url, params, data, headers = {}, responseType } = {}) {
+
+    const baseUrl = `https://${context.auth.domain}.freshdesk.com/api/v2`;
+    const targetUrl = /^https?:\/\//.test(url) ? url : `${baseUrl}${url}`;
+    const credentials = Buffer.from(`${context.auth.apiKey}:X`).toString('base64');
+    const hasContentType = Object.keys(headers).some(name => name.toLowerCase() === 'content-type');
+
+    const options = {
+        method,
+        url: targetUrl,
+        headers: {
+            Authorization: `Basic ${credentials}`,
+            ...(hasContentType ? {} : { 'Content-Type': 'application/json' }),
+            ...headers
+        }
+    };
+    if (params) options.params = params;
+    if (data !== undefined) options.data = data;
+    if (responseType) options.responseType = responseType;
+
+    return context.httpRequest(options);
+}
+
+/**
+ * Map a raw Freshdesk ticket into the output `fields` object emitted by the ticket triggers
+ * (NewTicket / UpdatedTicket). Single source of truth for the trigger output shape so the
+ * triggers and their test() methods can never drift apart.
+ * @param {object} ticket - raw ticket from the Freshdesk API
+ * @param {string[]} [normalizedEmbed] - embed fields requested by the component
+ * @returns {object}
+ */
+function mapTicket(ticket, normalizedEmbed = []) {
+
+    const fields = {
+        id: ticket.id,
+        createdAt: ticket.created_at,
+        updatedAt: ticket.updated_at,
+        dueBy: ticket.due_by,
+        frDueBy: ticket.fr_due_by,
+        subject: ticket.subject,
+        type: ticket.type,
+        source: ticket.source,
+        sourceInfo: ticket.source_info || null,
+        status: ticket.status,
+        priority: ticket.priority,
+        agentId: ticket.responder_id,
+        groupId: ticket.group_id,
+        emailConfigId: ticket.email_config_id,
+        productId: ticket.product_id,
+        tags: ticket.tags,
+        customFields: ticket.custom_fields,
+        ticketJson: ticket
+    };
+
+    if (normalizedEmbed.includes('requester') && ticket.requester) {
+        fields.requesterId = ticket.requester.id;
+        fields.requesterName = ticket.requester.name;
+        fields.requesterEmail = ticket.requester.email;
+    }
+    if (normalizedEmbed.includes('description')) {
+        fields.description = ticket.description_text;
+    }
+
+    return fields;
+}
+
+/**
+ * Fetch one page of tickets and map them to the trigger output shape. Shared by the polling
+ * triggers' tick() AND test() so the request, mapping and pagination parsing live in one place.
+ * @param {object} context
+ * @param {URLSearchParams|string} urlOrParams - query params (first page) or an absolute next-page URL
+ * @param {string[]} [normalizedEmbed]
+ * @returns {Promise<{ records: object[], nextUrl: (string|null) }>}
+ */
+async function requestTickets(context, urlOrParams, normalizedEmbed = []) {
+
+    const url = typeof urlOrParams === 'string'
+        ? urlOrParams
+        : `/tickets?${urlOrParams.toString()}`;
+
+    const res = await apiCall(context, { url });
+    const records = (res.data || []).map(ticket => mapTicket(ticket, normalizedEmbed));
+    const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
+
+    return { records, nextUrl: match ? match[1] : null };
+}
+
+/**
  * Remove undefined/null keys from body object.
  * Preserves falsy values like false, 0, and empty string.
  * @param {Object} body
@@ -100,6 +202,9 @@ async function sendArrayOutput({ context, records, outputType, defaultPrefix = '
 }
 
 module.exports = {
+    apiCall,
+    mapTicket,
+    requestTickets,
     trimUndefined,
     normalizeMultiselectInput,
     toCsv,

--- a/src/appmixer/freshdesk/package.json
+++ b/src/appmixer/freshdesk/package.json
@@ -2,11 +2,8 @@
     "name": "appmixer.freshdesk",
     "version": "1.2.0",
     "dependencies": {
-        "axios": "^0.19.2",
         "form-data": "^3.0.0",
         "mime-types": "^2.1.26",
-        "moment": "^2.26.0",
-        "request": "^2.83.0",
-        "request-promise": "^4.2.2"
+        "moment": "^2.26.0"
     }
 }

--- a/src/appmixer/freshdesk/solutionArticles/CreateArticle/CreateArticle.js
+++ b/src/appmixer/freshdesk/solutionArticles/CreateArticle/CreateArticle.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { folderId, title, description, status, tags } = context.messages.in.content;
 
         const body = { title, description };
         if (status !== undefined) body.status = status;
         if (tags) body.tags = tags.split(',').map(t => t.trim()).filter(Boolean);
 
-        const { data } = await axios.post(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/folders/${folderId}/articles`,
-            body,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            method: 'POST',
+            url: `/solutions/folders/${folderId}/articles`,
+            data: body
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionArticles/DeleteArticle/DeleteArticle.js
+++ b/src/appmixer/freshdesk/solutionArticles/DeleteArticle/DeleteArticle.js
@@ -1,18 +1,17 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { articleId } = context.messages.in.content;
 
-        await axios.delete(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/articles/${articleId}`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        await apiCall(context, {
+            method: 'DELETE',
+            url: `/solutions/articles/${articleId}`
+        });
 
         return context.sendJson({ id: articleId }, 'deleted');
     }

--- a/src/appmixer/freshdesk/solutionArticles/GetArticle/GetArticle.js
+++ b/src/appmixer/freshdesk/solutionArticles/GetArticle/GetArticle.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { articleId } = context.messages.in.content;
 
-        const { data } = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/articles/${articleId}`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            url: `/solutions/articles/${articleId}`
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionArticles/ListArticles/ListArticles.js
+++ b/src/appmixer/freshdesk/solutionArticles/ListArticles/ListArticles.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { folderId } = context.messages.in.content;
 
-        const { data } = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/folders/${folderId}/articles`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            url: `/solutions/folders/${folderId}/articles`
+        });
 
         return context.sendJson({ articles: data }, 'articles');
     }

--- a/src/appmixer/freshdesk/solutionArticles/UpdateArticle/UpdateArticle.js
+++ b/src/appmixer/freshdesk/solutionArticles/UpdateArticle/UpdateArticle.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { articleId, title, description, status, tags } = context.messages.in.content;
 
         const body = {};
@@ -15,11 +14,11 @@ module.exports = {
         if (status !== undefined) body.status = status;
         if (tags) body.tags = tags.split(',').map(t => t.trim()).filter(Boolean);
 
-        const { data } = await axios.put(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/articles/${articleId}`,
-            body,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            method: 'PUT',
+            url: `/solutions/articles/${articleId}`,
+            data: body
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionCategories/CreateCategory/CreateCategory.js
+++ b/src/appmixer/freshdesk/solutionCategories/CreateCategory/CreateCategory.js
@@ -1,22 +1,21 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { name, description } = context.messages.in.content;
 
         const body = { name };
         if (description) body.description = description;
 
-        const { data } = await axios.post(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories`,
-            body,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            method: 'POST',
+            url: '/solutions/categories',
+            data: body
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionCategories/DeleteCategory/DeleteCategory.js
+++ b/src/appmixer/freshdesk/solutionCategories/DeleteCategory/DeleteCategory.js
@@ -1,18 +1,17 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { categoryId } = context.messages.in.content;
 
-        await axios.delete(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories/${categoryId}`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        await apiCall(context, {
+            method: 'DELETE',
+            url: `/solutions/categories/${categoryId}`
+        });
 
         return context.sendJson({ id: categoryId }, 'deleted');
     }

--- a/src/appmixer/freshdesk/solutionCategories/GetCategory/GetCategory.js
+++ b/src/appmixer/freshdesk/solutionCategories/GetCategory/GetCategory.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { categoryId } = context.messages.in.content;
 
-        const { data } = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories/${categoryId}`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            url: `/solutions/categories/${categoryId}`
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionCategories/ListCategories/ListCategories.js
+++ b/src/appmixer/freshdesk/solutionCategories/ListCategories/ListCategories.js
@@ -1,17 +1,12 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
-
-        const { data } = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, { url: '/solutions/categories' });
 
         return context.sendJson({ categories: data }, 'categories');
     }

--- a/src/appmixer/freshdesk/solutionCategories/UpdateCategory/UpdateCategory.js
+++ b/src/appmixer/freshdesk/solutionCategories/UpdateCategory/UpdateCategory.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { categoryId, name, description } = context.messages.in.content;
 
         const body = {};
         if (name) body.name = name;
         if (description) body.description = description;
 
-        const { data } = await axios.put(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories/${categoryId}`,
-            body,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            method: 'PUT',
+            url: `/solutions/categories/${categoryId}`,
+            data: body
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionFolders/CreateFolder/CreateFolder.js
+++ b/src/appmixer/freshdesk/solutionFolders/CreateFolder/CreateFolder.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { categoryId, name, description, visibility } = context.messages.in.content;
 
         const body = { name };
         if (description !== undefined) body.description = description;
         if (visibility !== undefined) body.visibility = visibility;
 
-        const { data } = await axios.post(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories/${categoryId}/folders`,
-            body,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            method: 'POST',
+            url: `/solutions/categories/${categoryId}/folders`,
+            data: body
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionFolders/DeleteFolder/DeleteFolder.js
+++ b/src/appmixer/freshdesk/solutionFolders/DeleteFolder/DeleteFolder.js
@@ -1,18 +1,17 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { folderId } = context.messages.in.content;
 
-        await axios.delete(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/folders/${folderId}`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        await apiCall(context, {
+            method: 'DELETE',
+            url: `/solutions/folders/${folderId}`
+        });
 
         return context.sendJson({ id: folderId }, 'deleted');
     }

--- a/src/appmixer/freshdesk/solutionFolders/GetFolder/GetFolder.js
+++ b/src/appmixer/freshdesk/solutionFolders/GetFolder/GetFolder.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { folderId } = context.messages.in.content;
 
-        const { data } = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/folders/${folderId}`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            url: `/solutions/folders/${folderId}`
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/solutionFolders/ListFolders/ListFolders.js
+++ b/src/appmixer/freshdesk/solutionFolders/ListFolders/ListFolders.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { categoryId } = context.messages.in.content;
 
-        const { data } = await axios.get(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/categories/${categoryId}/folders`,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            url: `/solutions/categories/${categoryId}/folders`
+        });
 
         return context.sendJson({ folders: data }, 'folders');
     }

--- a/src/appmixer/freshdesk/solutionFolders/UpdateFolder/UpdateFolder.js
+++ b/src/appmixer/freshdesk/solutionFolders/UpdateFolder/UpdateFolder.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { folderId, name, description, visibility } = context.messages.in.content;
 
         const body = {};
@@ -14,11 +13,11 @@ module.exports = {
         if (description !== undefined) body.description = description;
         if (visibility !== undefined) body.visibility = visibility;
 
-        const { data } = await axios.put(
-            `https://${auth.domain}.freshdesk.com/api/v2/solutions/folders/${folderId}`,
-            body,
-            { auth: { username: auth.apiKey, password: 'X' } }
-        );
+        const { data } = await apiCall(context, {
+            method: 'PUT',
+            url: `/solutions/folders/${folderId}`,
+            data: body
+        });
 
         return context.sendJson({
             id: data.id,

--- a/src/appmixer/freshdesk/tickets/CreateNote/CreateNote.js
+++ b/src/appmixer/freshdesk/tickets/CreateNote/CreateNote.js
@@ -1,13 +1,11 @@
 'use strict';
-const axios = require('axios');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
         const { content } = context.messages.in;
-        const { auth } = context;
 
         const body = trimUndefined({
             body: content.body,
@@ -16,16 +14,12 @@ module.exports = {
             notify_emails: content.notifyEmails ? content.notifyEmails.split(',').map(e => e.trim()) : undefined
         });
 
-        const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets/${content.ticketId}/notes`;
-
-        const response = await axios.post(url, body, {
-            auth: {
-                username: auth.apiKey,
-                password: 'X'
-            }
+        const { data } = await apiCall(context, {
+            method: 'POST',
+            url: `/tickets/${content.ticketId}/notes`,
+            data: body
         });
 
-        const { data } = response;
         return context.sendJson({
             id: data.id,
             ticketId: data.ticket_id,

--- a/src/appmixer/freshdesk/tickets/CreateReply/CreateReply.js
+++ b/src/appmixer/freshdesk/tickets/CreateReply/CreateReply.js
@@ -1,13 +1,11 @@
 'use strict';
-const axios = require('axios');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
         const { content } = context.messages.in;
-        const { auth } = context;
 
         const body = trimUndefined({
             body: content.body,
@@ -16,16 +14,12 @@ module.exports = {
             bcc_emails: content.bccEmails ? content.bccEmails.split(',').map(e => e.trim()) : undefined
         });
 
-        const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets/${content.ticketId}/reply`;
-
-        const response = await axios.post(url, body, {
-            auth: {
-                username: auth.apiKey,
-                password: 'X'
-            }
+        const { data } = await apiCall(context, {
+            method: 'POST',
+            url: `/tickets/${content.ticketId}/reply`,
+            data: body
         });
 
-        const { data } = response;
         return context.sendJson({
             id: data.id,
             ticketId: data.ticket_id,

--- a/src/appmixer/freshdesk/tickets/CreateTicket/CreateTicket.js
+++ b/src/appmixer/freshdesk/tickets/CreateTicket/CreateTicket.js
@@ -1,8 +1,7 @@
 'use strict';
-const axios = require('axios');
 const FormData = require('form-data');
 const mime = require('mime-types');
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 
 module.exports = {
 
@@ -19,8 +18,6 @@ module.exports = {
             return context.sendJson({ attachmentId: file.fileId }, 'newTicket');
         } else {
             // Triggered from flow
-            const { auth } = context;
-
             let body = {
                 subject: content.subject,
                 description: content.description,
@@ -37,8 +34,6 @@ module.exports = {
                 responder_id: content.agentId,
                 tags: content.tags ? content.tags.split(',') : undefined
             };
-
-            const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets`;
 
             let response;
 
@@ -64,19 +59,17 @@ module.exports = {
                     }
                 });
 
-                response = await axios.post(url, formData, {
-                    headers: formData.getHeaders(),
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
+                response = await apiCall(context, {
+                    method: 'POST',
+                    url: '/tickets',
+                    data: formData,
+                    headers: formData.getHeaders()
                 });
             } else {
-                response = await axios.post(url, trimUndefined(body), {
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
+                response = await apiCall(context, {
+                    method: 'POST',
+                    url: '/tickets',
+                    data: trimUndefined(body)
                 });
             }
 

--- a/src/appmixer/freshdesk/tickets/DeleteTicket/DeleteTicket.js
+++ b/src/appmixer/freshdesk/tickets/DeleteTicket/DeleteTicket.js
@@ -1,19 +1,15 @@
 'use strict';
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { ticketId } = context.messages.in.content;
 
-        const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets/${ticketId}`;
-        await axios.delete(url, {
-            auth: {
-                username: auth.apiKey,
-                password: 'X'
-            }
+        await apiCall(context, {
+            method: 'DELETE',
+            url: `/tickets/${ticketId}`
         });
 
         return context.sendJson({ ticketId }, 'ticketId');

--- a/src/appmixer/freshdesk/tickets/DeletedTicket/DeletedTicket.js
+++ b/src/appmixer/freshdesk/tickets/DeletedTicket/DeletedTicket.js
@@ -1,16 +1,37 @@
 'use strict';
-const axios = require('axios');
+const { apiCall } = require('../../lib');
+
+function mapDeletedTicket(ticket) {
+    return {
+        id: ticket.id,
+        subject: ticket.subject,
+        deleted_at: ticket.updated_at,
+        ticketJson: ticket
+    };
+}
+
+// Shared by tick() and test(): fetch one page of deleted tickets, keep only the ones actually
+// flagged `deleted`, and map them to the trigger output shape. Centralizes the request, the
+// deleted-filter and the pagination parsing so tick() and test() stay in sync.
+async function requestDeletedTickets(context, urlOrParams) {
+
+    const url = typeof urlOrParams === 'string'
+        ? urlOrParams
+        : `/tickets?${urlOrParams.toString()}`;
+
+    const res = await apiCall(context, { url });
+    const records = (res.data || []).filter(ticket => ticket.deleted).map(mapDeletedTicket);
+    const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
+
+    return { records, nextUrl: match ? match[1] : null };
+}
 
 module.exports = {
 
     async tick(context) {
 
-        const { auth } = context;
         const state = context.state || {};
         const lookbackMs = 2 * 60 * 1000;
-
-        const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2/tickets`;
-        const authConfig = { username: auth.apiKey, password: 'X' };
 
         // Deleted tickets API supports updated_since too (filter=deleted)
         const cursorUpdatedAt = state.cursorUpdatedAt
@@ -21,27 +42,24 @@ module.exports = {
 
         const isFirstRun = !state.cursorUpdatedAt;
 
-        let nextUrl =
-            `${baseUrl}?filter=deleted` +
-            `&updated_since=${encodeURIComponent(from)}` +
-            '&order_by=updated_at&order_type=asc&per_page=100';
+        const params = new URLSearchParams({
+            filter: 'deleted',
+            updated_since: from,
+            order_by: 'updated_at',
+            order_type: 'asc',
+            per_page: '100'
+        });
 
+        let nextUrl = params;
         let maxUpdatedAt = state.cursorUpdatedAt || null;
         let maxTicketId = state.cursorTicketId || 0;
 
         while (nextUrl) {
-            const res = await axios.get(nextUrl, {
-                auth: authConfig,
-                validateStatus: s => s >= 200 && s < 300
-            });
+            const { records, nextUrl: next } = await requestDeletedTickets(context, nextUrl);
 
-            const tickets = res.data || [];
-
-            for (const ticket of tickets) {
-                const updatedAt = ticket.updated_at;
-                const ticketId = ticket.id;
-
-                if (!ticket.deleted) continue;
+            for (const fields of records) {
+                const updatedAt = fields.deleted_at;
+                const ticketId = fields.id;
 
                 // On the first run, skip emission entirely (baseline-only behavior).
                 const isAfterCursor =
@@ -52,12 +70,7 @@ module.exports = {
 
                 if (!isAfterCursor) continue;
 
-                await context.sendJson({
-                    id: ticket.id,
-                    subject: ticket.subject,
-                    deleted_at: ticket.updated_at,
-                    ticketJson: ticket
-                }, 'ticket');
+                await context.sendJson(fields, 'ticket');
 
                 if (
                     !maxUpdatedAt ||
@@ -69,13 +82,32 @@ module.exports = {
                 }
             }
 
-            const link = res.headers.link || '';
-            const match = link.match(/<([^>]+)>;\s*rel="next"/);
-            nextUrl = match ? match[1] : null;
+            nextUrl = next;
         }
 
         // Always persist cursor even when no results, to prevent gaps if polling interval exceeds lookback window.
         const cursorToSave = maxUpdatedAt || cursorUpdatedAt.toISOString();
         await context.saveState({ cursorUpdatedAt: cursorToSave, cursorTicketId: maxTicketId });
+    },
+
+    // Flow Test Mode: emit one realistic deleted ticket without starting the flow.
+    // Reuses requestDeletedTickets() — only the query differs (most recently deleted first,
+    // single page) and no cursor/state is touched.
+    async test(context) {
+
+        const params = new URLSearchParams({
+            filter: 'deleted',
+            order_by: 'updated_at',
+            order_type: 'desc',
+            per_page: '1'
+        });
+
+        const { records } = await requestDeletedTickets(context, params);
+
+        if (!records.length) {
+            throw new Error('No recent deleted tickets to use as test data.');
+        }
+
+        await context.sendJson(records[0], 'ticket');
     }
 };

--- a/src/appmixer/freshdesk/tickets/GetTicket/GetTicket.js
+++ b/src/appmixer/freshdesk/tickets/GetTicket/GetTicket.js
@@ -1,31 +1,24 @@
 'use strict';
-const axios = require('axios');
-const { normalizeMultiselectInput } = require('../../lib');
+const { apiCall, normalizeMultiselectInput } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { ticketId, embed } = context.messages.in.content;
 
         // Normalize the multiselect field
         const normalizedEmbed = embed ?
             normalizeMultiselectInput(embed, context, 'Embed fields') : [];
 
-        const requestObject = {
-            auth: {
-                username: auth.apiKey,
-                password: 'X'
-            }
-        };
+        const params = normalizedEmbed.length > 0
+            ? { include: normalizedEmbed.join(',') }
+            : undefined;
 
-        if (normalizedEmbed.length > 0) {
-            requestObject.params = { include: normalizedEmbed.join(',') };
-        }
-
-        const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets/${ticketId}`;
-        const { data } = await axios.get(url, requestObject);
+        const { data } = await apiCall(context, {
+            url: `/tickets/${ticketId}`,
+            params
+        });
 
         const fields = {
             id: data.id,

--- a/src/appmixer/freshdesk/tickets/ListTickets/ListTickets.js
+++ b/src/appmixer/freshdesk/tickets/ListTickets/ListTickets.js
@@ -1,6 +1,6 @@
 'use strict';
-const axios = require('axios');
 const moment = require('moment');
+const { apiCall } = require('../../lib');
 
 function joinOrClauses(orArray) {
 
@@ -60,38 +60,28 @@ module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { withFilters, limit, filters, allAtOnce } = context.messages.in.content;
-
-        const requestObject = {
-            auth: {
-                username: auth.apiKey,
-                password: 'X'
-            }
-        };
 
         const perPage = withFilters ? 30 : 100;
         const pages = limit ? Math.ceil(limit / perPage) : 1;
 
-        requestObject.params = {};
-
+        const params = {};
         let url;
 
         if (withFilters) {
-            const query = getQuery(filters);
-            url = `https://${auth.domain}.freshdesk.com/api/v2/search/tickets`;
-            requestObject.params.query = query;
+            url = '/search/tickets';
+            params.query = getQuery(filters);
         } else {
-            requestObject.params.per_page = perPage;
-            requestObject.params.updated_since = moment().subtract(30, 'years').format('YYYY-MM-DD');
-            url = `https://${auth.domain}.freshdesk.com/api/v2/tickets`;
+            url = '/tickets';
+            params.per_page = perPage;
+            params.updated_since = moment().subtract(30, 'years').format('YYYY-MM-DD');
         }
 
         let tickets = [];
 
         for (let i = 1; i <= pages; i++ ) {
-            requestObject.params.page = i;
-            let { data } = await axios.get(url, requestObject);
+            params.page = i;
+            let { data } = await apiCall(context, { url, params });
 
             if (!Array.isArray(data)) {
                 data = data.results;

--- a/src/appmixer/freshdesk/tickets/NewConversation/NewConversation.js
+++ b/src/appmixer/freshdesk/tickets/NewConversation/NewConversation.js
@@ -1,27 +1,59 @@
 'use strict';
-const axios = require('axios');
-const { normalizeMultiselectInput } = require('../../lib');
+const { apiCall, normalizeMultiselectInput } = require('../../lib');
+
+async function fetchConversations(context, ticketId) {
+    const res = await apiCall(context, {
+        url: `/tickets/${ticketId}/conversations`,
+        params: { per_page: 100 }
+    });
+    return Array.isArray(res.data) ? res.data : [];
+}
+
+async function fetchFullTicket(context, ticketId) {
+    const res = await apiCall(context, { url: `/tickets/${ticketId}` });
+    return res.data;
+}
+
+// Whether a conversation should be emitted given the component's include/ignore filters.
+// Shared by tick() and test() so both honor the exact same filtering.
+function isIncludedConversation(conv, includeTypes, ignoredAgentIds) {
+    const type = conv.private === true ? 'notes' : 'conversations';
+    if (!includeTypes.includes(type)) return false;
+    if (ignoredAgentIds.length > 0 && ignoredAgentIds.includes(conv.user_id)) return false;
+    return true;
+}
+
+// Build the trigger output object. Single source of truth for the output shape, shared by
+// tick() and test().
+function toConversationEvent(conv, conversations, ticket) {
+    return {
+        conversation: conv,
+        conversationType: conv.private === true ? 'note' : 'reply',
+        conversationsList: conversations,
+        ticket
+    };
+}
+
+function getFilters(context) {
+    const { ignoreAgents, include } = context.properties;
+    return {
+        ignoredAgentIds: ignoreAgents
+            ? normalizeMultiselectInput(ignoreAgents, context, 'Ignore agents').map(Number)
+            : [],
+        includeTypes: include
+            ? normalizeMultiselectInput(include, context, 'Include')
+            : ['conversations', 'notes']
+    };
+}
 
 module.exports = {
 
     async tick(context) {
 
-        const { auth } = context;
-        const { ignoreAgents, include } = context.properties;
-
-        const ignoredAgentIds = ignoreAgents
-            ? normalizeMultiselectInput(ignoreAgents, context, 'Ignore agents').map(Number)
-            : [];
-
-        const includeTypes = include
-            ? normalizeMultiselectInput(include, context, 'Include')
-            : ['conversations', 'notes'];
+        const { ignoredAgentIds, includeTypes } = getFilters(context);
 
         const state = context.state || {};
         const lookbackMs = 2 * 60 * 1000;
-
-        const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2`;
-        const authConfig = { username: auth.apiKey, password: 'X' };
 
         // flowStartedAt: set once on the very first tick. Any conversation created after this
         // timestamp on a ticket we're seeing for the first time is treated as new.
@@ -40,20 +72,21 @@ module.exports = {
 
         const from = new Date(cursorUpdatedAt.getTime() - lookbackMs).toISOString();
 
-        let nextUrl =
-            `${baseUrl}/tickets?updated_since=${encodeURIComponent(from)}` +
-            '&order_by=updated_at&order_type=asc&per_page=100';
+        const params = new URLSearchParams({
+            updated_since: from,
+            order_by: 'updated_at',
+            order_type: 'asc',
+            per_page: '100'
+        });
 
+        let nextUrl = `/tickets?${params.toString()}`;
         let maxUpdatedAt = state.cursorUpdatedAt || null;
         let maxTicketId = state.cursorTicketId || 0;
 
         const updatedTickets = [];
 
         while (nextUrl) {
-            const res = await axios.get(nextUrl, {
-                auth: authConfig,
-                validateStatus: s => s >= 200 && s < 300
-            });
+            const res = await apiCall(context, { url: nextUrl });
             const tickets = res.data || [];
 
             for (const ticket of tickets) {
@@ -79,8 +112,7 @@ module.exports = {
                 }
             }
 
-            const link = res.headers.link || '';
-            const match = link.match(/<([^>]+)>;\s*rel="next"/);
+            const match = (res.headers.link || '').match(/<([^>]+)>;\s*rel="next"/);
             nextUrl = match ? match[1] : null;
         }
 
@@ -90,11 +122,7 @@ module.exports = {
 
             let conversations;
             try {
-                const { data } = await axios.get(`${baseUrl}/tickets/${ticketId}/conversations`, {
-                    auth: authConfig,
-                    params: { per_page: 100 }
-                });
-                conversations = Array.isArray(data) ? data : [];
+                conversations = await fetchConversations(context, ticketId);
             } catch (err) {
                 continue;
             }
@@ -135,33 +163,18 @@ module.exports = {
 
             for (const conv of conversations) {
                 if (!isNewConv(conv)) continue;
-
-                // Filter by type
-                const isNote = conv.private === true;
-                const type = isNote ? 'notes' : 'conversations';
-                if (!includeTypes.includes(type)) continue;
-
-                // Filter out ignored agents
-                if (ignoredAgentIds.length > 0 && ignoredAgentIds.includes(conv.user_id)) continue;
+                if (!isIncludedConversation(conv, includeTypes, ignoredAgentIds)) continue;
 
                 if (!fetchedFullTicket) {
                     try {
-                        const { data: ticketDetail } = await axios.get(`${baseUrl}/tickets/${ticketId}`, {
-                            auth: authConfig
-                        });
-                        fullTicket = ticketDetail;
+                        fullTicket = await fetchFullTicket(context, ticketId);
                     } catch (err) {
                         // fallback to summary
                     }
                     fetchedFullTicket = true;
                 }
 
-                await context.sendJson({
-                    conversation: conv,
-                    conversationType: isNote ? 'note' : 'reply',
-                    conversationsList: conversations,
-                    ticket: fullTicket
-                }, 'out');
+                await context.sendJson(toConversationEvent(conv, conversations, fullTicket), 'out');
             }
 
             newKnownMaxConvId[ticketId] = newMaxId;
@@ -173,5 +186,34 @@ module.exports = {
             cursorTicketId: maxTicketId,
             knownMaxConvId: newKnownMaxConvId
         });
+    },
+
+    // Flow Test Mode: emit one realistic conversation event without starting the flow.
+    // Reuses the same fetch/filter/shape helpers as tick(): grabs the most recently updated
+    // ticket, picks its newest conversation matching the filters, and emits it. No state touched.
+    async test(context) {
+
+        const { ignoredAgentIds, includeTypes } = getFilters(context);
+
+        const listRes = await apiCall(context, {
+            url: '/tickets?order_by=updated_at&order_type=desc&per_page=1'
+        });
+        const ticketSummary = (listRes.data || [])[0];
+        if (!ticketSummary) {
+            throw new Error('No tickets to use as test data.');
+        }
+
+        const conversations = await fetchConversations(context, ticketSummary.id);
+        const conv = conversations
+            .filter(c => isIncludedConversation(c, includeTypes, ignoredAgentIds))
+            .sort((a, b) => b.id - a.id)[0];
+
+        if (!conv) {
+            throw new Error('No recent conversations to use as test data.');
+        }
+
+        const fullTicket = await fetchFullTicket(context, ticketSummary.id);
+
+        await context.sendJson(toConversationEvent(conv, conversations, fullTicket), 'out');
     }
 };

--- a/src/appmixer/freshdesk/tickets/NewTicket/NewTicket.js
+++ b/src/appmixer/freshdesk/tickets/NewTicket/NewTicket.js
@@ -1,22 +1,19 @@
 'use strict';
-const axios = require('axios');
-const { normalizeMultiselectInput } = require('../../lib');
+const { normalizeMultiselectInput, requestTickets } = require('../../lib');
+
+function getNormalizedEmbed(context) {
+    const { embed } = context.properties;
+    return embed ? normalizeMultiselectInput(embed, context, 'Embed fields') : [];
+}
 
 module.exports = {
 
     async tick(context) {
 
-        const { auth } = context;
-        const { embed } = context.properties;
-        const normalizedEmbed = embed
-            ? normalizeMultiselectInput(embed, context, 'Embed fields')
-            : [];
+        const normalizedEmbed = getNormalizedEmbed(context);
 
         const state = context.state || {};
         const lookbackMs = 2 * 60 * 1000;
-
-        const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2/tickets`;
-        const authConfig = { username: auth.apiKey, password: 'X' };
 
         // Cursor is based on created_at — we only want genuinely new tickets.
         // initialCursorCreatedAt is used as the fallback state so that on the first tick
@@ -42,21 +39,16 @@ module.exports = {
 
         const isFirstRun = !state.cursorCreatedAt;
 
-        let nextUrl = `${baseUrl}?${params.toString()}`;
+        let nextUrl = params;
         let maxCreatedAt = state.cursorCreatedAt || initialCursorCreatedAt;
         let maxTicketId = state.cursorTicketId || 0;
 
         while (nextUrl) {
-            const res = await axios.get(nextUrl, {
-                auth: authConfig,
-                validateStatus: s => s >= 200 && s < 300
-            });
+            const { records, nextUrl: next } = await requestTickets(context, nextUrl, normalizedEmbed);
 
-            const tickets = res.data || [];
-
-            for (const ticket of tickets) {
-                const createdAt = ticket.created_at;
-                const ticketId = ticket.id;
+            for (const fields of records) {
+                const createdAt = fields.createdAt;
+                const ticketId = fields.id;
 
                 // Only emit tickets created after the cursor (tie-break on id)
                 // On the first run, skip emission entirely (baseline-only behavior)
@@ -67,36 +59,6 @@ module.exports = {
                     );
 
                 if (!isNew) continue;
-
-                const fields = {
-                    id: ticket.id,
-                    createdAt: ticket.created_at,
-                    updatedAt: ticket.updated_at,
-                    dueBy: ticket.due_by,
-                    frDueBy: ticket.fr_due_by,
-                    subject: ticket.subject,
-                    type: ticket.type,
-                    source: ticket.source,
-                    sourceInfo: ticket.source_info || null,
-                    status: ticket.status,
-                    priority: ticket.priority,
-                    agentId: ticket.responder_id,
-                    groupId: ticket.group_id,
-                    emailConfigId: ticket.email_config_id,
-                    productId: ticket.product_id,
-                    tags: ticket.tags,
-                    customFields: ticket.custom_fields,
-                    ticketJson: ticket
-                };
-
-                if (normalizedEmbed.includes('requester') && ticket.requester) {
-                    fields.requesterId = ticket.requester.id;
-                    fields.requesterName = ticket.requester.name;
-                    fields.requesterEmail = ticket.requester.email;
-                }
-                if (normalizedEmbed.includes('description')) {
-                    fields.description = ticket.description_text;
-                }
 
                 await context.sendJson(fields, 'ticket');
 
@@ -110,11 +72,34 @@ module.exports = {
                 }
             }
 
-            const link = res.headers.link || '';
-            const match = link.match(/<([^>]+)>;\s*rel="next"/);
-            nextUrl = match ? match[1] : null;
+            nextUrl = next;
         }
 
         await context.saveState({ cursorCreatedAt: maxCreatedAt, cursorTicketId: maxTicketId });
+    },
+
+    // Flow Test Mode: emit one realistic ticket without starting the flow.
+    // Reuses the same requestTickets()/mapTicket() path as tick() — the only difference
+    // is the query (newest first, single page) and that no cursor/state is touched.
+    async test(context) {
+
+        const normalizedEmbed = getNormalizedEmbed(context);
+
+        const params = new URLSearchParams({
+            order_by: 'created_at',
+            order_type: 'desc',
+            per_page: '1'
+        });
+        if (normalizedEmbed.length > 0) {
+            params.set('include', normalizedEmbed.join(','));
+        }
+
+        const { records } = await requestTickets(context, params, normalizedEmbed);
+
+        if (!records.length) {
+            throw new Error('No recent tickets to use as test data.');
+        }
+
+        await context.sendJson(records[0], 'ticket');
     }
 };

--- a/src/appmixer/freshdesk/tickets/RestoreTicket/RestoreTicket.js
+++ b/src/appmixer/freshdesk/tickets/RestoreTicket/RestoreTicket.js
@@ -1,19 +1,16 @@
 'use strict';
-const axios = require('axios');
+const { apiCall } = require('../../lib');
 
 module.exports = {
 
     async receive(context) {
 
-        const { auth } = context;
         const { ticketId } = context.messages.in.content;
 
-        const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets/${ticketId}/restore`;
-        await axios.put(url, {}, {
-            auth: {
-                username: auth.apiKey,
-                password: 'X'
-            }
+        await apiCall(context, {
+            method: 'PUT',
+            url: `/tickets/${ticketId}/restore`,
+            data: {}
         });
 
         return context.sendJson({ ticketId }, 'ticketId');

--- a/src/appmixer/freshdesk/tickets/UpdateTicket/UpdateTicket.js
+++ b/src/appmixer/freshdesk/tickets/UpdateTicket/UpdateTicket.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const { trimUndefined } = require('../../lib');
+const { apiCall, trimUndefined } = require('../../lib');
 const mime = require('mime-types');
-const axios = require('axios');
 const FormData = require('form-data');
 
 module.exports = {
@@ -20,8 +19,6 @@ module.exports = {
             return context.sendJson({ attachmentId: file.fileId }, 'updatedTicket');
         } else {
             // Triggered from flow
-            const { auth } = context;
-
             let body = {
                 subject: content.subject,
                 description: content.description,
@@ -38,8 +35,6 @@ module.exports = {
                 responder_id: content.agentId,
                 tags: content.tags ? content.tags.split(',') : undefined
             };
-
-            const url = `https://${auth.domain}.freshdesk.com/api/v2/tickets/${content.ticketId}`;
 
             let response;
 
@@ -65,19 +60,17 @@ module.exports = {
                     }
                 });
 
-                response = await axios.put(url, formData, {
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    },
+                response = await apiCall(context, {
+                    method: 'PUT',
+                    url: `/tickets/${content.ticketId}`,
+                    data: formData,
                     headers: formData.getHeaders()
                 });
             } else {
-                response = await axios.put(url, trimUndefined(body), {
-                    auth: {
-                        username: auth.apiKey,
-                        password: 'X'
-                    }
+                response = await apiCall(context, {
+                    method: 'PUT',
+                    url: `/tickets/${content.ticketId}`,
+                    data: trimUndefined(body)
                 });
             }
 

--- a/src/appmixer/freshdesk/tickets/UpdatedTicket/UpdatedTicket.js
+++ b/src/appmixer/freshdesk/tickets/UpdatedTicket/UpdatedTicket.js
@@ -1,22 +1,19 @@
 'use strict';
-const axios = require('axios');
-const { normalizeMultiselectInput } = require('../../lib');
+const { normalizeMultiselectInput, requestTickets } = require('../../lib');
+
+function getNormalizedEmbed(context) {
+    const { embed } = context.properties;
+    return embed ? normalizeMultiselectInput(embed, context, 'Embed fields') : [];
+}
 
 module.exports = {
 
     async tick(context) {
 
-        const { auth } = context;
-        const { embed } = context.properties;
-        const normalizedEmbed = embed
-            ? normalizeMultiselectInput(embed, context, 'Embed fields')
-            : [];
+        const normalizedEmbed = getNormalizedEmbed(context);
 
         const state = context.state || {};
         const lookbackMs = 2 * 60 * 1000;
-
-        const baseUrl = `https://${auth.domain}.freshdesk.com/api/v2/tickets`;
-        const authConfig = { username: auth.apiKey, password: 'X' };
 
         const cursorUpdatedAt = state.cursorUpdatedAt
             ? new Date(state.cursorUpdatedAt)
@@ -37,21 +34,16 @@ module.exports = {
 
         const isFirstRun = !state.cursorUpdatedAt;
 
-        let nextUrl = `${baseUrl}?${params.toString()}`;
+        let nextUrl = params;
         let maxUpdatedAt = state.cursorUpdatedAt || null;
         let maxTicketId = state.cursorTicketId || 0;
 
         while (nextUrl) {
-            const res = await axios.get(nextUrl, {
-                auth: authConfig,
-                validateStatus: s => s >= 200 && s < 300
-            });
+            const { records, nextUrl: next } = await requestTickets(context, nextUrl, normalizedEmbed);
 
-            const tickets = res.data || [];
-
-            for (const ticket of tickets) {
-                const updatedAt = ticket.updated_at;
-                const ticketId = ticket.id;
+            for (const fields of records) {
+                const updatedAt = fields.updatedAt;
+                const ticketId = fields.id;
 
                 // Strict cursor check with tie-breaker on id.
                 // On the first run, skip emission entirely (baseline-only behavior).
@@ -62,36 +54,6 @@ module.exports = {
                     );
 
                 if (!isAfterCursor) continue;
-
-                const fields = {
-                    id: ticket.id,
-                    createdAt: ticket.created_at,
-                    updatedAt: ticket.updated_at,
-                    dueBy: ticket.due_by,
-                    frDueBy: ticket.fr_due_by,
-                    subject: ticket.subject,
-                    type: ticket.type,
-                    source: ticket.source,
-                    sourceInfo: ticket.source_info || null,
-                    status: ticket.status,
-                    priority: ticket.priority,
-                    agentId: ticket.responder_id,
-                    groupId: ticket.group_id,
-                    emailConfigId: ticket.email_config_id,
-                    productId: ticket.product_id,
-                    tags: ticket.tags,
-                    customFields: ticket.custom_fields,
-                    ticketJson: ticket
-                };
-
-                if (normalizedEmbed.includes('requester') && ticket.requester) {
-                    fields.requesterId = ticket.requester.id;
-                    fields.requesterName = ticket.requester.name;
-                    fields.requesterEmail = ticket.requester.email;
-                }
-                if (normalizedEmbed.includes('description')) {
-                    fields.description = ticket.description_text;
-                }
 
                 await context.sendJson(fields, 'ticket');
 
@@ -105,13 +67,36 @@ module.exports = {
                 }
             }
 
-            const link = res.headers.link || '';
-            const match = link.match(/<([^>]+)>;\s*rel="next"/);
-            nextUrl = match ? match[1] : null;
+            nextUrl = next;
         }
 
         // Always persist cursor even when no results, to prevent gaps if polling interval exceeds lookback window.
         const cursorToSave = maxUpdatedAt || cursorUpdatedAt.toISOString();
         await context.saveState({ cursorUpdatedAt: cursorToSave, cursorTicketId: maxTicketId });
+    },
+
+    // Flow Test Mode: emit one realistic ticket without starting the flow.
+    // Reuses the same requestTickets()/mapTicket() path as tick() — the only difference
+    // is the query (most recently updated first, single page) and that no cursor/state is touched.
+    async test(context) {
+
+        const normalizedEmbed = getNormalizedEmbed(context);
+
+        const params = new URLSearchParams({
+            order_by: 'updated_at',
+            order_type: 'desc',
+            per_page: '1'
+        });
+        if (normalizedEmbed.length > 0) {
+            params.set('include', normalizedEmbed.join(','));
+        }
+
+        const { records } = await requestTickets(context, params, normalizedEmbed);
+
+        if (!records.length) {
+            throw new Error('No recent tickets to use as test data.');
+        }
+
+        await context.sendJson(records[0], 'ticket');
     }
 };

--- a/src/appmixer/google/gmail/NewAttachment/NewAttachment.js
+++ b/src/appmixer/google/gmail/NewAttachment/NewAttachment.js
@@ -25,17 +25,7 @@ module.exports = {
             }
 
             return Promise.map(email.attachments || [], async (attachment) => {
-                const out = {
-                    email,
-                    attachment
-                };
-                if (download) {
-                    const savedFile = await downloadAttachment(context, email.id, attachment.id, attachment.filename);
-                    out.fileId = savedFile.fileId;
-                    out.filename = savedFile.filename;
-                    out.contentType = savedFile.contentType;
-                }
-                output.push(out);
+                output.push(await buildOutput(context, email, attachment, download));
             });
         });
 
@@ -43,7 +33,44 @@ module.exports = {
         if (JSON.stringify(state != JSON.stringify(newState))) {
             return context.saveState(newState);
         }
+    },
+
+    // Flow Test Mode: emit one realistic attachment without starting the flow. Builds the same
+    // query as tick() (user query + has:attachment), honors the inbox filter and the download
+    // property, and shapes the output through the same buildOutput() helper.
+    async test(context) {
+
+        const { download } = context.properties;
+        let query = context.properties.query;
+        query = (query ? query + ' AND ' : '') + 'has:attachment';
+
+        const email = await emailCommons.fetchLatestExample(context, query);
+        if (!email || !(email.attachments || []).length) {
+            throw new Error('No recent emails with attachments matching the query to use as test data.');
+        }
+        if (!emailCommons.isNewInboxEmail(email.labelIds || [])) {
+            throw new Error('The most recent matching email is a SENT or DRAFT email.');
+        }
+
+        const out = await buildOutput(context, email, email.attachments[0], download);
+        return context.sendJson(out, 'attachment');
     }
+};
+
+// Build one output record ({ email, attachment, [fileId, filename, contentType] }).
+// Shared by tick() and test() so the output shape lives in one place.
+const buildOutput = async (context, email, attachment, download) => {
+    const out = {
+        email,
+        attachment
+    };
+    if (download) {
+        const savedFile = await downloadAttachment(context, email.id, attachment.id, attachment.filename);
+        out.fileId = savedFile.fileId;
+        out.filename = savedFile.filename;
+        out.contentType = savedFile.contentType;
+    }
+    return out;
 };
 
 const downloadAttachment = async (context, emailId, attachmentId, filename) => {

--- a/src/appmixer/google/gmail/NewEmail/NewEmail.js
+++ b/src/appmixer/google/gmail/NewEmail/NewEmail.js
@@ -13,5 +13,18 @@ module.exports = {
         if (JSON.stringify(state != JSON.stringify(newState))) {
             return context.saveState(newState);
         }
+    },
+
+    // Flow Test Mode: emit one realistic email without starting the flow.
+    // Thin wrapper over the same lib helpers tick() uses (fetchMessage/normalizeEmail) — the
+    // only difference is it fetches the latest message matching `query` and touches no state.
+    async test(context) {
+
+        const { query } = context.properties;
+        const email = await emailCommons.fetchLatestExample(context, query);
+        if (!email) {
+            throw new Error('No recent emails matching the query to use as test data.');
+        }
+        return context.sendJson(email, 'out');
     }
 };

--- a/src/appmixer/google/gmail/NewLabel/NewLabel.js
+++ b/src/appmixer/google/gmail/NewLabel/NewLabel.js
@@ -33,5 +33,21 @@ module.exports = {
                 return context.sendJson(label, 'out');
             });
         }
+    },
+
+    // Flow Test Mode: emit one realistic label without starting the flow. Same list call and
+    // item shape as tick(); prefers a user-created label since that's what the trigger
+    // detects in production (system labels never appear as "new").
+    async test(context) {
+
+        const listLabels = await emailCommons.callEndpoint(context, '/users/me/labels', {
+            method: 'GET'
+        }).then(response => response.data.labels || []);
+
+        const sample = listLabels.filter(label => label.type === 'user').pop() || listLabels.pop();
+        if (!sample) {
+            throw new Error('No labels to use as test data.');
+        }
+        return context.sendJson(sample, 'out');
     }
 };

--- a/src/appmixer/google/gmail/NewStarredEmail/NewStarredEmail.js
+++ b/src/appmixer/google/gmail/NewStarredEmail/NewStarredEmail.js
@@ -50,5 +50,16 @@ module.exports = {
                 await context.sendJson(emailCommons.normalizeEmail(email), 'out');
             });
         }
+    },
+
+    // Flow Test Mode: emit one realistic starred email without starting the flow.
+    // Reuses lib.fetchLatestExample/fetchMessage (normalizeEmail) — same shape as tick().
+    async test(context) {
+
+        const email = await emailCommons.fetchLatestExample(context, 'is:starred');
+        if (!email) {
+            throw new Error('No starred emails to use as test data.');
+        }
+        return context.sendJson(email, 'out');
     }
 };

--- a/src/appmixer/google/gmail/bundle.json
+++ b/src/appmixer/google/gmail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.google.gmail",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -61,6 +61,9 @@
         ],
         "3.0.0": [
             "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs (body remains textarea/JSON to support nested structures) per standard #1459 — existing flows that used the old string/textarea headers or parameters must be updated"
+        ],
+        "3.1.0": [
+            "Added test() (Flow Test Mode) to all triggers: NewEmail, NewAttachment, NewLabel, NewStarredEmail — emit one realistic item via a read-only call, reusing the same lib helpers as tick()."
         ]
     }
 }

--- a/src/appmixer/google/gmail/lib.js
+++ b/src/appmixer/google/gmail/lib.js
@@ -190,6 +190,40 @@ module.exports = {
         return labelIds.length !== 1 || (labelIds.indexOf('SENT') === -1 && labelIds.indexOf('DRAFT') === -1);
     },
 
+    // Fetch a single full message by ID and normalize it to the trigger output shape.
+    // Shared by listNewMessages() (per-message fetch) and fetchLatestExample()/test() so the
+    // output is produced in exactly one place. Returns null if the message was deleted
+    // (permanently) between listing and fetching — Gmail returns 404 in that race.
+    async fetchMessage(context, id) {
+
+        try {
+            const response = await this.callEndpoint(context, `/users/me/messages/${id}`, {
+                method: 'GET',
+                params: { format: 'full' }
+            });
+            return this.normalizeEmail(response.data);
+        } catch (err) {
+            if (err?.response?.status === 404) {
+                return null;
+            }
+            throw err;
+        }
+    },
+
+    // Fetch the single most recent message matching `query`, normalized to the same shape
+    // tick() emits. Read-only, touches no state — used by NewEmail.test() for Flow Test Mode.
+    async fetchLatestExample(context, query) {
+
+        const response = await this.callEndpoint(context, '/users/me/messages', {
+            params: { maxResults: 1, q: query || '' }
+        });
+        const message = (response.data.messages || [])[0];
+        if (!message) {
+            return null;
+        }
+        return this.fetchMessage(context, message.id);
+    },
+
     async listNewMessages(context, query, state) {
 
         const newState = {};
@@ -254,22 +288,11 @@ module.exports = {
         }
 
         // Fetch the full email data for new messages.
-        let emails = await Promise.map(messages, async (message) => {
-            try {
-                const response = await this.callEndpoint(context, `/users/me/messages/${message.id}`, {
-                    method: 'GET',
-                    params: { format: 'full' }
-                });
-                return this.normalizeEmail(response.data);
-            } catch (err) {
-                // email can be deleted (permanently) in gmail between listNewMessages call and
-                // this getMessage call, in such case - ignore it and return null.
-                if (err?.response?.status === 404) {
-                    return null;
-                }
-                throw err;
-            }
-        }, { concurrency: 10 });
+        let emails = await Promise.map(
+            messages,
+            (message) => this.fetchMessage(context, message.id),
+            { concurrency: 10 }
+        );
 
         // Update the state with the latest message ID.
         const lastMessage = emails[0];

--- a/src/appmixer/slack/bundle.json
+++ b/src/appmixer/slack/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.slack",
-    "version": "5.2.0",
+    "version": "5.3.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.1": [
@@ -58,6 +58,9 @@
         "5.1.4": [
             "Added output examples to component schemas."
         ],
-        "5.2.0": "ListChannels: make component public; add output port schema for channels."
+        "5.2.0": "ListChannels: make component public; add output port schema for channels.",
+        "5.3.0": [
+            "Added test() (Flow Test Mode) to all triggers: NewChannelMessage, NewPrivateChannelMessage, NewChannelMessageRT, NewUser, NewUserWebhook — emit one realistic item via a read-only call, same shape as production output."
+        ]
     }
 }

--- a/src/appmixer/slack/list/NewChannelMessage/NewChannelMessage.js
+++ b/src/appmixer/slack/list/NewChannelMessage/NewChannelMessage.js
@@ -62,6 +62,23 @@ module.exports = {
         }));
 
         await context.saveState({ since });
+    },
+
+    // Flow Test Mode: emit one realistic channel message without starting the flow.
+    // Same conversations.history call and message shape as tick(); no state touched.
+    async test(context) {
+
+        const { channelId } = context.properties;
+        const web = new WebClient(context.auth.accessToken);
+
+        const { messages } = await web.conversations.history({ channel: channelId, limit: 1 });
+        const sample = (messages || [])[0];
+        if (!sample) {
+            throw new Error('No recent messages in the channel to use as test data.');
+        }
+
+        sample.text = new Entities().decode(sample.text);
+        return context.sendJson(sample, 'message');
     }
 };
 

--- a/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
+++ b/src/appmixer/slack/list/NewChannelMessageRT/NewChannelMessageRT.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { WebClient } = require('@slack/web-api');
+const Entities = require('html-entities').AllHtmlEntities;
+
 module.exports = {
 
     async start(context) {
@@ -31,5 +34,27 @@ module.exports = {
             }
             await context.sendJson(context.messages.webhook.content.data, 'message');
         }
+    },
+
+    // Flow Test Mode: emit one realistic channel message without registering the app webhook.
+    // This plugin trigger normally receives events via context.addListener; test() instead fetches
+    // the latest message through the same Slack conversations.history call the polling
+    // NewChannelMessage trigger uses, and honors the same ignoreBotMessages filter as receive().
+    async test(context) {
+
+        const { channelId, ignoreBotMessages } = context.properties;
+        const web = new WebClient(context.auth.accessToken);
+
+        const { messages } = await web.conversations.history({ channel: channelId, limit: 1 });
+        const sample = (messages || [])[0];
+        if (!sample) {
+            throw new Error('No recent messages in the channel to use as test data.');
+        }
+        if (ignoreBotMessages && sample.subtype === 'bot_message') {
+            throw new Error('The most recent message is a bot message.');
+        }
+
+        sample.text = new Entities().decode(sample.text);
+        return context.sendJson(sample, 'message');
     }
 };

--- a/src/appmixer/slack/list/NewPrivateChannelMessage/NewPrivateChannelMessage.js
+++ b/src/appmixer/slack/list/NewPrivateChannelMessage/NewPrivateChannelMessage.js
@@ -65,6 +65,23 @@ module.exports = {
 
 
         await context.saveState({ since });
+    },
+
+    // Flow Test Mode: emit one realistic private channel message without starting the flow.
+    // Same conversations.history call and message shape as tick(); no state touched.
+    async test(context) {
+
+        const { channelId } = context.properties;
+        const web = new WebClient(context.auth.accessToken);
+
+        const { messages } = await web.conversations.history({ channel: channelId, limit: 1 });
+        const sample = (messages || [])[0];
+        if (!sample) {
+            throw new Error('No recent messages in the channel to use as test data.');
+        }
+
+        sample.text = new Entities().decode(sample.text);
+        return context.sendJson(sample, 'message');
     }
 };
 

--- a/src/appmixer/slack/list/NewUser/NewUser.js
+++ b/src/appmixer/slack/list/NewUser/NewUser.js
@@ -41,6 +41,22 @@ module.exports = {
             }
         }
         await context.saveState({ known: Array.from(actual) });
+    },
+
+    // Flow Test Mode: emit one realistic user without starting the flow. Same users.list call
+    // and user shape as tick(); picks the most recently updated active member. No state touched.
+    async test(context) {
+
+        const web = new WebClient(context.auth.accessToken);
+        const { members } = await web.users.list({ limit: 999 });
+
+        const sample = (members || [])
+            .filter(member => !member.deleted)
+            .sort((a, b) => (b.updated || 0) - (a.updated || 0))[0];
+        if (!sample) {
+            throw new Error('No users to use as test data.');
+        }
+        return context.sendJson(sample, 'user');
     }
 };
 

--- a/src/appmixer/slack/list/NewUserWebhook/NewUserWebhook.js
+++ b/src/appmixer/slack/list/NewUserWebhook/NewUserWebhook.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { WebClient } = require('@slack/web-api');
+
 module.exports = {
 
     async start(context) {
@@ -24,5 +26,22 @@ module.exports = {
             // `data` contains `user` object from Slack API
             await context.sendJson(context.messages.webhook.content.data, 'user');
         }
+    },
+
+    // Flow Test Mode: emit one realistic user without registering the app webhook. The
+    // team_join listener delivers the raw Slack user object, so fetching the most recently
+    // updated active member via users.list produces the same shape receive() emits.
+    async test(context) {
+
+        const web = new WebClient(context.auth.accessToken);
+        const { members } = await web.users.list({ limit: 999 });
+
+        const sample = (members || [])
+            .filter(member => !member.deleted)
+            .sort((a, b) => (b.updated || 0) - (a.updated || 0))[0];
+        if (!sample) {
+            throw new Error('No users to use as test data.');
+        }
+        return context.sendJson(sample, 'user');
     }
 };

--- a/src/appmixer/utils/forms/FormTrigger/FormTrigger.js
+++ b/src/appmixer/utils/forms/FormTrigger/FormTrigger.js
@@ -54,5 +54,40 @@ module.exports = {
                 return context.response(successPage, 200, { 'Content-Type': 'text/html' });
             }
         }
+    },
+
+    // Flow Test Mode: emit one plausible form entry without waiting for a real submission.
+    // Mirrors what a POST submission produces: keys are 'field_<index>', values are strings
+    // (HTML forms submit strings) except checkbox, which receive() normalizes to a boolean.
+    // Prefers the field's configured defaultValue for realism.
+    test(context) {
+
+        const fields = (context.properties.fields && context.properties.fields.ADD) || [];
+        if (!fields.length) {
+            throw new Error('No form fields defined.');
+        }
+
+        const entry = {};
+        fields.forEach((field, index) => {
+            const name = 'field_' + index;
+            if (field.type === 'checkbox') {
+                entry[name] = true;
+                return;
+            }
+            if (field.defaultValue) {
+                entry[name] = field.defaultValue;
+                return;
+            }
+            switch (field.type) {
+                case 'number': entry[name] = '42'; break;
+                case 'date': entry[name] = '2026-01-01'; break;
+                case 'email': entry[name] = 'user@example.com'; break;
+                case 'color': entry[name] = '#336699'; break;
+                case 'password': entry[name] = 'secret'; break;
+                default: entry[name] = field.label || 'Sample text';
+            }
+        });
+
+        return context.sendJson(entry, 'entry');
     }
 };

--- a/src/appmixer/utils/forms/bundle.json
+++ b/src/appmixer/utils/forms/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.forms",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -16,6 +16,9 @@
         ],
         "1.1.2": [
             "FormTrigger: declare all configuration inputs (logo, title, description, fields, cta, thanksMessage, thanksImage, script, stylesheet) in properties.schema.properties to match the inspector."
+        ],
+        "1.2.0": [
+            "FormTrigger: added test() (Flow Test Mode) — emits one plausible form entry synthesized from the configured fields (prefers defaultValue), without waiting for a real submission."
         ]
     }
 }

--- a/src/appmixer/utils/timers/SchedulerTrigger/SchedulerTrigger.js
+++ b/src/appmixer/utils/timers/SchedulerTrigger/SchedulerTrigger.js
@@ -31,6 +31,30 @@ module.exports = {
         return this.scheduleJob(context, { now, previousDate: null, firstTime: true });
     },
 
+    // Flow Test Mode: emit one well-formed schedule payload without setting any timeout or
+    // touching state. Reuses the same getNextRun() computation start()/receive() use, so the
+    // output shape and the schedule semantics can never drift from production.
+    async test(context) {
+
+        const { timezone = 'GMT' } = context.properties;
+        if (timezone && !isValidTimezone(timezone)) {
+            throw new context.CancelError('Invalid timezone');
+        }
+
+        const now = moment().toISOString();
+        const nextDate = this.getNextRun(context, { now, previousDate: null, firstTime: true });
+        if (!nextDate) {
+            throw new Error('No next run within the configured schedule (end date reached).');
+        }
+
+        return context.sendJson({
+            previousDate: null,
+            nextDateGMT: nextDate.toISOString(),
+            nextDateLocal: moment(nextDate).tz(timezone).format('YYYY-MM-DDTHH:mm:ss.SSS'),
+            timezone
+        }, 'out');
+    },
+
     /**
      *
      * @param context

--- a/src/appmixer/utils/timers/bundle.json
+++ b/src/appmixer/utils/timers/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.timers",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -24,6 +24,9 @@
         ],
         "1.3.0": [
             "Implemented multiselect input normalization for SchedulerTrigger daysOfWeek and daysOfMonth fields."
+        ],
+        "1.4.0": [
+            "SchedulerTrigger: added test() (Flow Test Mode) — emits one well-formed schedule payload via the same getNextRun() computation, without setting timeouts or touching state."
         ]
     }
 }


### PR DESCRIPTION
## What

Adds a `test(context)` method (Flow Test Mode) to **all triggers** in four connectors and ships the **`connector-test-method` skill + slash command** so customers can implement `test()` in their custom connectors.

In Flow Test Mode the engine skips `start()/stop()/tick()` and resolves trigger output via a fallback chain (`test()` → log search → schema samples). Schema samples produce synthetic IDs that downstream components reject, so `test()` — one read-only fetch of the newest real item — is what makes Test Mode actually useful.

## Core principle

`test()` **shares the request + mapping code** with `tick()`/`receive()` — it's a thin wrapper, never a parallel implementation, so the test output can't drift from production shape.

## Triggers covered (17)

| Connector | Triggers | Approach |
|-----------|----------|----------|
| **freshdesk** (2.1.0) | NewTicket, UpdatedTicket, DeletedTicket, NewConversation | shared `lib.requestTickets`/`mapTicket`, newest-first query |
| **google.gmail** (3.1.0) | NewEmail, NewAttachment, NewLabel, NewStarredEmail | shared `lib.fetchMessage`/`fetchLatestExample` (reused by `listNewMessages`) |
| **slack** (5.3.0) | NewChannelMessage, NewPrivateChannelMessage, NewChannelMessageRT, NewUser, NewUserWebhook | same `conversations.history`/`users.list` calls as production; RT/webhook triggers skip `addListener` |
| **calendly** (3.1.0) | InviteeCreated, InviteeCanceled, InviteeNoShowCreated, InviteeNoShowDeleted | commons `fetchLatestExample` (status/no-show filters) + `toWebhookShape`/`toNoShowWebhookShape` |
| **utils.timers** (1.4.0) | SchedulerTrigger | reuses `getNextRun()` — synthetic payload respecting the configured schedule |
| **utils.forms** (1.2.0) | FormTrigger | synthesizes one entry from configured fields (string values, checkbox boolean, prefers `defaultValue`) |

All `test()` methods follow the same rules: read-only upstream, no state writes (any scope), honor `context.properties` filters, emit exactly one item via `sendJson` on the production port, throw when no example exists (falls through to the engine fallback chain).

## Freshdesk: axios removal

Freshdesk components now issue all requests through a shared `lib.apiCall` built on `context.httpRequest` — `axios`, `request` and `request-promise` removed from the connector's dependencies. No behavior change; multipart (CreateTicket/UpdateTicket) and stream download (ExportContacts) handled.

## Skill + command (customer-facing)

- `.claude/skills/connector-test-method/SKILL.md` — full guide: fallback chain, code-sharing principle with anti-pattern, hard rules, procedure, trigger groups A–F with worked examples (all referencing real files in this repo), verification (CLI `--test` flag or live-instance Flow Test Mode), checklist. No internal repo/issue references.
- `.claude/commands/connector-test-method.md` — `/connector-test-method <connector> [trigger]` slash command driving the skill.

## Verification

- `eslint` clean on all touched connectors
- `npm run validate` — no new findings (remaining hits are pre-existing `component.json` warnings, untouched here)
- Live verification against real accounts pending review (CLI `--test` flag ships separately in appmixer-cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
