### PR TITLE
triggers: add test() (Flow Test Mode) to the remaining 23 webhook triggers

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -215,12 +215,13 @@ Options:
                          still shows a "(+N warning(s))" count).
 
   --show-suppressed [validator]
-                         Print failures that are normally hidden because the
-                         validator is at or under its threshold. Use this when
-                         you want to fix the leftover issues. Does not change
-                         the CI exit status. Pass an optional validator name to
-                         limit the listing to that validator, e.g.
-                         --show-suppressed dynamic-outport-required-inputs.
+                         Print everything hidden from the default clean output:
+                         failures held under a threshold AND warnings (which are
+                         never printed by default). Use this when you want to fix
+                         the leftover issues. Does not change the CI exit status.
+                         Pass an optional validator name to limit the listing to
+                         that validator, e.g.
+                         --show-suppressed trigger-test-method.
 
   --show-ignored [validator]
                          List the reports suppressed by the ignore-list
@@ -337,7 +338,9 @@ async function runChangedMode({
         await validator.run(context);
 
         const warnSuffix = warnings.length > 0 ? ` (+${warnings.length} warning(s))` : '';
-        console.log(`- ${validator.name}: ${failures.length === 0 ? 'OK' : `${failures.length} issue(s)`}${warnSuffix}`);
+        const ignoredCount = suppressed.filter((item) => item.validator === validator.name).length;
+        const ignoredSuffix = ignoredCount > 0 ? ` (+${ignoredCount} ignored)` : '';
+        console.log(`- ${validator.name}: ${failures.length === 0 ? 'OK' : `${failures.length} issue(s)`}${warnSuffix}${ignoredSuffix}`);
 
         for (const failure of failures) {
             console.error(`  - ${failure}`);
@@ -489,7 +492,9 @@ async function main() {
         }
 
         const warnSuffix = !connectorFilter && warnings.length > 0 ? ` (+${warnings.length} warning(s))` : '';
-        console.log(`- ${validator.name}: ${status}${warnSuffix}`);
+        const ignoredCount = suppressed.filter((item) => item.validator === validator.name).length;
+        const ignoredSuffix = !connectorFilter && ignoredCount > 0 ? ` (+${ignoredCount} ignored)` : '';
+        console.log(`- ${validator.name}: ${status}${warnSuffix}${ignoredSuffix}`);
         results.push({ validator, failures, warnings, threshold, regressed });
     }
 
@@ -561,18 +566,18 @@ async function main() {
         }
     }
 
-    // --show-suppressed: print failures hidden by the threshold so they can be fixed.
-    // An optional validator name (e.g. --show-suppressed makeapicall-standards) limits
-    // the listing to that one validator.
+    // --show-suppressed: print everything hidden from the default clean output —
+    // both failures held under a threshold AND warnings (which are never printed by
+    // default) — so they can be fixed. An optional validator name (e.g.
+    // --show-suppressed makeapicall-standards) limits the listing to that validator.
     if (showSuppressed) {
+        const matchesFilter = (r) => !showSuppressedFilter || r.validator.name === showSuppressedFilter;
+        const scope = showSuppressedFilter ? ` for ${showSuppressedFilter}` : '';
+
         const suppressed = results.filter((r) =>
-            r.threshold !== null &&
-            r.failures.length > 0 &&
-            !r.regressed &&
-            (!showSuppressedFilter || r.validator.name === showSuppressedFilter));
+            r.threshold !== null && r.failures.length > 0 && !r.regressed && matchesFilter(r));
         const totalSuppressed = suppressed.reduce((sum, r) => sum + r.failures.length, 0);
 
-        const scope = showSuppressedFilter ? ` for ${showSuppressedFilter}` : '';
         if (totalSuppressed > 0) {
             console.log(`\nSuppressed failures${scope} (${totalSuppressed}) — under threshold, not failing CI:`);
 
@@ -584,6 +589,21 @@ async function main() {
             }
         } else {
             console.log(`\nNo suppressed failures${scope} — all thresholded validators are clean.`);
+        }
+
+        // Warnings are also hidden from the default output — surface them here too.
+        const warned = results.filter((r) => r.warnings.length > 0 && matchesFilter(r));
+        const totalWarned = warned.reduce((sum, r) => sum + r.warnings.length, 0);
+
+        if (totalWarned > 0) {
+            console.log(`\nWarnings${scope} (${totalWarned}) — informational, not failing CI:`);
+
+            for (const result of warned) {
+                console.log(`\n  ${result.validator.name} (${result.warnings.length} warning(s)):`);
+                for (const warning of result.warnings) {
+                    console.log(`  - ${warning}`);
+                }
+            }
         }
     }
 

--- a/scripts/validators/.thresholds.json
+++ b/scripts/validators/.thresholds.json
@@ -9,5 +9,5 @@
     "outport-schema-xor-options": 8,
     "output-port-examples": 9948,
     "required-inputs-asserted": 505,
-    "trigger-has-test-method": 23
+    "trigger-has-test-method": 0
 }

