### PR TITLE
http: WebhookTrigger output schema from request data example

### DIFF
--- a/src/appmixer/utils/http/WebhookTrigger/WebhookTrigger.js
+++ b/src/appmixer/utils/http/WebhookTrigger/WebhookTrigger.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const GenerateSchema = require('generate-schema');
+
 /**
  * This component is used to trigger flows (through trigger port). The other ports
  * can be used to pair request - response of the flow.
@@ -8,6 +10,10 @@
 module.exports = {
 
     async receive(context) {
+
+        if (context.properties.generateOutputPortOptions) {
+            return this.getOutputPortOptions(context, context.properties.dataExample);
+        }
 
         const immediateResponseTooltip = [
             'If you want a customized response, set it to <b>false</b> and to define the response using the <b>Response</b> component anywhere in the flow.',
@@ -43,5 +49,46 @@ module.exports = {
         }
 
         return context.response(context.messages.response.content);
+    },
+
+    // Flow Test Mode: a webhook has no upstream to fetch from, so emit the user-provided
+    // request data example in the exact { method, data, query, headers } shape that
+    // receive() forwards for a real request. Only reads the configured example — no state
+    // writes, no fabricated data.
+    test(context) {
+
+        const example = context.properties.dataExample;
+        if (!example) {
+            throw new Error('No request data example configured to use as test data.');
+        }
+
+        let data;
+        try {
+            data = JSON.parse(example);
+        } catch (err) {
+            throw new Error('The configured request data example is not valid JSON.');
+        }
+
+        return context.sendJson({ method: 'POST', data, query: {}, headers: {} }, 'request');
+    },
+
+    // Builds the variable-picker options for the `request` port. `method`, `query` and
+    // `headers` are always present; the shape of `data` is inferred from the user-provided
+    // JSON example so its individual fields become referable in connected components.
+    getOutputPortOptions(context, dataExample) {
+
+        let dataSchema = { type: 'object' };
+        try {
+            dataSchema = GenerateSchema.json('Data', JSON.parse(dataExample));
+        } catch (err) {
+            // No example or invalid JSON — leave `data` as a generic object.
+        }
+
+        return context.sendJson([
+            { label: 'Method', value: 'method', schema: { type: 'string' } },
+            { label: 'Data', value: 'data', schema: dataSchema },
+            { label: 'Query', value: 'query', schema: { type: 'object' } },
+            { label: 'Headers', value: 'headers', schema: { type: 'object' } }
+        ], 'request');
     }
 };

--- a/src/appmixer/utils/http/WebhookTrigger/component.json
+++ b/src/appmixer/utils/http/WebhookTrigger/component.json
@@ -9,19 +9,24 @@
     "outPorts": [
         {
             "name": "request",
-            "options": [
-                { "label": "Method", "value": "method" },
-                { "label": "Data", "value": "data" },
-                { "label": "Query", "value": "query" },
-                { "label": "Headers", "value": "headers" }
-            ]
+            "source": {
+                "url": "/component/appmixer/utils/http/WebhookTrigger?outPort=request&ignoreAuth=true",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true,
+                        "dataExample": "properties/dataExample"
+                    }
+                }
+            }
         }
     ],
     "properties": {
         "schema": {
             "properties": {
                 "generateInspector": { "type": "boolean" },
+                "generateOutputPortOptions": { "type": "boolean" },
                 "immediateResponse": { "type": "boolean", "default": true },
+                "dataExample": { "type": "string" },
                 "url": {}
             }
         },
@@ -32,6 +37,13 @@
                         "url": "/component/appmixer/utils/http/WebhookTrigger?outPort=request",
                         "data": { "properties": { "generateInspector": true } }
                     }
+                },
+                "dataExample": {
+                    "type": "textarea",
+                    "label": "Request Data Example",
+                    "index": 3,
+                    "tooltip": "Paste an example of the JSON request body you expect to receive. Its properties are used to name the output variables so you can reference the individual fields (e.g. Data > customer > email) in connected components. Also used as the payload in Flow Test Mode.",
+                    "defaultValue": "{\n  \"id\": 123,\n  \"name\": \"John Doe\"\n}"
                 }
             }
         }

--- a/src/appmixer/utils/http/bundle.json
+++ b/src/appmixer/utils/http/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.http",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -44,6 +44,9 @@
         ],
         "1.7.0": [
             "Added test() (Flow Test Mode) to triggers (Uptime)."
+        ],
+        "1.8.0": [
+            "Webhook Trigger: added a `Request Data Example` field that generates the output schema from a sample JSON body, so individual request data fields become referable in connected components. The example also powers Flow Test Mode via the new test() method."
         ]
     }
 }

--- a/src/appmixer/utils/http/package-lock.json
+++ b/src/appmixer/utils/http/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "axios": "^0.22.0",
                 "content-type": "^1.0.4",
+                "generate-schema": "^2.6.0",
                 "qs": "^6.10.1",
                 "undici": "^7.18.2"
             }
@@ -51,6 +52,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "license": "MIT"
         },
         "node_modules/content-type": {
             "version": "1.0.5",
@@ -132,6 +139,19 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generate-schema": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/generate-schema/-/generate-schema-2.6.0.tgz",
+            "integrity": "sha512-EUBKfJNzT8f91xUk5X5gKtnbdejZeE065UAJ3BCzE8VEbvwKI9Pm5jaWmqVeK1MYc1g5weAVFDTSJzN7ymtTqA==",
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^2.9.0",
+                "type-of-is": "^3.4.0"
+            },
+            "bin": {
+                "generate-schema": "bin/generate-schema"
             }
         },
         "node_modules/get-intrinsic": {
@@ -313,6 +333,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/type-of-is": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/type-of-is/-/type-of-is-3.5.1.tgz",
+            "integrity": "sha512-SOnx8xygcAh8lvDU2exnK2bomASfNjzB3Qz71s2tw9QnX8fkAo7aC+D0H7FV0HjRKj94CKV2Hi71kVkkO6nOxg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.5"
             }
         },
         "node_modules/undici": {

--- a/src/appmixer/utils/http/package.json
+++ b/src/appmixer/utils/http/package.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "axios": "^0.22.0",
         "content-type": "^1.0.4",
+        "generate-schema": "2.6.0",
         "qs": "^6.10.1",
         "undici": "^7.18.2"
     }


### PR DESCRIPTION
## What

The `http.WebhookTrigger` accepts arbitrary request bodies, so its `request` output port only exposed flat options (`method` / `data` / `query` / `headers`). Downstream you could reference the whole `data` blob but **not its individual fields**, which makes wiring a webhook into a flow painful.

This adds a **`Request Data Example`** inspector field. The pasted JSON is run through `generate-schema` to infer the shape of `data`, surfaced via a dynamic `generateOutputPortOptions` output port — so `{{$.request.data.customer.email}}` and friends show up in the variable picker. The same example also powers **Flow Test Mode** via a new `test()` method that replays it in the real `{ method, data, query, headers }` shape.

Mirrors the existing `appmixer.utils.appevents.OnAppEvent` pattern.

## Changes

- `WebhookTrigger/component.json`: `request` outPort is now dynamic (`generateOutputPortOptions` source, `ignoreAuth=true`); added `dataExample` textarea input and the matching property schema.
- `WebhookTrigger/WebhookTrigger.js`: `generateOutputPortOptions` branch → `getOutputPortOptions()` infers the `data` schema via `generate-schema`; new `test()` replays the example.
- `package.json` / `package-lock.json`: add `generate-schema@2.6.0` (already used by `utils/appevents`).
- `bundle.json`: `1.7.0` → `1.8.0` + changelog.

## Backward compatibility

Real request handling in `receive()` is unchanged — it still forwards `context.messages.webhook.content` verbatim. Existing flows keep working; `method`/`data`/`query`/`headers` are always returned even with no example set (invalid/empty example falls back to a generic `object` schema for `data`).

## Testing

- Unit-exercised all branches: nested-example schema inference, invalid-example fallback, `test()` replay, `test()` throw on missing example, and unchanged real-request forwarding.
- `npm run validate` passes. `eslint` clean.
- Pre-commit's changed-files check also flags the pre-existing `connector-has-makeapicall` gap (issue #1459) for `utils/http`; unrelated to this change and left out of scope.

Refs Appmixer-ai/appmixer-components#2755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
