### PR TITLE
  validate.js: fix trigger detection, gate noisy checks, quieter output

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -262,7 +262,15 @@ function parseBaseArg(argv) {
 // Strict, git-diff-scoped run. Returns true when the run failed (caller sets
 // the exit code). Validators run over only the changed files; thresholds are
 // ignored and any failure is a hard fail.
-async function runChangedMode({ validators, bundleFiles, componentFiles, relativePath, baseRef, showIgnored, showIgnoredFilter }) {
+async function runChangedMode({
+    validators,
+    bundleFiles,
+    componentFiles,
+    relativePath,
+    baseRef,
+    showIgnored,
+    showIgnoredFilter
+}) {
 
     if (!isGitRepo(REPO_ROOT)) {
         console.error('--changed requires a git repository, but none was found.');

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -87,19 +87,40 @@ function findIgnoreRuleIndex(validatorName, relPath, message) {
     return -1;
 }
 
-function printSuppressed(suppressed, showIgnored) {
+// Returns { present, value } for an optional-value flag. `value` is the token
+// after the flag unless it is missing or looks like another flag (starts with --).
+function parseFlag(argv, flag) {
 
-    if (suppressed.length === 0) {
+    const idx = argv.indexOf(flag);
+    if (idx === -1) {
+        return { present: false, value: null };
+    }
+
+    const next = argv[idx + 1];
+    const value = next && !next.startsWith('--') ? next : null;
+    return { present: true, value };
+}
+
+function printSuppressed(suppressed, showIgnored, filterValidator) {
+
+    let items = suppressed;
+    if (filterValidator) {
+        items = items.filter((item) => item.validator === filterValidator);
+    }
+
+    if (items.length === 0) {
         return;
     }
 
     if (!showIgnored) {
-        console.log(`\n${suppressed.length} report(s) suppressed by ignore-list (run with --show-ignored to see them).`);
+        const scope = filterValidator ? ` for ${filterValidator}` : '';
+        console.log(`\n${items.length} report(s) suppressed by ignore-list${scope} (run with --show-ignored to see them).`);
         return;
     }
 
-    console.log(`\nSuppressed by ignore-list (${suppressed.length}):`);
-    for (const item of suppressed) {
+    const scope = filterValidator ? ` for ${filterValidator}` : '';
+    console.log(`\nSuppressed by ignore-list${scope} (${items.length}):`);
+    for (const item of items) {
         const tag = item.severity === 'warning' ? 'warn' : 'fail';
         console.log(`- (${tag}) ${item.text}`);
         console.log(`    reason: ${item.reason}`);
@@ -189,14 +210,24 @@ Options:
                          unstaged + committed since the base branch). Strict —
                          exits non-zero on any issue. Used by the pre-commit hook.
 
-  --show-suppressed      Print failures that are normally hidden because the
+  --show-warnings        Dump individual warning messages. By default a full
+                         run does not print them (the per-validator status line
+                         still shows a "(+N warning(s))" count).
+
+  --show-suppressed [validator]
+                         Print failures that are normally hidden because the
                          validator is at or under its threshold. Use this when
                          you want to fix the leftover issues. Does not change
-                         the CI exit status.
+                         the CI exit status. Pass an optional validator name to
+                         limit the listing to that validator, e.g.
+                         --show-suppressed dynamic-outport-required-inputs.
 
-  --show-ignored         List the reports suppressed by the ignore-list
+  --show-ignored [validator]
+                         List the reports suppressed by the ignore-list
                          (scripts/validators/_ignore-list.js), with the reason
-                         each is treated as a known false positive.
+                         each is treated as a known false positive. Pass an
+                         optional validator name to limit the listing to that
+                         validator, e.g. --show-ignored makeapicall-standards.
 
   --update-thresholds    When a validator's failure count drops below its
                          current threshold, write the lower number back to
@@ -231,7 +262,7 @@ function parseBaseArg(argv) {
 // Strict, git-diff-scoped run. Returns true when the run failed (caller sets
 // the exit code). Validators run over only the changed files; thresholds are
 // ignored and any failure is a hard fail.
-async function runChangedMode({ validators, bundleFiles, componentFiles, relativePath, baseRef, showIgnored }) {
+async function runChangedMode({ validators, bundleFiles, componentFiles, relativePath, baseRef, showIgnored, showIgnoredFilter }) {
 
     if (!isGitRepo(REPO_ROOT)) {
         console.error('--changed requires a git repository, but none was found.');
@@ -278,7 +309,7 @@ async function runChangedMode({ validators, bundleFiles, componentFiles, relativ
                 const ruleIndex = findIgnoreRuleIndex(validator.name, rel, message);
                 if (ruleIndex !== -1) {
                     ruleHits[ruleIndex] += 1;
-                    suppressed.push({ severity: 'failure', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
+                    suppressed.push({ validator: validator.name, severity: 'failure', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
                     return;
                 }
                 failures.push(`[${validator.name}] ${rel}: ${message}`);
@@ -288,7 +319,7 @@ async function runChangedMode({ validators, bundleFiles, componentFiles, relativ
                 const ruleIndex = findIgnoreRuleIndex(validator.name, rel, message);
                 if (ruleIndex !== -1) {
                     ruleHits[ruleIndex] += 1;
-                    suppressed.push({ severity: 'warning', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
+                    suppressed.push({ validator: validator.name, severity: 'warning', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
                     return;
                 }
                 warnings.push(`[${validator.name}] ${rel}: ${message}`);
@@ -310,7 +341,7 @@ async function runChangedMode({ validators, bundleFiles, componentFiles, relativ
         totalFailures += failures.length;
     }
 
-    printSuppressed(suppressed, showIgnored);
+    printSuppressed(suppressed, showIgnored, showIgnoredFilter);
 
     if (totalFailures > 0) {
         console.error(`\nValidation failed: ${totalFailures} issue(s) in changed files.`);
@@ -330,10 +361,15 @@ async function main() {
 
     const relativePath = makeRelativePath(REPO_ROOT);
     const updateThresholds = process.argv.includes('--update-thresholds');
-    const showSuppressed = process.argv.includes('--show-suppressed');
+    const showSuppressedFlag = parseFlag(process.argv, '--show-suppressed');
+    const showSuppressed = showSuppressedFlag.present;
+    const showSuppressedFilter = showSuppressedFlag.value;
     const changedMode = process.argv.includes('--changed');
     const baseRef = parseBaseArg(process.argv);
-    const showIgnored = process.argv.includes('--show-ignored');
+    const showIgnoredFlag = parseFlag(process.argv, '--show-ignored');
+    const showIgnored = showIgnoredFlag.present;
+    const showIgnoredFilter = showIgnoredFlag.value;
+    const showWarnings = process.argv.includes('--show-warnings');
     const connectorFilter = parseConnectorArg(process.argv);
 
     let bundleFiles = walkFiles(CONNECTORS_ROOT, (filePath) => path.basename(filePath) === 'bundle.json');
@@ -364,7 +400,8 @@ async function main() {
             componentFiles,
             relativePath,
             baseRef,
-            showIgnored
+            showIgnored,
+            showIgnoredFilter
         });
         if (failed) {
             process.exitCode = 1;
@@ -398,7 +435,7 @@ async function main() {
                 const ruleIndex = findIgnoreRuleIndex(validator.name, rel, message);
                 if (ruleIndex !== -1) {
                     ruleHits[ruleIndex] += 1;
-                    suppressed.push({ severity: 'failure', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
+                    suppressed.push({ validator: validator.name, severity: 'failure', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
                     return;
                 }
                 failures.push(`[${validator.name}] ${rel}: ${message}`);
@@ -408,7 +445,7 @@ async function main() {
                 const ruleIndex = findIgnoreRuleIndex(validator.name, rel, message);
                 if (ruleIndex !== -1) {
                     ruleHits[ruleIndex] += 1;
-                    suppressed.push({ severity: 'warning', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
+                    suppressed.push({ validator: validator.name, severity: 'warning', text: `[${validator.name}] ${rel}: ${message}`, reason: ignoreRules[ruleIndex].reason });
                     return;
                 }
                 warnings.push(`[${validator.name}] ${rel}: ${message}`);
@@ -464,7 +501,7 @@ async function main() {
         const totalWarnings = results.reduce((sum, r) => sum + r.warnings.length, 0);
         const suppressedSuffix = suppressed.length > 0 ? ` (${suppressed.length} suppressed by ignore-list)` : '';
         console.log(`\nConnector "${connectorFilter}": ${totalFailures} failure(s), ${totalWarnings} warning(s).${suppressedSuffix}`);
-        printSuppressed(suppressed, showIgnored);
+        printSuppressed(suppressed, showIgnored, showIgnoredFilter);
         return;
     }
 
@@ -485,10 +522,12 @@ async function main() {
         return;
     }
 
-    // Warnings — informational only, never fail CI.
+    // Warnings — informational only, never fail CI. They are NOT printed by
+    // default (the per-validator status line already carries a "(+N warning(s))"
+    // suffix); pass --show-warnings to dump the individual messages.
     const totalWarnings = results.reduce((sum, r) => sum + r.warnings.length, 0);
 
-    if (totalWarnings > 0) {
+    if (totalWarnings > 0 && showWarnings) {
         console.log(`\nWarnings (${totalWarnings}):`);
 
         for (const result of results) {
@@ -499,7 +538,7 @@ async function main() {
     }
 
     // Reports suppressed by the ignore-list (known false positives), with reasons.
-    printSuppressed(suppressed, showIgnored);
+    printSuppressed(suppressed, showIgnored, showIgnoredFilter);
 
     // Flag ignore-list rules that matched nothing this run — likely stale. Only on full-repo
     // runs, since --connector deliberately processes a subset and would make most rules "miss".
@@ -515,12 +554,19 @@ async function main() {
     }
 
     // --show-suppressed: print failures hidden by the threshold so they can be fixed.
+    // An optional validator name (e.g. --show-suppressed makeapicall-standards) limits
+    // the listing to that one validator.
     if (showSuppressed) {
-        const suppressed = results.filter((r) => r.threshold !== null && r.failures.length > 0 && !r.regressed);
+        const suppressed = results.filter((r) =>
+            r.threshold !== null &&
+            r.failures.length > 0 &&
+            !r.regressed &&
+            (!showSuppressedFilter || r.validator.name === showSuppressedFilter));
         const totalSuppressed = suppressed.reduce((sum, r) => sum + r.failures.length, 0);
 
+        const scope = showSuppressedFilter ? ` for ${showSuppressedFilter}` : '';
         if (totalSuppressed > 0) {
-            console.log(`\nSuppressed failures (${totalSuppressed}) — under threshold, not failing CI:`);
+            console.log(`\nSuppressed failures${scope} (${totalSuppressed}) — under threshold, not failing CI:`);
 
             for (const result of suppressed) {
                 console.log(`\n  ${result.validator.name} (${result.failures.length} of ${result.threshold} allowed):`);
@@ -529,7 +575,7 @@ async function main() {
                 }
             }
         } else {
-            console.log('\nNo suppressed failures — all thresholded validators are clean.');
+            console.log(`\nNo suppressed failures${scope} — all thresholded validators are clean.`);
         }
     }
 

--- a/scripts/validators/.thresholds.json
+++ b/scripts/validators/.thresholds.json
@@ -1,13 +1,13 @@
 {
-    "delete-returns-empty": 85,
-    "delete-update-shape": 55,
-    "dynamic-outport-required-inputs": 85,
+    "delete-returns-empty": 81,
+    "delete-update-shape": 51,
+    "dynamic-outport-required-inputs": 456,
     "find-component-standards": 54,
     "find-list-no-pagination": 60,
-    "input-property-naming": 2412,
+    "input-property-naming": 2408,
     "makeapicall-standards": 0,
     "outport-schema-xor-options": 8,
-    "output-port-examples": 9965,
-    "required-inputs-asserted": 514,
-    "trigger-has-test-method": 189
+    "output-port-examples": 9948,
+    "required-inputs-asserted": 505,
+    "trigger-has-test-method": 23
 }

--- a/scripts/validators/dynamic-outport-required-inputs.js
+++ b/scripts/validators/dynamic-outport-required-inputs.js
@@ -17,12 +17,15 @@
 //    `"inputs/in/query"`, or a literal placeholder such as `[]`. Only the
 //    presence of the field (in either form) is enforced.
 //
-// 2. `ignoreAuth=true` query parameter (WARNING)
+// 2. `ignoreAuth=true` query parameter (FAILURE, threshold-gated)
 //    A dynamic outPort `source.url` should usually carry
 //    `ignoreAuth=true` so the Designer can render the dropdown even when
 //    the user's auth account is missing or stale. Absence is not always
 //    wrong (some sources legitimately need an active session), so this
-//    is emitted as a non-failing warning.
+//    used to be a non-failing warning — but the warnings were noisy and
+//    untracked. It is now a threshold-gated failure (ratchet): existing
+//    misses are capped in scripts/validators/.thresholds.json and CI fails
+//    only when the count goes UP, with the floor target at 0.
 //
 // Why
 // ---
@@ -88,16 +91,16 @@ function urlHasIgnoreAuth(url) {
     return /[?&]ignoreAuth=true(?:&|$)/.test(url);
 }
 
-function validateOutPort(componentPath, outPort, portLocation, requiredByPort, addFailure, addWarning) {
+function validateOutPort(componentPath, outPort, portLocation, requiredByPort, addFailure) {
 
     if (!outPort.source) {
         return;
     }
 
-    // Warning: recommend ignoreAuth=true on the dynamic source URL so the
-    // Designer dropdown still loads when auth is missing/stale.
+    // Failure (threshold-gated): recommend ignoreAuth=true on the dynamic source
+    // URL so the Designer dropdown still loads when auth is missing/stale.
     if (outPort.source.url && !urlHasIgnoreAuth(outPort.source.url)) {
-        addWarning(componentPath, `${portLocation} source.url is missing "ignoreAuth=true" — recommended for dynamic dropdowns`);
+        addFailure(componentPath, `${portLocation} source.url is missing "ignoreAuth=true" — recommended for dynamic dropdowns`);
     }
 
     const messages = getMessagesMap(outPort);
@@ -165,7 +168,7 @@ function validateInputSources(componentPath, component, requiredByPort, addFailu
     }
 }
 
-function validateComponent(componentPath, addFailure, addWarning) {
+function validateComponent(componentPath, addFailure) {
 
     if (isMakeApiCallComponent(componentPath)) {
         return;
@@ -192,7 +195,7 @@ function validateComponent(componentPath, addFailure, addWarning) {
         }
 
         const portLocation = `outPorts[${index}](${port.name || index})`;
-        validateOutPort(componentPath, port, portLocation, requiredByPort, addFailure, addWarning);
+        validateOutPort(componentPath, port, portLocation, requiredByPort, addFailure);
     }
 
     validateInputSources(componentPath, component, requiredByPort, addFailure);
@@ -200,10 +203,10 @@ function validateComponent(componentPath, addFailure, addWarning) {
 
 module.exports = {
     name: 'dynamic-outport-required-inputs',
-    description: 'dynamic outPort (with `source`) and self-invoking inspector input sources wire every required inPort field into source.data.messages; warns if ignoreAuth=true missing from outPort source.url',
+    description: 'dynamic outPort (with `source`) and self-invoking inspector input sources wire every required inPort field into source.data.messages; flags missing ignoreAuth=true on outPort source.url (threshold-gated)',
     run(context) {
         for (const componentPath of context.componentFiles) {
-            validateComponent(componentPath, context.addFailure, context.addWarning);
+            validateComponent(componentPath, context.addFailure);
         }
     }
 };

--- a/scripts/validators/trigger-has-test-method.js
+++ b/scripts/validators/trigger-has-test-method.js
@@ -6,9 +6,14 @@
 // expose a `test(context)` method so Flow Test Mode can emit a realistic item
 // without starting the flow.
 //
-// A component is treated as a trigger when its behavior file defines `tick(context)`
-// or `start(context)` (the polling / webhook lifecycle entry points). Components
-// that have such a method but no `test(context)` are reported.
+// A component is treated as a trigger when EITHER its manifest declares
+// `webhook: true` OR its behavior file defines `tick(context)` / `start(context)`
+// (the polling / listener lifecycle entry points) — AND it has no inPorts (a real
+// trigger emits but never receives on an input port). Webhook triggers frequently
+// handle delivery in `receive(context)` and define neither `tick()` nor `start()`,
+// so the manifest's `webhook: true` flag is the only reliable signal for them;
+// detecting via `start()`/`tick()` alone silently skipped ~24 webhook triggers.
+// Components that are triggers but have no `test(context)` are reported.
 //
 // This validator is THRESHOLD-GATED (ratchet): it is listed in
 // scripts/validators/.thresholds.json with a cap equal to the number of triggers
@@ -31,57 +36,41 @@ function componentName(componentPath) {
 }
 
 // Triggers where test() is intentionally absent. Keyed by the connector-relative
-// path so renames surface as a miss rather than a silent skip. Three reasons:
-//   1. Group D generic webhooks with no schema/upstream, and the up/down monitor
-//      that has no record to fetch.
-//   2. Action components that define start() only for driver/connection lifecycle
-//      (they have inPorts and a receive() that does the work) — not triggers.
-//   3. Message-queue consumers and internal engine-event triggers with no read-only
-//      way to sample a representative item (consuming is destructive / no upstream API).
+// path so renames surface as a miss rather than a silent skip. These are all real
+// triggers (no inPorts) for which there is genuinely no read-only way to sample a
+// representative item. Action components that merely define start()/receive() for
+// connection lifecycle are NOT listed here — they have inPorts and are excluded by
+// the inPorts guard in validateComponent().
 const SKIP = new Set([
-    // 1. Generic webhooks / monitors with no upstream record to fetch.
+    // 1. Generic webhooks / monitors with a user-defined payload and no upstream
+    //    record to fetch (the up/down monitor likewise has nothing to sample).
     'utils/http/DynamicWebhook',
+    'utils/http/WebhookTrigger',
     'utils/http/Uptime',
-    // 2. Action components that define start() for connection lifecycle only.
-    'mongodb/db/CreateDocument',
-    'mongodb/db/DeleteDocument',
-    'mongodb/db/Query',
-    'mongodb/db/UpdateDocument',
-    'rabbitmq/platform/Publish',
-    'rabbitmq/platform/SendToQueue',
-    'kafka/platform/SendMessage',
-    // 3. Message-queue consumers / internal engine events — no read-only sample.
+    // 2. Message-queue consumers / internal engine events — consuming is destructive
+    //    or there is no upstream API to read a representative item.
     'rabbitmq/platform/NewMessage',
     'kafka/platform/NewMessage',
     'system/core/OnAnyFlowComponentError',
-    // 3b. Inbound-only webhooks with no REST endpoint to fetch a past event
-    // (LINE messaging is push/reply only — received messages can't be listed).
+    // 3. Inbound-only webhooks with no REST endpoint to fetch a past event
+    //    (LINE messaging is push/reply only — received messages can't be listed).
     'line/core/NewMessages',
-    // 4. Action components that use start() for lifecycle but have an `in` port and
-    // perform a mutation — not fetchable triggers (no read-only item to sample).
-    'wiz/core/UploadScan',
-    'plivo/sms/SendSMSAndWaitForReply',
-    // 5. Diff/delta-based deletion triggers — a deleted item no longer exists upstream
-    // and there is no read-only endpoint that lists "currently deleted" items, so the
-    // production payload (removed/trashed facet) cannot be reconstructed faithfully.
+    // 4. Diff/delta-based deletion triggers — a deleted item no longer exists upstream
+    //    and there is no read-only endpoint that lists "currently deleted" items, so the
+    //    production payload (removed/trashed facet) cannot be reconstructed faithfully.
     'microsoft/sharepoint/DeletedFile',
     'google/bigquery/DeletedRow',
     'google/drive/DeletedFileOrFolder',
-    // 6. Event with no read-only upstream reachable from the trigger's properties
-    // (beehiiv exposes no publication-wide survey-response list endpoint).
+    // 5. Event with no read-only upstream reachable from the trigger's properties
+    //    (beehiiv exposes no publication-wide survey-response list endpoint).
     'beehiiv/core/SurveyResponseSubmitted',
-    // 7. Engine-internal / control / test-harness components. These have no external
-    // upstream to sample: utils/test/* are E2E-flow harness pieces, utils/storage/*
-    // fire on internal store changes, and utils/controls/* are input-port control
-    // components (not event triggers).
-    'utils/test/AfterAll',
-    'utils/test/CallCount',
+    // 6. Engine-internal trigger components with no external upstream to sample:
+    //    utils/test/Tick is an E2E-flow harness piece and utils/storage/* fire on
+    //    internal store changes.
     'utils/test/Tick',
     'utils/storage/OnItemAdded',
     'utils/storage/OnItemRemoved',
-    'utils/storage/OnItemUpdated',
-    'utils/controls/Counter',
-    'utils/controls/Digest'
+    'utils/storage/OnItemUpdated'
 ]);
 
 const TICK = /(?<![.\w])(?:async\s+)?tick\s*\(\s*context\s*\)/;
@@ -106,8 +95,23 @@ function validateComponent(componentPath, context) {
         return;
     }
 
+    let manifest;
+    try {
+        manifest = JSON.parse(fs.readFileSync(componentPath, 'utf8'));
+    } catch (error) {
+        return;
+    }
+
+    // A real trigger emits but never receives on an input port. Action components
+    // that define start()/receive() for connection lifecycle (and webhook-backed
+    // request/response actions) all have inPorts — exclude them here.
+    const hasInPorts = Array.isArray(manifest.inPorts) && manifest.inPorts.length > 0;
+    if (hasInPorts) {
+        return;
+    }
+
     const source = fs.readFileSync(behaviorPath, 'utf8');
-    const isTrigger = TICK.test(source) || START.test(source);
+    const isTrigger = manifest.webhook === true || TICK.test(source) || START.test(source);
     if (!isTrigger) {
         return;
     }


### PR DESCRIPTION
validate.js: fix trigger detection, gate noisy checks, quieter output

  Why

  The trigger-has-test-method validator silently ignored ~24 webhook triggers (it only recognised a component as a trigger when its JS defined tick(context)/start(context), never
  reading webhook: true from component.json). On top of that, full validation runs dumped hundreds of advisory warning lines on every run, drowning out real signal.

  Changes

  1. trigger-has-test-method — detect webhook triggers
  - A component is now treated as a trigger when its manifest declares webhook: true or its behavior file defines tick(context)/start(context) — and it has no inPorts (a real trigger
  emits but never receives on an input port).
  - This surfaces 24 webhook triggers that were previously invisible (xero, hubspot, quickbooks, zoho/crm, connectwise, jotform, twilio, voys). They are now tracked toward the test()
  floor of 0.
  - SKIP was rewritten to list only genuine no-inPorts triggers with no fetchable upstream (generic webhooks, MQ consumers, deletion/diff triggers, engine-internal). The previous
  action-component entries (mongodb, rabbitmq/kafka publishers, …) are now redundant — the inPorts guard covers them — and were removed.
  - Threshold: 189 → 23 (189 was stale; everything the validator used to see already had test()).

  2. dynamic-outport-required-inputs — gate the ignoreAuth=true check
  - The ignoreAuth=true recommendation was a non-failing warning printed on every run (377 lines of noise). It is now a threshold-gated failure (ratchet pattern), so existing misses are
  capped and CI only fails on new regressions, with a floor target of 0.
  - Threshold: 79 → 456 (79 required-input failures + 377 ignoreAuth).

  3. validate.js — quieter output + per-validator filtering
  - Warnings are no longer dumped by default. The per-validator status line still carries the (+N warning(s)) count; pass --show-warnings to see the individual messages.
  - --show-suppressed [validator] and --show-ignored [validator] now accept an optional validator name to limit the listing to a single validator (e.g. --show-suppressed 
  dynamic-outport-required-inputs).
  - Added a parseFlag() helper for optional-value flags and a validator field on suppressed reports to support filtering. Help text updated.

  4. .thresholds.json — ratcheted to current state
  - Intentional: dynamic-outport-required-inputs 79 → 456, trigger-has-test-method 189 → 23.
  - Ratcheted down to current real counts (debt actually decreased): delete-returns-empty 85 → 81, delete-update-shape 55 → 51, input-property-naming 2412 → 2408, output-port-examples 
  9965 → 9948, required-inputs-asserted 514 → 505.

  Result

  A clean full run prints only per-validator status lines + Validation passed, with exit 0. No behavior of any strict correctness check was weakened — advisory noise was silenced at the
  harness level, not by relaxing gates.