--- a/scripts/validators/_ignore-list.js
+++ b/scripts/validators/_ignore-list.js
@@ -43,5 +43,86 @@ module.exports = [
         messageIncludes: 'auth.scope is empty',
         paths: ['microsoft/dynamics/MakeApiCall/component.json'],
         reason: 'Dynamics 365 uses the legacy resource-based OAuth flow (authorize?resource={org url}); the access token is scoped to the org resource, not to granular OAuth scopes. The connector declares scope [] on every component by design, so MakeApiCall matches that convention.'
+    },
+    {
+        validator: 'trigger-test-method',
+        messageIncludes: 'test() should throw when no example is available',
+        paths: [
+            'hubspot/crm/NewContact/component.json',
+            'hubspot/crm/NewDeal/component.json',
+            'hubspot/crm/UpdatedContact/component.json',
+            'hubspot/crm/UpdatedDeal/component.json',
+            'zoho/crm/ContactCreated/component.json',
+            'zoho/crm/ContactUpdated/component.json',
+            'zoho/crm/LeadCreated/component.json',
+            'zoho/crm/LeadUpdated/component.json'
+        ],
+        reason: 'These test() methods delegate the "no example" throw to the connector-shared fetchLatestExample() helper (hubspot BaseSubscriptionComponent / zoho ZohoNotifiable), which throws a CancelError when the upstream returns no record. The validator only scans the test() body for a literal throw, so it reports a false positive; the fallback-on-empty behaviour is present.'
+    },
+    {
+        validator: 'trigger-test-method',
+        messageIncludes: 'test() should throw when no example is available',
+        paths: [
+            'utils/controls/OnStart/component.json',
+            'utils/http/Uptime/component.json',
+            'utils/subflows/OnFlowCall/component.json',
+            'utils/timers/Timer/component.json'
+        ],
+        reason: 'These sourceless triggers have no upstream to be empty: their test() always produces a deterministic/synthetic payload of the production shape (OnStart = start timestamp, Uptime = a single up/down probe result, OnFlowCall = a payload built from the configured input fields, Timer = a computed tick). There is no "no example available" case, so a throw is intentionally absent.'
+    },
+
+    // trigger-has-test-method: triggers where a test() is intentionally NOT implemented
+    // (no read-only way to sample a representative production item). Grouped by reason.
+    {
+        validator: 'trigger-has-test-method',
+        messageIncludes: 'missing a test(context) method',
+        paths: [
+            'utils/http/DynamicWebhook/component.json',
+            'utils/http/WebhookTrigger/component.json'
+        ],
+        reason: 'Generic webhooks with a user-defined payload and no upstream record to fetch, so test() cannot emit a representative item.'
+    },
+    {
+        validator: 'trigger-has-test-method',
+        messageIncludes: 'missing a test(context) method',
+        paths: [
+            'rabbitmq/platform/NewMessage/component.json',
+            'kafka/platform/NewMessage/component.json',
+            'system/core/OnAnyFlowComponentError/component.json'
+        ],
+        reason: 'Message-queue consumers / internal engine events — consuming is destructive or there is no upstream API to read a representative item.'
+    },
+    {
+        validator: 'trigger-has-test-method',
+        messageIncludes: 'missing a test(context) method',
+        paths: ['line/core/NewMessages/component.json'],
+        reason: 'Inbound-only webhook with no REST endpoint to fetch a past event (LINE messaging is push/reply only — received messages cannot be listed).'
+    },
+    {
+        validator: 'trigger-has-test-method',
+        messageIncludes: 'missing a test(context) method',
+        paths: [
+            'microsoft/sharepoint/DeletedFile/component.json',
+            'google/bigquery/DeletedRow/component.json',
+            'google/drive/DeletedFileOrFolder/component.json'
+        ],
+        reason: 'Diff/delta-based deletion triggers — a deleted item no longer exists upstream and there is no read-only endpoint that lists "currently deleted" items, so the production payload cannot be reconstructed faithfully.'
+    },
+    {
+        validator: 'trigger-has-test-method',
+        messageIncludes: 'missing a test(context) method',
+        paths: ['beehiiv/core/SurveyResponseSubmitted/component.json'],
+        reason: 'Event with no read-only upstream reachable from the trigger\'s properties (beehiiv exposes no publication-wide survey-response list endpoint).'
+    },
+    {
+        validator: 'trigger-has-test-method',
+        messageIncludes: 'missing a test(context) method',
+        paths: [
+            'utils/test/Tick/component.json',
+            'utils/storage/OnItemAdded/component.json',
+            'utils/storage/OnItemRemoved/component.json',
+            'utils/storage/OnItemUpdated/component.json'
+        ],
+        reason: 'Engine-internal triggers with no external upstream to sample: utils/test/Tick is an E2E-flow harness piece and utils/storage/* fire on internal store changes.'
     }
 ];

--- a/scripts/validators/trigger-has-test-method.js
+++ b/scripts/validators/trigger-has-test-method.js
@@ -43,6 +43,7 @@ const START = /(?<![.\w])(?:async\s+)?start\s*\(\s*context\s*\)/;
 // Accept both the shorthand method form `test(context) {` / `async test(context) {`
 // and the object-property form `test: function (context)` / `test: async function (context)`
 // that many connectors use alongside `start: async function (context)`.
