### PR TITLE
xero(patch)

### DIFF
--- a/src/appmixer/xero/auth.js
+++ b/src/appmixer/xero/auth.js
@@ -28,32 +28,21 @@ module.exports = {
 
             requestProfileInfo: async context => {
 
-                const tenants = await context.httpRequest({
-                    url: 'https://api.xero.com/connections',
-                    method: 'GET',
-                    headers: {
-                        authorization: `Bearer ${context.accessToken}`,
-                        accept: 'application/json'
-                    }
-                });
-
-                const tenantId = tenants.data[0].tenantId;
-
-                // Use first tenant to get user info. All tenants should have the same user.
                 const { data } = await context.httpRequest({
-                    url: 'https://api.xero.com/api.xro/2.0/Users',
+                    url: 'https://identity.xero.com/connect/userinfo',
                     method: 'GET',
                     headers: {
                         authorization: `Bearer ${context.accessToken}`,
-                        'Xero-tenant-id': tenantId,
                         accept: 'application/json'
                     }
                 });
 
-                return data.Users[0];
+
+                await context.log({ 'step': 'auth', data });
+                return data;
             },
 
-            accountNameFromProfileInfo: 'EmailAddress'
+            accountNameFromProfileInfo: 'email'
         };
     }
 };

--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.xero",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -37,6 +37,10 @@
         ],
         "1.6.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Xero API."
+        ],
+        "1.6.1": [
+            "Fixed account identity resolution: profile info now comes from the OpenID Connect userinfo endpoint (the authenticated user) instead of the organisation's first user, so two users on the same Xero org no longer collapse to the same connected account.",
+            "Re-authentication required: existing Xero connections still carry the old (organisation's first user) identity. Remove and re-authorize each affected connection after upgrading for the correct user to resolve."
         ]
     }
 }


### PR DESCRIPTION
Fixed account identity resolution: profile info now comes from the OpenID Connect userinfo endpoint (the authenticated user) instead of the organisation's first user, so two users on the same Xero org no longer collapse to the same connected account.",

 Re-authentication required: existing Xero connections still carry the old (organisation's first user) identity. Remove and re-authorize each affected connection after upgrading for the correct user to resolve."