+// eslint-disable-next-line max-len
 const TEST_METHOD = /(?<![.\w])(?:async\s+)?test\s*\(\s*context\s*\)\s*\{|(?<![.\w])test\s*:\s*(?:async\s+)?function\s*\(\s*context\s*\)/;
 
 function validateComponent(componentPath, context) {

--- a/scripts/validators/trigger-has-test-method.js
+++ b/scripts/validators/trigger-has-test-method.js
@@ -21,9 +21,12 @@
 // without test()); as triggers gain test() the count drops and the threshold can
 // be ratcheted down with `--update-thresholds`. The target floor is 0.
 //
-// SKIP holds the few triggers where test() is intentionally not implemented
-// (skill "Group D" generic webhooks with a user-defined payload and no upstream
-// record to fetch). These are excluded so the floor stays at 0.
+// Triggers where test() is intentionally absent (generic webhooks with a
+// user-defined payload, deletion/diff triggers, message-queue consumers, engine
+// internals with no read-only upstream to sample) are NOT special-cased here —
+// they are suppressed via scripts/validators/_ignore-list.js with a recorded
+// reason, like every other validator's known deviations. Run
+// `node scripts/validate.js --show-ignored trigger-has-test-method` to see them.
 //
 // See .claude/skills/connector-test-method/SKILL.md ("Trigger groups").
 
@@ -35,59 +38,12 @@ function componentName(componentPath) {
     return path.basename(path.dirname(componentPath));
 }
 
-// Triggers where test() is intentionally absent. Keyed by the connector-relative
-// path so renames surface as a miss rather than a silent skip. These are all real
-// triggers (no inPorts) for which there is genuinely no read-only way to sample a
-// representative item. Action components that merely define start()/receive() for
-// connection lifecycle are NOT listed here — they have inPorts and are excluded by
-// the inPorts guard in validateComponent().
-const SKIP = new Set([
-    // 1. Generic webhooks / monitors with a user-defined payload and no upstream
-    //    record to fetch (the up/down monitor likewise has nothing to sample).
-    'utils/http/DynamicWebhook',
-    'utils/http/WebhookTrigger',
-    'utils/http/Uptime',
-    // 2. Message-queue consumers / internal engine events — consuming is destructive
-    //    or there is no upstream API to read a representative item.
-    'rabbitmq/platform/NewMessage',
-    'kafka/platform/NewMessage',
-    'system/core/OnAnyFlowComponentError',
-    // 3. Inbound-only webhooks with no REST endpoint to fetch a past event
-    //    (LINE messaging is push/reply only — received messages can't be listed).
-    'line/core/NewMessages',
-    // 4. Diff/delta-based deletion triggers — a deleted item no longer exists upstream
-    //    and there is no read-only endpoint that lists "currently deleted" items, so the
-    //    production payload (removed/trashed facet) cannot be reconstructed faithfully.
-    'microsoft/sharepoint/DeletedFile',
-    'google/bigquery/DeletedRow',
-    'google/drive/DeletedFileOrFolder',
-    // 5. Event with no read-only upstream reachable from the trigger's properties
-    //    (beehiiv exposes no publication-wide survey-response list endpoint).
-    'beehiiv/core/SurveyResponseSubmitted',
-    // 6. Engine-internal trigger components with no external upstream to sample:
-    //    utils/test/Tick is an E2E-flow harness piece and utils/storage/* fire on
-    //    internal store changes.
-    'utils/test/Tick',
-    'utils/storage/OnItemAdded',
-    'utils/storage/OnItemRemoved',
-    'utils/storage/OnItemUpdated'
-]);
-
 const TICK = /(?<![.\w])(?:async\s+)?tick\s*\(\s*context\s*\)/;
 const START = /(?<![.\w])(?:async\s+)?start\s*\(\s*context\s*\)/;
 // Accept both the shorthand method form `test(context) {` / `async test(context) {`
 // and the object-property form `test: function (context)` / `test: async function (context)`
 // that many connectors use alongside `start: async function (context)`.
 const TEST_METHOD = /(?<![.\w])(?:async\s+)?test\s*\(\s*context\s*\)\s*\{|(?<![.\w])test\s*:\s*(?:async\s+)?function\s*\(\s*context\s*\)/;
-
-function relativeToConnectors(componentPath) {
-
-    // .../src/appmixer/<connector>/<...>/<Component> -> <connector>/<...>/<Component>
-    const dir = path.dirname(componentPath);
-    const marker = `${path.sep}appmixer${path.sep}`;
-    const idx = dir.indexOf(marker);
-    return idx === -1 ? dir : dir.slice(idx + marker.length);
-}
 
 function validateComponent(componentPath, context) {
 
@@ -119,10 +75,8 @@ function validateComponent(componentPath, context) {
         return;
     }
 
-    if (SKIP.has(relativeToConnectors(componentPath))) {
-        return;
-    }
-
+    // Intentional "no test()" cases are suppressed centrally in _ignore-list.js
+    // (keyed by validator + path), not special-cased here.
     if (!TEST_METHOD.test(source)) {
         context.addFailure(componentPath, `Trigger is missing a test(context) method for Flow Test Mode — see the connector-test-method skill (${name}.js)`);
     }

--- a/scripts/validators/trigger-has-test-method.js
+++ b/scripts/validators/trigger-has-test-method.js
@@ -75,7 +75,10 @@ const SKIP = new Set([
 
 const TICK = /(?<![.\w])(?:async\s+)?tick\s*\(\s*context\s*\)/;
 const START = /(?<![.\w])(?:async\s+)?start\s*\(\s*context\s*\)/;
-const TEST_METHOD = /(?<![.\w])(?:async\s+)?test\s*\(\s*context\s*\)\s*\{/;
+// Accept both the shorthand method form `test(context) {` / `async test(context) {`
+// and the object-property form `test: function (context)` / `test: async function (context)`
+// that many connectors use alongside `start: async function (context)`.
+const TEST_METHOD = /(?<![.\w])(?:async\s+)?test\s*\(\s*context\s*\)\s*\{|(?<![.\w])test\s*:\s*(?:async\s+)?function\s*\(\s*context\s*\)/;
 
 function relativeToConnectors(componentPath) {
 

--- a/src/appmixer/connectwise/bundle.json
+++ b/src/appmixer/connectwise/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.connectwise",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -10,6 +10,9 @@
         ],
         "1.0.2": [
             "Added output examples to component schemas."
+        ],
+        "1.1.0": [
+            "Added test() (Flow Test Mode) to the NewContact, NewProject and NewServiceTicket triggers."
         ]
     }
 }

--- a/src/appmixer/connectwise/core/NewContact/NewContact.js
+++ b/src/appmixer/connectwise/core/NewContact/NewContact.js
@@ -27,6 +27,22 @@ module.exports = {
         }
     },
 
+    test: async function(context) {
+
+        // Fetch the newest contact through the same REST client/base URL the webhook
+        // lifecycle uses; the list resource matches the schema of the webhook Entity.
+        const response = await this.httpRequest(context, {
+            url: this.getBaseUrl(context) + '/company/contacts',
+            method: 'GET',
+            query: { orderBy: 'id desc', pageSize: 1 }
+        });
+        const record = (response.data || [])[0];
+        if (!record) {
+            throw new context.CancelError('No contacts found to use as test data.');
+        }
+        return context.sendJson(record, 'out');
+    },
+
     httpRequest: async function(context, override = {}) {
 
         let url = null;

--- a/src/appmixer/connectwise/core/NewContact/NewContact.js
+++ b/src/appmixer/connectwise/core/NewContact/NewContact.js
@@ -29,18 +29,44 @@ module.exports = {
 
     test: async function(context) {
 
-        // Fetch the newest contact through the same REST client/base URL the webhook
-        // lifecycle uses; the list resource matches the schema of the webhook Entity.
-        const response = await this.httpRequest(context, {
-            url: this.getBaseUrl(context) + '/company/contacts',
-            method: 'GET',
-            query: { orderBy: 'id desc', pageSize: 1 }
-        });
-        const record = (response.data || [])[0];
-        if (!record) {
-            throw new context.CancelError('No contacts found to use as test data.');
+        // Honor the subscription scope (properties.level/objectId) so Test Mode emits an
+        // example the configured trigger would actually deliver. All paths fetch through the
+        // same REST client/base URL the webhook lifecycle uses; the resource matches the
+        // schema of the webhook Entity.
+        const { level, objectId } = context.properties;
+        const baseUrl = this.getBaseUrl(context) + '/company/contacts';
+
+        // level=Owner subscribes to every contact — the newest one is representative.
+        if (level === 'Owner') {
+            const response = await this.httpRequest(context, {
+                url: baseUrl,
+                method: 'GET',
+                query: { orderBy: 'id desc', pageSize: 1 }
+            });
+            const record = (response.data || [])[0];
+            if (!record) {
+                throw new context.CancelError('No contacts found to use as test data.');
+            }
+            return context.sendJson(record, 'out');
         }
-        return context.sendJson(record, 'out');
+
+        // level=Contact subscribes to one specific contact — fetch exactly that record.
+        if (level === 'Contact') {
+            const response = await this.httpRequest(context, {
+                url: `${baseUrl}/${objectId}`,
+                method: 'GET'
+            });
+            if (!response.data) {
+                throw new context.CancelError(`Contact ${objectId} not found to use as test data.`);
+            }
+            return context.sendJson(response.data, 'out');
+        }
+
+        // Type/Territory/Company narrow delivery to a subset that cannot be reproduced
+        // faithfully with a read-only fetch — throw rather than emit an out-of-scope sample.
+        throw new context.CancelError(
+            `Flow Test Mode cannot sample a "${level}"-scoped subscription read-only. Use level "Owner" or "Contact", or trigger it with a real event.`
+        );
     },
 
     httpRequest: async function(context, override = {}) {

--- a/src/appmixer/connectwise/core/NewProject/NewProject.js
+++ b/src/appmixer/connectwise/core/NewProject/NewProject.js
@@ -27,6 +27,22 @@ module.exports = {
         }
     },
 
+    test: async function(context) {
+
+        // Fetch the newest project through the same REST client/base URL the webhook
+        // lifecycle uses; the list resource matches the schema of the webhook Entity.
+        const response = await this.httpRequest(context, {
+            url: this.getBaseUrl(context) + '/project/projects',
+            method: 'GET',
+            query: { orderBy: 'id desc', pageSize: 1 }
+        });
+        const record = (response.data || [])[0];
+        if (!record) {
+            throw new context.CancelError('No projects found to use as test data.');
+        }
+        return context.sendJson(record, 'out');
+    },
+
     httpRequest: async function(context, override = {}) {
 
         let url = null;

--- a/src/appmixer/connectwise/core/NewProject/NewProject.js
+++ b/src/appmixer/connectwise/core/NewProject/NewProject.js
@@ -29,18 +29,44 @@ module.exports = {
 
     test: async function(context) {
 
-        // Fetch the newest project through the same REST client/base URL the webhook
-        // lifecycle uses; the list resource matches the schema of the webhook Entity.
-        const response = await this.httpRequest(context, {
-            url: this.getBaseUrl(context) + '/project/projects',
-            method: 'GET',
-            query: { orderBy: 'id desc', pageSize: 1 }
-        });
-        const record = (response.data || [])[0];
-        if (!record) {
-            throw new context.CancelError('No projects found to use as test data.');
+        // Honor the subscription scope (properties.level/objectId) so Test Mode emits an
+        // example the configured trigger would actually deliver. All paths fetch through the
+        // same REST client/base URL the webhook lifecycle uses; the resource matches the
+        // schema of the webhook Entity.
+        const { level, objectId } = context.properties;
+        const baseUrl = this.getBaseUrl(context) + '/project/projects';
+
+        // level=Owner subscribes to every project — the newest one is representative.
+        if (level === 'Owner') {
+            const response = await this.httpRequest(context, {
+                url: baseUrl,
+                method: 'GET',
+                query: { orderBy: 'id desc', pageSize: 1 }
+            });
+            const record = (response.data || [])[0];
+            if (!record) {
+                throw new context.CancelError('No projects found to use as test data.');
+            }
+            return context.sendJson(record, 'out');
         }
-        return context.sendJson(record, 'out');
+
+        // level=Project subscribes to one specific project — fetch exactly that record.
+        if (level === 'Project') {
+            const response = await this.httpRequest(context, {
+                url: `${baseUrl}/${objectId}`,
+                method: 'GET'
+            });
+            if (!response.data) {
+                throw new context.CancelError(`Project ${objectId} not found to use as test data.`);
+            }
+            return context.sendJson(response.data, 'out');
+        }
+
+        // Status/Board narrow delivery to a subset that cannot be reproduced faithfully
+        // with a read-only fetch — throw rather than emit an out-of-scope sample.
+        throw new context.CancelError(
+            `Flow Test Mode cannot sample a "${level}"-scoped subscription read-only. Use level "Owner" or "Project", or trigger it with a real event.`
+        );
     },
 
     httpRequest: async function(context, override = {}) {

--- a/src/appmixer/connectwise/core/NewServiceTicket/NewServiceTicket.js
+++ b/src/appmixer/connectwise/core/NewServiceTicket/NewServiceTicket.js
@@ -27,6 +27,22 @@ module.exports = {
         }
     },
 
+    test: async function(context) {
+
+        // Fetch the newest service ticket through the same REST client/base URL the webhook
+        // lifecycle uses; the list resource matches the schema of the webhook Entity.
+        const response = await this.httpRequest(context, {
+            url: this.getBaseUrl(context) + '/service/tickets',
+            method: 'GET',
+            query: { orderBy: 'id desc', pageSize: 1 }
+        });
+        const record = (response.data || [])[0];
+        if (!record) {
+            throw new context.CancelError('No service tickets found to use as test data.');
+        }
+        return context.sendJson(record, 'out');
+    },
+
     httpRequest: async function(context, override = {}) {
 
         let url = null;

--- a/src/appmixer/connectwise/core/NewServiceTicket/NewServiceTicket.js
+++ b/src/appmixer/connectwise/core/NewServiceTicket/NewServiceTicket.js
@@ -29,18 +29,44 @@ module.exports = {
 
     test: async function(context) {
 
-        // Fetch the newest service ticket through the same REST client/base URL the webhook
-        // lifecycle uses; the list resource matches the schema of the webhook Entity.
-        const response = await this.httpRequest(context, {
-            url: this.getBaseUrl(context) + '/service/tickets',
-            method: 'GET',
-            query: { orderBy: 'id desc', pageSize: 1 }
-        });
-        const record = (response.data || [])[0];
-        if (!record) {
-            throw new context.CancelError('No service tickets found to use as test data.');
+        // Honor the subscription scope (properties.level/objectId) so Test Mode emits an
+        // example the configured trigger would actually deliver. All paths fetch through the
+        // same REST client/base URL the webhook lifecycle uses; the resource matches the
+        // schema of the webhook Entity.
+        const { level, objectId } = context.properties;
+        const baseUrl = this.getBaseUrl(context) + '/service/tickets';
+
+        // level=Owner subscribes to every ticket — the newest one is representative.
+        if (level === 'Owner') {
+            const response = await this.httpRequest(context, {
+                url: baseUrl,
+                method: 'GET',
+                query: { orderBy: 'id desc', pageSize: 1 }
+            });
+            const record = (response.data || [])[0];
+            if (!record) {
+                throw new context.CancelError('No service tickets found to use as test data.');
+            }
+            return context.sendJson(record, 'out');
         }
-        return context.sendJson(record, 'out');
+
+        // level=Ticket subscribes to one specific ticket — fetch exactly that record.
+        if (level === 'Ticket') {
+            const response = await this.httpRequest(context, {
+                url: `${baseUrl}/${objectId}`,
+                method: 'GET'
+            });
+            if (!response.data) {
+                throw new context.CancelError(`Ticket ${objectId} not found to use as test data.`);
+            }
+            return context.sendJson(response.data, 'out');
+        }
+
+        // Board/Project/Phase/Status/IntegratorTag narrow delivery to a subset that cannot be
+        // reproduced faithfully with a read-only fetch — throw rather than emit an out-of-scope sample.
+        throw new context.CancelError(
+            `Flow Test Mode cannot sample a "${level}"-scoped subscription read-only. Use level "Owner" or "Ticket", or trigger it with a real event.`
+        );
     },
 
     httpRequest: async function(context, override = {}) {

--- a/src/appmixer/hubspot/BaseSubscriptionComponent.js
+++ b/src/appmixer/hubspot/BaseSubscriptionComponent.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Hubspot = require('./Hubspot');
+const { getObjectProperties } = require('./commons');
 
 class BaseSubscriptionComponent {
 
@@ -109,6 +110,49 @@ class BaseSubscriptionComponent {
         this.configureHubspot(context);
         const portalId = context.auth?.profileInfo?.hub_id;
         return context.removeListener(`${this.subscriptionType}:${portalId}`);
+    }
+
+    /**
+     * Flow Test Mode helper shared by every subscription trigger's test(). Fetches the
+     * newest object of `objectType` via the CRM search API and emits it on `outputPort`
+     * in the SAME shape receive() emits (an element of a batch/read result:
+     * { id, properties, createdAt, updatedAt, archived }). Honors the same `properties`
+     * selection as receive(); callers pass any property filters (pipeline, dealstage)
+     * so the example matches the trigger's configuration.
+     * @param {string} objectType 'contacts' | 'deals'
+     * @param {object} [opts]
+     * @param {string} [opts.sortProperty] property to sort newest-first ('createdate' by default)
+     * @param {object[]} [opts.filters] HubSpot search filters ({ propertyName, operator, value })
+     * @returns {Promise<object>} The newest record.
+     */
+    async fetchLatestExample(context, objectType, { sortProperty = 'createdate', filters = [] } = {}) {
+
+        this.configureHubspot(context);
+
+        let propertiesToReturn;
+        const { properties } = context.properties;
+        if (!properties) {
+            propertiesToReturn = await getObjectProperties(context, this.hubspot, objectType, 'names');
+        } else {
+            propertiesToReturn = properties.split(',');
+        }
+
+        const body = {
+            sorts: [{ propertyName: sortProperty, direction: 'DESCENDING' }],
+            properties: propertiesToReturn,
+            limit: 1
+        };
+        if (filters.length) {
+            body.filterGroups = [{ filters }];
+        }
+
+        const { data } = await this.hubspot.call('post', `crm/v3/objects/${objectType}/search`, body);
+        const record = data.results && data.results[0];
+        if (!record) {
+            throw new context.CancelError(`No ${objectType} found to use as test data.`);
+        }
+
+        return record;
     }
 }
 

--- a/src/appmixer/hubspot/bundle.json
+++ b/src/appmixer/hubspot/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.hubspot",
-    "version": "4.5.1",
+    "version": "4.6.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -94,6 +94,9 @@
         ],
         "4.5.1": [
             "Added output examples to component schemas."
+        ],
+        "4.6.0": [
+            "Added test() (Flow Test Mode) to the NewContact, UpdatedContact, NewDeal, UpdatedDeal and DeletedContact triggers."
         ]
     }
 }

--- a/src/appmixer/hubspot/crm/DeletedContact/DeletedContact.js
+++ b/src/appmixer/hubspot/crm/DeletedContact/DeletedContact.js
@@ -23,6 +23,16 @@ class DeletedContact extends BaseSubscriptionComponent {
         }
         return context.response();
     }
+
+    // No fetchable example: a deletion emits the raw webhook event for a contact
+    // that no longer exists, and HubSpot exposes no API to list past deletion
+    // events. Throw so Flow Test Mode falls through to the log/schema fallbacks.
+    async test(context) {
+
+        throw new context.CancelError(
+            'DeletedContact can only be tested by deleting a contact in HubSpot — there is no API to fetch a past deletion event.'
+        );
+    }
 }
 
 module.exports = new DeletedContact(subscriptionType);

--- a/src/appmixer/hubspot/crm/NewContact/NewContact.js
+++ b/src/appmixer/hubspot/crm/NewContact/NewContact.js
@@ -62,6 +62,12 @@ class NewContact extends BaseSubscriptionComponent {
 
         return context.response();
     }
+
+    async test(context) {
+
+        const record = await this.fetchLatestExample(context, 'contacts');
+        return context.sendJson(record, 'contact');
+    }
 }
 
 module.exports = new NewContact(subscriptionType);

--- a/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
+++ b/src/appmixer/hubspot/crm/NewDeal/NewDeal.js
@@ -69,6 +69,17 @@ class NewDeal extends BaseSubscriptionComponent {
 
         return context.response();
     }
+
+    async test(context) {
+
+        const { pipeline: filterPipeline } = context.properties;
+        const filters = [];
+        if (filterPipeline) {
+            filters.push({ propertyName: 'pipeline', operator: 'EQ', value: filterPipeline });
+        }
+        const record = await this.fetchLatestExample(context, 'deals', { filters });
+        return context.sendJson(record, 'deal');
+    }
 }
 
 module.exports = new NewDeal(subscriptionType);

--- a/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
+++ b/src/appmixer/hubspot/crm/UpdatedContact/UpdatedContact.js
@@ -69,6 +69,12 @@ class UpdatedContact extends BaseSubscriptionComponent {
 
         return context.response();
     }
+
+    async test(context) {
+
+        const record = await this.fetchLatestExample(context, 'contacts', { sortProperty: 'lastmodifieddate' });
+        return context.sendJson(record, 'contact');
+    }
 }
 
 module.exports = new UpdatedContact(subscriptionType);

--- a/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
+++ b/src/appmixer/hubspot/crm/UpdatedDeal/UpdatedDeal.js
@@ -78,6 +78,20 @@ class UpdatedDeal extends BaseSubscriptionComponent {
 
         return context.response();
     }
+
+    async test(context) {
+
+        const { pipeline: filterPipeline, dealstage: filterStage } = context.properties;
+        const filters = [];
+        if (filterPipeline) {
+            filters.push({ propertyName: 'pipeline', operator: 'EQ', value: filterPipeline });
+        }
+        if (filterStage) {
+            filters.push({ propertyName: 'dealstage', operator: 'EQ', value: filterStage });
+        }
+        const record = await this.fetchLatestExample(context, 'deals', { sortProperty: 'lastmodifieddate', filters });
+        return context.sendJson(record, 'deal');
+    }
 }
 
 module.exports = new UpdatedDeal(subscriptionType);

--- a/src/appmixer/jotform/bundle.json
+++ b/src/appmixer/jotform/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.jotform",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -22,6 +22,9 @@
         ],
         "3.0.0": [
             "(breaking change) MakeApiCall: headers and parameters changed to key-value array inputs per standard #1459 — existing flows that previously set these as JSON strings must migrate to the key-value editor. Body remains textarea/JSON."
+        ],
+        "3.1.0": [
+            "Added test() (Flow Test Mode) to the NewFormSubmission trigger (throws to defer to the engine fallback chain, as the JotForm webhook body has no fetchable REST equivalent)."
         ]
     }
 }

--- a/src/appmixer/jotform/core/NewFormSubmission/NewFormSubmission.js
+++ b/src/appmixer/jotform/core/NewFormSubmission/NewFormSubmission.js
@@ -22,6 +22,16 @@ module.exports = {
         }
     },
 
+    // No fetchable example: NewFormSubmission emits the raw JotForm webhook POST body
+    // (multipart form fields, rawRequest, …), which has no equivalent fetchable REST
+    // shape. Throw and let Flow Test Mode fall through to the log/schema fallbacks.
+    test: async function(context) {
+
+        throw new context.CancelError(
+            'NewFormSubmission can only be tested by submitting the form — the JotForm webhook POST body has no equivalent fetchable REST shape.'
+        );
+    },
+
     httpRequest: async function(context, override = {}) {
 
         let url = null;

--- a/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
+++ b/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 const ENTITY_NAME = 'Customer';
 
 module.exports = {
@@ -26,5 +26,11 @@ module.exports = {
     receive: function(context) {
 
         return webhookHandler(context, ENTITY_NAME);
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, ENTITY_NAME, 'MetaData.CreateTime');
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 const ENTITY_NAME = 'Invoice';
 
 module.exports = {
@@ -26,5 +26,11 @@ module.exports = {
     receive: function(context) {
 
         return webhookHandler(context, ENTITY_NAME);
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, ENTITY_NAME, 'MetaData.CreateTime');
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 const ENTITY_NAME = 'Customer';
 
 module.exports = {
@@ -26,5 +26,11 @@ module.exports = {
     receive: function(context) {
 
         return webhookHandler(context, ENTITY_NAME);
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, ENTITY_NAME);
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 const ENTITY_NAME = 'Invoice';
 
 module.exports = {
@@ -26,5 +26,11 @@ module.exports = {
     receive: function(context) {
 
         return webhookHandler(context, ENTITY_NAME);
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, ENTITY_NAME);
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.quickbooks",
-    "version": "1.5.7",
+    "version": "1.6.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -56,6 +56,9 @@
         ],
         "1.5.7": [
             "Added output examples to component schemas."
+        ],
+        "1.6.0": [
+            "Added test() (Flow Test Mode) to the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers."
         ]
     }
 }

--- a/src/appmixer/quickbooks/commons.js
+++ b/src/appmixer/quickbooks/commons.js
@@ -222,6 +222,30 @@ module.exports = {
         }
     },
 
+    /**
+     * Fetches the most recent record of an entity to use as a Flow Test Mode example.
+     * Uses the SAME query endpoint and `select * from <entity>` projection as
+     * webhookHandler(), so the emitted object is identical to a real webhook delivery —
+     * only the selection differs (newest-first instead of the webhook's IDs).
+     * @param {string} entity QuickBooks entity, e.g. 'Invoice' or 'Customer'.
+     * @param {string} [orderBy] metadata field to sort newest-first.
+     * @returns {Promise<object>} The newest record.
+     */
+    async fetchLatestExample(context, entity, orderBy = 'MetaData.LastUpdatedTime') {
+
+        const query = `select * from ${entity} order by ${orderBy} desc maxresults 1`;
+        const options = {
+            path: `v3/company/${context.profileInfo.companyId}/query?query=${encodeURIComponent(query)}`,
+            method: 'GET'
+        };
+        const { data } = await module.exports.makeRequest({ context, options });
+        const records = (data && data.QueryResponse && data.QueryResponse[entity]) || [];
+        if (!records.length) {
+            throw new context.CancelError(`No ${entity} records found to use as test data.`);
+        }
+        return records[0];
+    },
+
     getBaseUrl,
 
     /**

--- a/src/appmixer/twilio/bundle.json
+++ b/src/appmixer/twilio/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.twilio",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.1": [
             "Initial version."
@@ -11,6 +11,9 @@
         "1.1.0": [
             "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
+        ],
+        "1.2.0": [
+            "Added test() (Flow Test Mode) to the NewCall trigger (throws to defer to the engine fallback chain, as the inbound-call webhook has no fetchable REST equivalent)."
         ]
     }
 }

--- a/src/appmixer/twilio/calls/NewCall/NewCall.js
+++ b/src/appmixer/twilio/calls/NewCall/NewCall.js
@@ -23,5 +23,16 @@ module.exports = {
             await context.sendJson(context.messages.webhook.content.data, 'call');
             return context.response();
         }
+    },
+
+    // No fetchable example: NewCall emits Twilio's inbound voice callback request
+    // ("A Call Comes In" webhook). Twilio exposes no API that returns a past
+    // call-event payload in the same parameter shape, so throw and let Flow Test
+    // Mode fall through to the log/schema fallbacks.
+    async test(context) {
+
+        throw new context.CancelError(
+            'NewCall can only be tested by placing a real call to your Twilio number — there is no API to fetch a past inbound-call webhook payload.'
+        );
     }
 };

--- a/src/appmixer/voys/bundle.json
+++ b/src/appmixer/voys/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.voys",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -8,6 +8,9 @@
         "1.1.0": [
             "re-generate using the OpenAPI Generator 2.1.2",
             "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459"
+        ],
+        "1.2.0": [
+            "Added test() (Flow Test Mode) to the WatchCall trigger (throws to defer to the engine fallback chain, as the call-notification webhook has no fetchable REST equivalent)."
         ]
     }
 }

--- a/src/appmixer/voys/freedom/WatchCall/WatchCall.js
+++ b/src/appmixer/voys/freedom/WatchCall/WatchCall.js
@@ -123,6 +123,16 @@ module.exports = {
             await context.sendJson(out, 'out');
             return context.response(out);
         }
+    },
+
+    // No fetchable example: WatchCall emits the raw Voys call-notification webhook
+    // body. Voys exposes no API to fetch a past notification in the same shape, so
+    // throw and let Flow Test Mode fall through to the log/schema fallbacks.
+    test: async function(context) {
+
+        throw new context.CancelError(
+            'WatchCall can only be tested by a real Voys call notification — there is no API to fetch a past notification payload.'
+        );
     }
 
 };

--- a/src/appmixer/xero/accounting/NewContact/NewContact.js
+++ b/src/appmixer/xero/accounting/NewContact/NewContact.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 
 module.exports = {
 
@@ -25,5 +25,11 @@ module.exports = {
         await webhookHandler(context, '/api.xro/2.0/Contacts');
 
         return context.response();
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, '/api.xro/2.0/Contacts');
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/xero/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/xero/accounting/NewInvoice/NewInvoice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 
 module.exports = {
 
@@ -25,5 +25,11 @@ module.exports = {
         await webhookHandler(context, '/api.xro/2.0/Invoices');
 
         return context.response();
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, '/api.xro/2.0/Invoices');
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/xero/accounting/UpdatedContact/UpdatedContact.js
+++ b/src/appmixer/xero/accounting/UpdatedContact/UpdatedContact.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 
 module.exports = {
 
@@ -25,5 +25,11 @@ module.exports = {
         await webhookHandler(context, '/api.xro/2.0/Contacts');
 
         return context.response();
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, '/api.xro/2.0/Contacts');
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/xero/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/xero/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webhookHandler } = require('../../commons');
+const { webhookHandler, fetchLatestExample } = require('../../commons');
 
 module.exports = {
 
@@ -25,5 +25,11 @@ module.exports = {
         await webhookHandler(context, '/api.xro/2.0/Invoices');
 
         return context.response();
+    },
+
+    test: async function(context) {
+
+        const record = await fetchLatestExample(context, '/api.xro/2.0/Invoices');
+        return context.sendJson(record, 'out');
     }
 };

--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.xero",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -31,6 +31,9 @@
             "Added component: CreateTrackingCategory.",
             "CreateTrackingCategoryOption: validate required inputs (tenantId, trackingCategoryId, name).",
             "ListTrackingCategories: tenantId is no longer a hard schema requirement so it can back a dependent dropdown; when used as a dropdown source (isSource) it degrades to an empty list on a missing/invalid tenant or API error instead of surfacing an inspector error."
+        ],
+        "1.5.0": [
+            "Added test() (Flow Test Mode) to the NewContact, UpdatedContact, NewInvoice and UpdatedInvoice triggers."
         ]
     }
 }

--- a/src/appmixer/xero/commons.js
+++ b/src/appmixer/xero/commons.js
@@ -72,5 +72,34 @@ module.exports = {
                 await lock.unlock();
             }
         }
+    },
+
+    /**
+     * Fetches the most recently updated record from a Xero endpoint to use as a
+     * Flow Test Mode example. Goes through the SAME XeroClient as webhookHandler()
+     * (same auth, endpoint, dataKey and includeArchived/summaryOnly flags) so the
+     * emitted object is byte-for-byte identical to a real webhook delivery — only
+     * the selection differs (newest-first instead of the webhook's IDs).
+     * @param {string} endpoint The Xero endpoint, e.g. '/api.xro/2.0/Contacts'.
+     * @returns {Promise<object>} The newest record.
+     */
+    async fetchLatestExample(context, endpoint) {
+
+        const { tenantId } = context.properties;
+        if (!tenantId) {
+            throw new context.CancelError('Tenant is required to fetch a test example.');
+        }
+
+        const xc = new XeroClient(context, tenantId);
+        const records = await xc.requestPaginated('GET', endpoint, {
+            countLimit: 1,
+            params: { order: 'UpdatedDateUTC DESC', includeArchived: true, summaryOnly: false }
+        });
+
+        if (!records.length) {
+            throw new context.CancelError(`No records found at ${endpoint} to use as test data.`);
+        }
+
+        return records[0];
     }
 };

--- a/src/appmixer/zoho/ZohoNotifiable.js
+++ b/src/appmixer/zoho/ZohoNotifiable.js
@@ -50,4 +50,24 @@ module.exports = class ZohoNotifiable {
             return this.updateState(context, events);
         }
     }
+
+    /**
+     * Flow Test Mode helper shared by every CRM notification trigger's test(). Fetches the
+     * newest record of `moduleName` via the SAME ZohoClient.getRecords() that ListRecords
+     * (and therefore receive()) uses, so the emitted object is identical to a real webhook
+     * delivery — only the selection differs (newest-first instead of the webhook's ids).
+     * @param {string} moduleName CRM module, e.g. 'Contacts' or 'Leads'.
+     * @param {string} [sortBy] field to sort newest-first ('Modified_Time' by default).
+     * @returns {Promise<object>} The newest record.
+     */
+    async fetchLatestExample(context, moduleName, sortBy = 'Modified_Time') {
+
+        const records = await this.makeZohoClient(context).getRecords(moduleName, {
+            params: { sort_by: sortBy, sort_order: 'desc', per_page: 1 }
+        });
+        if (!records || !records.length) {
+            throw new context.CancelError(`No ${moduleName} records found to use as test data.`);
+        }
+        return records[0];
+    }
 };

--- a/src/appmixer/zoho/crm/ContactCreated/ContactCreated.js
+++ b/src/appmixer/zoho/crm/ContactCreated/ContactCreated.js
@@ -21,6 +21,12 @@ class ContactCreated extends ZohoNotifiable {
         }
 
     }
+
+    async test(context) {
+
+        const contact = await this.fetchLatestExample(context, 'Contacts', 'Created_Time');
+        return context.sendJson(contact, 'contact');
+    }
 }
 
 const events = [

--- a/src/appmixer/zoho/crm/ContactUpdated/ContactUpdated.js
+++ b/src/appmixer/zoho/crm/ContactUpdated/ContactUpdated.js
@@ -21,6 +21,12 @@ class ContactUpdated extends ZohoNotifiable {
         }
 
     }
+
+    async test(context) {
+
+        const contact = await this.fetchLatestExample(context, 'Contacts');
+        return context.sendJson(contact, 'contact');
+    }
 }
 
 const events = [

--- a/src/appmixer/zoho/crm/LeadCreated/LeadCreated.js
+++ b/src/appmixer/zoho/crm/LeadCreated/LeadCreated.js
@@ -21,6 +21,12 @@ class LeadCreated extends ZohoNotifiable {
         }
 
     }
+
+    async test(context) {
+
+        const lead = await this.fetchLatestExample(context, 'Leads', 'Created_Time');
+        return context.sendJson(lead, 'lead');
+    }
 }
 
 const events = [

--- a/src/appmixer/zoho/crm/LeadUpdated/LeadUpdated.js
+++ b/src/appmixer/zoho/crm/LeadUpdated/LeadUpdated.js
@@ -21,6 +21,12 @@ class LeadUpdated extends ZohoNotifiable {
         }
 
     }
+
+    async test(context) {
+
+        const lead = await this.fetchLatestExample(context, 'Leads');
+        return context.sendJson(lead, 'lead');
+    }
 }
 
 const events = [

--- a/src/appmixer/zoho/crm/bundle.json
+++ b/src/appmixer/zoho/crm/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.zoho.crm",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -16,6 +16,9 @@
         ],
         "2.0.3": [
             "Fixed module ID."
+        ],
+        "2.1.0": [
+            "Added test() (Flow Test Mode) to the ContactCreated, ContactUpdated, LeadCreated and LeadUpdated triggers."
         ]
     }
 }


### PR DESCRIPTION
Flow Test Mode resolves a trigger's sample output via `test(context)` before falling
  back to log search / synthetic schema samples. Following the detection fix in #1154,
  **23 webhook triggers** were surfaced as still missing `test()`
  (`node scripts/validate.js --show-suppressed trigger-has-test-method`). This adds
  `test()` to all of them, bringing the `trigger-has-test-method` ratchet to its
  **floor of 0**.

  ### Approach

  Each `test()` follows the skill's core principle — **share the request + mapping path
  with `receive()`**, stay read-only, honor `context.properties`, emit exactly one item
  via `context.sendJson` in the same shape production emits, and **throw (never
  fabricate)** when there is no fetchable example.

  | Connector | Triggers | How `test()` gets the example |
  |---|---|---|
  | **xero** (4) | New/Updated Contact & Invoice | `commons.fetchLatestExample()` — newest-first via the same `XeroClient` `webhookHandler()` uses |
  | **hubspot** (5) | New/Updated Contact & Deal | `BaseSubscriptionComponent.fetchLatestExample()` — CRM search API, same `properties` selection + pipeline/dealstage filters as
  `receive()` |
  | | DeletedContact | **throws** — a deletion event has no fetchable upstream record |
  | **quickbooks** (4) | New/Updated Invoice & Customer | `commons.fetchLatestExample()` — same `select * from <entity>` query endpoint as `webhookHandler()` |
  | **zoho/crm** (4) | Contact/Lead Created & Updated | `ZohoNotifiable.fetchLatestExample()` — same `ZohoClient.getRecords()` seam ListRecords/`receive()` use |
  | **connectwise** (3) | NewContact, NewProject, NewServiceTicket | newest record via the trigger's existing `httpRequest()`/`getBaseUrl()` REST helpers |
  | **jotform / twilio / voys** (3) | NewFormSubmission, NewCall, WatchCall | **throw** — raw webhook body (form POST / inbound-call callback / call notification) has no equivalent
  fetchable REST shape (Hard rule 5) |

  Shared `fetchLatestExample()` helpers were added to each connector's commons / base
  class so `test()` is a thin wrapper and cannot drift from the production path.

  ### Validator & harness

  - Broadened `TEST_METHOD` detection in `trigger-has-test-method.js` to also recognise
    the `test: async function (context)` object-property form these connectors use
    (alongside the shorthand form).
  - **Removed the hardcoded `SKIP` set** from `trigger-has-test-method.js`. Triggers
    where `test()` is intentionally absent (generic webhooks, deletion/diff triggers,
    MQ consumers, engine internals) are now suppressed via `_ignore-list.js` with a
    recorded reason — consistent with every other validator's known deviations.
  - Added `_ignore-list.js` entries for the `trigger-test-method` "should throw"
    advisory on triggers that delegate the throw to a shared helper (hubspot/zoho) or
    legitimately always emit a synthetic payload (`utils` timers/controls).
  - `validate.js`: `--show-suppressed [validator]` now also surfaces **warnings** (not
    just threshold-held failures), and each validator's status line shows a
    `(+N ignored)` count.
  - `.thresholds.json`: `trigger-has-test-method 23 → 0`.

  ### Verification

  - `npm run lint` — clean
  - `node scripts/validate.js` — `exit 0`; `trigger-has-test-method: 0 (at threshold 0)`,
    `trigger-test-method: OK`, `bundle-versions` / `bundle-bump-on-change` OK
  - 8 connector bundles bumped (minor), changelogs ascending