### PR TITLE
test-flows: remove deprecated BeforeAll from 23 legacy E2E flows

### DIFF
--- a/src/appmixer/MSPowerBI/artifacts/test-flows/test-flow-add-rows.json
+++ b/src/appmixer/MSPowerBI/artifacts/test-flows/test-flow-add-rows.json
@@ -247,19 +247,6 @@
             "x": 1104,
             "y": 160
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 16
-        },
         "create-dataset": {
             "config": {
                 "transform": {
@@ -389,7 +376,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -413,7 +400,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/MSPowerBI/artifacts/test-flows/test-flow-datasets.json
+++ b/src/appmixer/MSPowerBI/artifacts/test-flows/test-flow-datasets.json
@@ -147,19 +147,6 @@
             "x": 1008,
             "y": 16
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 16
-        },
         "get-dataset": {
             "config": {
                 "transform": {
@@ -307,7 +294,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -331,7 +318,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/azuredevops/artifacts/test-flows/test-flow-list-projects-and-manage-work-item.json
+++ b/src/appmixer/azuredevops/artifacts/test-flows/test-flow-list-projects-and-manage-work-item.json
@@ -115,19 +115,6 @@
             "x": 832,
             "y": 16
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 16
-        },
         "create-work-item": {
             "config": {
                 "properties": {
@@ -321,7 +308,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -355,7 +342,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/azuredevops/artifacts/test-flows/test-flow-work-item-crud.json
+++ b/src/appmixer/azuredevops/artifacts/test-flows/test-flow-work-item-crud.json
@@ -169,19 +169,6 @@
             "x": 1200,
             "y": 272
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 16
-        },
         "create-work-item": {
             "config": {
                 "properties": {
@@ -387,7 +374,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -426,7 +413,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/azuredevops/artifacts/test-flows/test-flow-work-item-search-and-lifecycle.json
+++ b/src/appmixer/azuredevops/artifacts/test-flows/test-flow-work-item-search-and-lifecycle.json
@@ -234,19 +234,6 @@
             "x": 1296,
             "y": 416
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 16
-        },
         "create-work-item": {
             "config": {
                 "properties": {
@@ -502,7 +489,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -541,7 +528,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/box/artifacts/test-flows/test-flow-e2e-box-folder-crud.json
+++ b/src/appmixer/box/artifacts/test-flows/test-flow-e2e-box-folder-crud.json
@@ -136,18 +136,6 @@
                 }
             }
         },
-        "19f2a626-2650-4b4a-87f9-ea829b034ed3": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "source": {
-                "in": {
-                    "92a96ff4-3d88-40b8-a205-b29d49737d72": [
-                        "out"
-                    ]
-                }
-            },
-            "x": 336,
-            "y": 0
-        },
         "0c1d1fe9-2740-46c2-8f04-3afb148a541d": {
             "type": "appmixer.box.core.GetFile",
             "version": "1.0.0",
@@ -655,7 +643,7 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "19f2a626-2650-4b4a-87f9-ea829b034ed3": [
+                    "92a96ff4-3d88-40b8-a205-b29d49737d72": [
                         "out"
                     ]
                 }
@@ -677,7 +665,7 @@
                                 }
                             }
                         },
-                        "19f2a626-2650-4b4a-87f9-ea829b034ed3": {
+                        "92a96ff4-3d88-40b8-a205-b29d49737d72": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/box/artifacts/test-flows/test-flow-file-locking.json
+++ b/src/appmixer/box/artifacts/test-flows/test-flow-file-locking.json
@@ -8,20 +8,6 @@
             "version": "1.0.0",
             "config": {}
         },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 192,
-            "version": "1.0.0",
-            "config": {},
-            "source": {
-                "in": {
-                    "98b28ed7-0d1b-4ad6-ae76-efceaa755b0e": [
-                        "out"
-                    ]
-                }
-            }
-        },
         "upload-file": {
             "type": "appmixer.box.core.UploadFile",
             "x": 464,
@@ -29,7 +15,7 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "before-all": [
+                    "98b28ed7-0d1b-4ad6-ae76-efceaa755b0e": [
                         "out"
                     ]
                 }
@@ -37,7 +23,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "98b28ed7-0d1b-4ad6-ae76-efceaa755b0e": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/freshdesk/artifacts/test-flows/test-flow-company-lifecycle.json
+++ b/src/appmixer/freshdesk/artifacts/test-flows/test-flow-company-lifecycle.json
@@ -1,418 +1,404 @@
 {
-  "flow": {
-    "on-start": {
-      "type": "appmixer.utils.controls.OnStart",
-      "x": 64,
-      "y": 16,
-      "source": {},
-      "version": "1.0.0",
-      "config": {}
-    },
-    "before-all": {
-      "type": "appmixer.utils.test.BeforeAll",
-      "x": 256,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "on-start": [
-            "out"
-          ]
-        }
-      },
-      "config": {}
-    },
-    "create-company": {
-      "type": "appmixer.freshdesk.companies.CreateCompany",
-      "x": 640,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "gen-ts": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "gen-ts": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "name": {
-                    "6d4eb06b-4fff-439d-90a6-090b3a518da7": {
-                      "variable": "$.gen-ts.out.result",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "name": "{{{6d4eb06b-4fff-439d-90a6-090b3a518da7}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "get-company": {
-      "type": "appmixer.freshdesk.companies.GetCompany",
-      "x": 1024,
-      "y": 144,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "create-company": [
-            "company"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "create-company": {
-              "company": {
-                "type": "json2new",
-                "modifiers": {
-                  "companyId": {
-                    "13d8b68c-efd4-4123-88ff-ee8214243f97": {
-                      "variable": "$.create-company.company.id",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "companyId": "{{{13d8b68c-efd4-4123-88ff-ee8214243f97}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "update-company": {
-      "type": "appmixer.freshdesk.companies.UpdateCompany",
-      "x": 1168,
-      "y": 400,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "get-company": [
-            "company"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "get-company": {
-              "company": {
-                "type": "json2new",
-                "modifiers": {
-                  "name": {
-                    "972e32ae-47f4-432a-a40b-09db70504881": {
-                      "variable": "$.gen-ts.out.result",
-                      "functions": []
-                    }
-                  },
-                  "companyId": {
-                    "2289c993-c683-4717-826f-95652386f1c4": {
-                      "variable": "$.create-company.company.id",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "name": "{{{972e32ae-47f4-432a-a40b-09db70504881}}} Updated",
-                  "companyId": "{{{2289c993-c683-4717-826f-95652386f1c4}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "assert-create": {
-      "type": "appmixer.utils.test.Assert",
-      "x": 1408,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "create-company": [
-            "company"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "create-company": {
-              "company": {
-                "type": "json2new",
-                "modifiers": {
-                  "expression": {
-                    "7ffe8505-c9ed-4897-acd9-9d783e211c07": {
-                      "variable": "$.create-company.company.id",
-                      "functions": []
-                    },
-                    "18b08b59-6f5b-4447-8584-ec730a335fe5": {
-                      "variable": "$.create-company.company.name",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "expression": {
-                    "AND": [
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{7ffe8505-c9ed-4897-acd9-9d783e211c07}}}"
-                      },
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{18b08b59-6f5b-4447-8584-ec730a335fe5}}}"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "assert-get": {
-      "type": "appmixer.utils.test.Assert",
-      "x": 1408,
-      "y": 272,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "get-company": [
-            "company"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "get-company": {
-              "company": {
-                "type": "json2new",
-                "modifiers": {
-                  "expression": {
-                    "a2116d34-9faa-438e-9ebf-13317349d1b9": {
-                      "variable": "$.create-company.company.id",
-                      "functions": []
-                    },
-                    "aa1204cd-eac6-46a2-b275-f8eb164360e4": {
-                      "variable": "$.get-company.company.id",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "expression": {
-                    "AND": [
-                      {
-                        "assertion": "equal",
-                        "field": "{{{a2116d34-9faa-438e-9ebf-13317349d1b9}}}",
-                        "expected": "{{{aa1204cd-eac6-46a2-b275-f8eb164360e4}}}"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "assert-update": {
-      "type": "appmixer.utils.test.Assert",
-      "x": 1408,
-      "y": 400,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "update-company": [
-            "company"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "update-company": {
-              "company": {
-                "type": "json2new",
-                "modifiers": {
-                  "expression": {
-                    "303c929d-bfe4-487a-a0c8-05148a8ed4c6": {
-                      "variable": "$.update-company.company.name",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "expression": {
-                    "AND": [
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{303c929d-bfe4-487a-a0c8-05148a8ed4c6}}}"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "after-all": {
-      "type": "appmixer.utils.test.AfterAll",
-      "x": 1600,
-      "y": 272,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "assert-create": [
-            "out"
-          ],
-          "assert-get": [
-            "out"
-          ],
-          "assert-update": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "properties": {
-          "timeout": 30
-        }
-      }
-    },
-    "delete-company": {
-      "type": "appmixer.freshdesk.companies.DeleteCompany",
-      "x": 1792,
-      "y": 272,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "after-all": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "after-all": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "companyId": {
-                    "5e1822ae-e31d-4ff7-924c-4b846e9be7d4": {
-                      "variable": "$.create-company.company.id",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "companyId": "{{{5e1822ae-e31d-4ff7-924c-4b846e9be7d4}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "process-results": {
-      "type": "appmixer.utils.test.ProcessE2EResults",
-      "x": 1984,
-      "y": 272,
-      "version": "1.0.1",
-      "source": {
-        "in": {
-          "delete-company": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "properties": {
-          "successStoreId": "69cd26f6e2b144c4b022fd1e",
-          "failedStoreId": "69cd26f6e92e34e939fd2d1a"
+    "flow": {
+        "on-start": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "version": "1.0.0",
+            "config": {}
         },
-        "transform": {
-          "in": {
-            "delete-company": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "recipients": {},
-                  "testCase": {},
-                  "result": {
-                    "result-var": {
-                      "variable": "$.after-all.out",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "recipients": "david.durman@appmixer.ai",
-                  "testCase": "E2E Freshdesk - Company Lifecycle",
-                  "result": "{{{result-var}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gen-ts": {
-      "type": "appmixer.utils.controls.CodeBlock",
-      "x": 448,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "before-all": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "before-all": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "code": {},
-                  "variables": {}
-                },
-                "lambda": {
-                  "code": "'E2E Test Company ' + Date.now()",
-                  "variables": {
-                    "ADD": [
-                      {
-                        "type": "text",
-                        "toggle": false
-                      }
+        "create-company": {
+            "type": "appmixer.freshdesk.companies.CreateCompany",
+            "x": 640,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "gen-ts": [
+                        "out"
                     ]
-                  }
                 }
-              }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "gen-ts": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "name": {
+                                        "6d4eb06b-4fff-439d-90a6-090b3a518da7": {
+                                            "variable": "$.gen-ts.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "name": "{{{6d4eb06b-4fff-439d-90a6-090b3a518da7}}}"
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
+        },
+        "get-company": {
+            "type": "appmixer.freshdesk.companies.GetCompany",
+            "x": 1024,
+            "y": 144,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "create-company": [
+                        "company"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-company": {
+                            "company": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "companyId": {
+                                        "13d8b68c-efd4-4123-88ff-ee8214243f97": {
+                                            "variable": "$.create-company.company.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "companyId": "{{{13d8b68c-efd4-4123-88ff-ee8214243f97}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "update-company": {
+            "type": "appmixer.freshdesk.companies.UpdateCompany",
+            "x": 1168,
+            "y": 400,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "get-company": [
+                        "company"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "get-company": {
+                            "company": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "name": {
+                                        "972e32ae-47f4-432a-a40b-09db70504881": {
+                                            "variable": "$.gen-ts.out.result",
+                                            "functions": []
+                                        }
+                                    },
+                                    "companyId": {
+                                        "2289c993-c683-4717-826f-95652386f1c4": {
+                                            "variable": "$.create-company.company.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "name": "{{{972e32ae-47f4-432a-a40b-09db70504881}}} Updated",
+                                    "companyId": "{{{2289c993-c683-4717-826f-95652386f1c4}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-create": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1408,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "create-company": [
+                        "company"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-company": {
+                            "company": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "7ffe8505-c9ed-4897-acd9-9d783e211c07": {
+                                            "variable": "$.create-company.company.id",
+                                            "functions": []
+                                        },
+                                        "18b08b59-6f5b-4447-8584-ec730a335fe5": {
+                                            "variable": "$.create-company.company.name",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{7ffe8505-c9ed-4897-acd9-9d783e211c07}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{18b08b59-6f5b-4447-8584-ec730a335fe5}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-get": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1408,
+            "y": 272,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "get-company": [
+                        "company"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "get-company": {
+                            "company": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "a2116d34-9faa-438e-9ebf-13317349d1b9": {
+                                            "variable": "$.create-company.company.id",
+                                            "functions": []
+                                        },
+                                        "aa1204cd-eac6-46a2-b275-f8eb164360e4": {
+                                            "variable": "$.get-company.company.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "equal",
+                                                "field": "{{{a2116d34-9faa-438e-9ebf-13317349d1b9}}}",
+                                                "expected": "{{{aa1204cd-eac6-46a2-b275-f8eb164360e4}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-update": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1408,
+            "y": 400,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "update-company": [
+                        "company"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "update-company": {
+                            "company": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "303c929d-bfe4-487a-a0c8-05148a8ed4c6": {
+                                            "variable": "$.update-company.company.name",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{303c929d-bfe4-487a-a0c8-05148a8ed4c6}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "after-all": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1600,
+            "y": 272,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "assert-create": [
+                        "out"
+                    ],
+                    "assert-get": [
+                        "out"
+                    ],
+                    "assert-update": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 30
+                }
+            }
+        },
+        "delete-company": {
+            "type": "appmixer.freshdesk.companies.DeleteCompany",
+            "x": 1792,
+            "y": 272,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "after-all": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "after-all": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "companyId": {
+                                        "5e1822ae-e31d-4ff7-924c-4b846e9be7d4": {
+                                            "variable": "$.create-company.company.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "companyId": "{{{5e1822ae-e31d-4ff7-924c-4b846e9be7d4}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "process-results": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1984,
+            "y": 272,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "delete-company": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "successStoreId": "69cd26f6e2b144c4b022fd1e",
+                    "failedStoreId": "69cd26f6e92e34e939fd2d1a"
+                },
+                "transform": {
+                    "in": {
+                        "delete-company": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "result-var": {
+                                            "variable": "$.after-all.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "david.durman@appmixer.ai",
+                                    "testCase": "E2E Freshdesk - Company Lifecycle",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "gen-ts": {
+            "type": "appmixer.utils.controls.CodeBlock",
+            "x": 448,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "on-start": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "on-start": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "code": {},
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "code": "'E2E Test Company ' + Date.now()",
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "toggle": false
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/src/appmixer/freshdesk/artifacts/test-flows/test-flow-contact-lifecycle.json
+++ b/src/appmixer/freshdesk/artifacts/test-flows/test-flow-contact-lifecycle.json
@@ -10,9 +10,9 @@
             "version": "1.0.0",
             "config": {}
         },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
+        "set-variables": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 448,
             "y": 16,
             "version": "1.0.0",
             "source": {
@@ -22,24 +22,10 @@
                     ]
                 }
             },
-            "config": {}
-        },
-        "set-variables": {
-            "type": "appmixer.utils.controls.SetVariable",
-            "x": 448,
-            "y": 16,
-            "version": "1.0.0",
-            "source": {
-                "in": {
-                    "before-all": [
-                        "out"
-                    ]
-                }
-            },
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/freshdesk/artifacts/test-flows/test-flow-reply-note-lifecycle.json
+++ b/src/appmixer/freshdesk/artifacts/test-flows/test-flow-reply-note-lifecycle.json
@@ -1,389 +1,375 @@
 {
-  "name": "E2E Freshdesk - Reply and Note Lifecycle",
-  "flow": {
-    "on-start": {
-      "type": "appmixer.utils.controls.OnStart",
-      "x": 64,
-      "y": 16,
-      "source": {},
-      "version": "1.0.0",
-      "config": {}
-    },
-    "before-all": {
-      "type": "appmixer.utils.test.BeforeAll",
-      "x": 256,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "on-start": [
-            "out"
-          ]
-        }
-      },
-      "config": {}
-    },
-    "gen-ts": {
-      "type": "appmixer.utils.controls.CodeBlock",
-      "x": 448,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "before-all": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "before-all": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "code": {},
-                  "variables": {}
-                },
-                "lambda": {
-                  "code": "Date.now().toString()",
-                  "variables": {
-                    "ADD": [
-                      {
-                        "type": "text",
-                        "toggle": false
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "create-ticket": {
-      "type": "appmixer.freshdesk.tickets.CreateTicket",
-      "x": 640,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "gen-ts": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "gen-ts": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "subject": {
-                    "ts-var": {
-                      "variable": "$.gen-ts.out.result",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "subject": "E2E Test Ticket {{{ts-var}}}",
-                  "description": "E2E test ticket for reply and note lifecycle testing",
-                  "requesterEmail": "e2e-test@appmixer.ai",
-                  "status": 2,
-                  "priority": 1
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "create-reply": {
-      "type": "appmixer.freshdesk.tickets.CreateReply",
-      "x": 896,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "create-ticket": [
-            "newTicket"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "create-ticket": {
-              "newTicket": {
-                "type": "json2new",
-                "modifiers": {
-                  "ticketId": {
-                    "ticket-id-var": {
-                      "variable": "$.create-ticket.newTicket.id",
-                      "functions": []
-                    }
-                  },
-                  "body": {
-                    "ts-var": {
-                      "variable": "$.gen-ts.out.result",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "ticketId": "{{{ticket-id-var}}}",
-                  "body": "E2E test reply {{{ts-var}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "create-note": {
-      "type": "appmixer.freshdesk.tickets.CreateNote",
-      "x": 896,
-      "y": 200,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "create-ticket": [
-            "newTicket"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "create-ticket": {
-              "newTicket": {
-                "type": "json2new",
-                "modifiers": {
-                  "ticketId": {
-                    "ticket-id-var": {
-                      "variable": "$.create-ticket.newTicket.id",
-                      "functions": []
-                    }
-                  },
-                  "body": {
-                    "ts-var": {
-                      "variable": "$.gen-ts.out.result",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "ticketId": "{{{ticket-id-var}}}",
-                  "body": "E2E test note {{{ts-var}}}",
-                  "private": true
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "assert-reply": {
-      "type": "appmixer.utils.test.Assert",
-      "x": 1152,
-      "y": 16,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "create-reply": [
-            "newReply"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "create-reply": {
-              "newReply": {
-                "type": "json2new",
-                "modifiers": {
-                  "expression": {
-                    "reply-id-var": {
-                      "variable": "$.create-reply.newReply.id",
-                      "functions": []
-                    },
-                    "reply-ticket-id-var": {
-                      "variable": "$.create-reply.newReply.ticketId",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "expression": {
-                    "AND": [
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{reply-id-var}}}"
-                      },
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{reply-ticket-id-var}}}"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "assert-note": {
-      "type": "appmixer.utils.test.Assert",
-      "x": 1152,
-      "y": 200,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "create-note": [
-            "newNote"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "create-note": {
-              "newNote": {
-                "type": "json2new",
-                "modifiers": {
-                  "expression": {
-                    "note-id-var": {
-                      "variable": "$.create-note.newNote.id",
-                      "functions": []
-                    },
-                    "note-ticket-id-var": {
-                      "variable": "$.create-note.newNote.ticketId",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "expression": {
-                    "AND": [
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{note-id-var}}}"
-                      },
-                      {
-                        "assertion": "notEmpty",
-                        "field": "{{{note-ticket-id-var}}}"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "after-all": {
-      "type": "appmixer.utils.test.AfterAll",
-      "x": 1344,
-      "y": 100,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "assert-reply": [
-            "out"
-          ],
-          "assert-note": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "properties": {
-          "timeout": 30
-        }
-      }
-    },
-    "delete-ticket": {
-      "type": "appmixer.freshdesk.tickets.DeleteTicket",
-      "x": 1536,
-      "y": 100,
-      "version": "1.0.0",
-      "source": {
-        "in": {
-          "after-all": [
-            "out"
-          ]
-        }
-      },
-      "config": {
-        "transform": {
-          "in": {
-            "after-all": {
-              "out": {
-                "type": "json2new",
-                "modifiers": {
-                  "ticketId": {
-                    "ticket-id-var": {
-                      "variable": "$.create-ticket.newTicket.id",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "ticketId": "{{{ticket-id-var}}}"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "process-results": {
-      "type": "appmixer.utils.test.ProcessE2EResults",
-      "x": 1728,
-      "y": 100,
-      "version": "1.0.1",
-      "source": {
-        "in": {
-          "delete-ticket": [
-            "ticketId"
-          ]
-        }
-      },
-      "config": {
-        "properties": {
-          "successStoreId": "69cd26f6e2b144c4b022fd1e",
-          "failedStoreId": "69cd26f6e92e34e939fd2d1a"
+    "name": "E2E Freshdesk - Reply and Note Lifecycle",
+    "flow": {
+        "on-start": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "version": "1.0.0",
+            "config": {}
         },
-        "transform": {
-          "in": {
-            "delete-ticket": {
-              "ticketId": {
-                "type": "json2new",
-                "modifiers": {
-                  "recipients": {},
-                  "testCase": {},
-                  "result": {
-                    "result-var": {
-                      "variable": "$.after-all.out",
-                      "functions": []
-                    }
-                  }
-                },
-                "lambda": {
-                  "recipients": "david.durman@appmixer.ai",
-                  "testCase": "E2E Freshdesk - Reply and Note Lifecycle",
-                  "result": "{{{result-var}}}"
+        "gen-ts": {
+            "type": "appmixer.utils.controls.CodeBlock",
+            "x": 448,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "on-start": [
+                        "out"
+                    ]
                 }
-              }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "on-start": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "code": {},
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "code": "Date.now().toString()",
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "toggle": false
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
+        },
+        "create-ticket": {
+            "type": "appmixer.freshdesk.tickets.CreateTicket",
+            "x": 640,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "gen-ts": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "gen-ts": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "subject": {
+                                        "ts-var": {
+                                            "variable": "$.gen-ts.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "subject": "E2E Test Ticket {{{ts-var}}}",
+                                    "description": "E2E test ticket for reply and note lifecycle testing",
+                                    "requesterEmail": "e2e-test@appmixer.ai",
+                                    "status": 2,
+                                    "priority": 1
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "create-reply": {
+            "type": "appmixer.freshdesk.tickets.CreateReply",
+            "x": 896,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "create-ticket": [
+                        "newTicket"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-ticket": {
+                            "newTicket": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "ticketId": {
+                                        "ticket-id-var": {
+                                            "variable": "$.create-ticket.newTicket.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "body": {
+                                        "ts-var": {
+                                            "variable": "$.gen-ts.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "ticketId": "{{{ticket-id-var}}}",
+                                    "body": "E2E test reply {{{ts-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "create-note": {
+            "type": "appmixer.freshdesk.tickets.CreateNote",
+            "x": 896,
+            "y": 200,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "create-ticket": [
+                        "newTicket"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-ticket": {
+                            "newTicket": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "ticketId": {
+                                        "ticket-id-var": {
+                                            "variable": "$.create-ticket.newTicket.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "body": {
+                                        "ts-var": {
+                                            "variable": "$.gen-ts.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "ticketId": "{{{ticket-id-var}}}",
+                                    "body": "E2E test note {{{ts-var}}}",
+                                    "private": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-reply": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1152,
+            "y": 16,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "create-reply": [
+                        "newReply"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-reply": {
+                            "newReply": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "reply-id-var": {
+                                            "variable": "$.create-reply.newReply.id",
+                                            "functions": []
+                                        },
+                                        "reply-ticket-id-var": {
+                                            "variable": "$.create-reply.newReply.ticketId",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{reply-id-var}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{reply-ticket-id-var}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "assert-note": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1152,
+            "y": 200,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "create-note": [
+                        "newNote"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "create-note": {
+                            "newNote": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "note-id-var": {
+                                            "variable": "$.create-note.newNote.id",
+                                            "functions": []
+                                        },
+                                        "note-ticket-id-var": {
+                                            "variable": "$.create-note.newNote.ticketId",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{note-id-var}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{note-ticket-id-var}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "after-all": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1344,
+            "y": 100,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "assert-reply": [
+                        "out"
+                    ],
+                    "assert-note": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 30
+                }
+            }
+        },
+        "delete-ticket": {
+            "type": "appmixer.freshdesk.tickets.DeleteTicket",
+            "x": 1536,
+            "y": 100,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "after-all": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "after-all": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "ticketId": {
+                                        "ticket-id-var": {
+                                            "variable": "$.create-ticket.newTicket.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "ticketId": "{{{ticket-id-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "process-results": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1728,
+            "y": 100,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "delete-ticket": [
+                        "ticketId"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "successStoreId": "69cd26f6e2b144c4b022fd1e",
+                    "failedStoreId": "69cd26f6e92e34e939fd2d1a"
+                },
+                "transform": {
+                    "in": {
+                        "delete-ticket": {
+                            "ticketId": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "result-var": {
+                                            "variable": "$.after-all.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "david.durman@appmixer.ai",
+                                    "testCase": "E2E Freshdesk - Reply and Note Lifecycle",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/src/appmixer/freshdesk/artifacts/test-flows/test-flow-solutions-lifecycle.json
+++ b/src/appmixer/freshdesk/artifacts/test-flows/test-flow-solutions-lifecycle.json
@@ -10,18 +10,6 @@
             "version": "1.0.0",
             "config": {}
         },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 256,
-            "y": 16,
-            "version": "1.0.0",
-            "source": {
-                "in": {
-                    "on-start": ["out"]
-                }
-            },
-            "config": {}
-        },
         "gen-ts": {
             "type": "appmixer.utils.controls.CodeBlock",
             "x": 448,
@@ -29,13 +17,15 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "before-all": ["out"]
+                    "on-start": [
+                        "out"
+                    ]
                 }
             },
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -66,7 +56,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "gen-ts": ["out"]
+                    "gen-ts": [
+                        "out"
+                    ]
                 }
             },
             "config": {
@@ -99,7 +91,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "create-category": ["category"]
+                    "create-category": [
+                        "category"
+                    ]
                 }
             },
             "config": {
@@ -147,7 +141,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "create-category": ["category"]
+                    "create-category": [
+                        "category"
+                    ]
                 }
             },
             "config": {
@@ -188,7 +184,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "create-folder": ["folder"]
+                    "create-folder": [
+                        "folder"
+                    ]
                 }
             },
             "config": {
@@ -241,7 +239,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "create-folder": ["folder"]
+                    "create-folder": [
+                        "folder"
+                    ]
                 }
             },
             "config": {
@@ -283,7 +283,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "create-article": ["article"]
+                    "create-article": [
+                        "article"
+                    ]
                 }
             },
             "config": {
@@ -336,7 +338,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "create-article": ["article"]
+                    "create-article": [
+                        "article"
+                    ]
                 }
             },
             "config": {
@@ -376,7 +380,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "update-article": ["article"]
+                    "update-article": [
+                        "article"
+                    ]
                 }
             },
             "config": {
@@ -424,7 +430,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "update-article": ["article"]
+                    "update-article": [
+                        "article"
+                    ]
                 }
             },
             "config": {
@@ -457,7 +465,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "get-article": ["article"]
+                    "get-article": [
+                        "article"
+                    ]
                 }
             },
             "config": {
@@ -502,11 +512,21 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "assert-create-category": ["out"],
-                    "assert-create-folder": ["out"],
-                    "assert-create-article": ["out"],
-                    "assert-update-article": ["out"],
-                    "assert-get-article": ["out"]
+                    "assert-create-category": [
+                        "out"
+                    ],
+                    "assert-create-folder": [
+                        "out"
+                    ],
+                    "assert-create-article": [
+                        "out"
+                    ],
+                    "assert-update-article": [
+                        "out"
+                    ],
+                    "assert-get-article": [
+                        "out"
+                    ]
                 }
             },
             "config": {
@@ -522,7 +542,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "after-all": ["out"]
+                    "after-all": [
+                        "out"
+                    ]
                 }
             },
             "config": {
@@ -555,7 +577,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "delete-article": ["deleted"]
+                    "delete-article": [
+                        "deleted"
+                    ]
                 }
             },
             "config": {
@@ -588,7 +612,9 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "delete-folder": ["deleted"]
+                    "delete-folder": [
+                        "deleted"
+                    ]
                 }
             },
             "config": {
@@ -621,7 +647,9 @@
             "version": "1.0.1",
             "source": {
                 "in": {
-                    "delete-category": ["deleted"]
+                    "delete-category": [
+                        "deleted"
+                    ]
                 }
             },
             "config": {

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-appointment-scheduling.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-appointment-scheduling.json
@@ -120,19 +120,6 @@
             "x": 1168,
             "y": 16
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 96,
-            "y": 16
-        },
         "compute-end": {
             "config": {
                 "transform": {
@@ -337,7 +324,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -371,7 +358,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-contact-crud.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-contact-crud.json
@@ -172,19 +172,6 @@
             "x": 1008,
             "y": 272
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 160,
-            "y": 16
-        },
         "create-contact": {
             "config": {
                 "properties": {
@@ -368,7 +355,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -407,7 +394,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-find-contacts.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-find-contacts.json
@@ -111,19 +111,6 @@
             "x": 784,
             "y": 16
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 176,
-            "y": 32
-        },
         "create-contact": {
             "config": {
                 "properties": {
@@ -301,7 +288,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -340,7 +327,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-opportunity-lifecycle.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-opportunity-lifecycle.json
@@ -216,19 +216,6 @@
             "x": 1504,
             "y": 400
         },
-        "before-all": {
-            "config": {},
-            "source": {
-                "in": {
-                    "on-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": -24,
-            "y": 16
-        },
         "create-contact": {
             "config": {
                 "properties": {
@@ -509,7 +496,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "on-start": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -548,7 +535,7 @@
             },
             "source": {
                 "in": {
-                    "before-all": [
+                    "on-start": [
                         "out"
                     ]
                 }

--- a/src/appmixer/ragieai/artifacts/test-flows/test-flow-life-cycle.json
+++ b/src/appmixer/ragieai/artifacts/test-flows/test-flow-life-cycle.json
@@ -55,19 +55,6 @@
                 "properties": {}
             }
         },
-        "bd763065-560a-4c71-b27a-aa0762bd457a": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 320,
-            "y": 0,
-            "source": {
-                "in": {
-                    "e430d3c5-c8d4-48dd-8963-b95768abdbdd": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0"
-        },
         "460e8482-0f10-4f0d-9f0a-b45a82500fd7": {
             "type": "appmixer.utils.test.AfterAll",
             "x": 2496,
@@ -734,7 +721,7 @@
             "y": 0,
             "source": {
                 "in": {
-                    "bd763065-560a-4c71-b27a-aa0762bd457a": [
+                    "e430d3c5-c8d4-48dd-8963-b95768abdbdd": [
                         "out"
                     ]
                 }
@@ -743,7 +730,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "bd763065-560a-4c71-b27a-aa0762bd457a": {
+                        "e430d3c5-c8d4-48dd-8963-b95768abdbdd": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/redis/artifacts/test-flows/test-flow-pub-sub.json
+++ b/src/appmixer/redis/artifacts/test-flows/test-flow-pub-sub.json
@@ -53,9 +53,9 @@
                 }
             }
         },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 400,
+        "publish-message": {
+            "type": "appmixer.redis.core.PublishMessage",
+            "x": 550,
             "y": 200,
             "source": {
                 "in": {
@@ -65,24 +65,10 @@
                 }
             },
             "version": "1.0.0",
-            "config": {}
-        },
-        "publish-message": {
-            "type": "appmixer.redis.core.PublishMessage",
-            "x": 550,
-            "y": 200,
-            "source": {
-                "in": {
-                    "before-all": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0",
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "set-variables": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/todoist/artifacts/test-flows/test-flow-comment-crud.json
+++ b/src/appmixer/todoist/artifacts/test-flows/test-flow-comment-crud.json
@@ -50,20 +50,6 @@
                 }
             }
         },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 96,
-            "y": 128,
-            "source": {
-                "in": {
-                    "set-variables": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0",
-            "config": {}
-        },
         "create-comment": {
             "type": "appmixer.todoist.core.CreateComment",
             "x": 288,
@@ -71,7 +57,7 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "before-all": [
+                    "set-variables": [
                         "out"
                     ]
                 }
@@ -79,7 +65,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "set-variables": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/todoist/artifacts/test-flows/test-flow-label-crud.json
+++ b/src/appmixer/todoist/artifacts/test-flows/test-flow-label-crud.json
@@ -8,20 +8,6 @@
             "version": "1.0.0",
             "config": {}
         },
-        "before-all": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 320,
-            "y": 448,
-            "source": {
-                "in": {
-                    "fe2ff4ae-9b09-4c6c-bf93-484bc307a942": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0",
-            "config": {}
-        },
         "get-label": {
             "type": "appmixer.todoist.core.GetLabel",
             "x": 784,
@@ -115,7 +101,7 @@
             "y": 720,
             "source": {
                 "in": {
-                    "before-all": [
+                    "fe2ff4ae-9b09-4c6c-bf93-484bc307a942": [
                         "out"
                     ]
                 }
@@ -125,7 +111,7 @@
                 "transform": {
                     "in": {
                         "create-label": {},
-                        "before-all": {
+                        "fe2ff4ae-9b09-4c6c-bf93-484bc307a942": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -360,7 +346,7 @@
             "y": 160,
             "source": {
                 "in": {
-                    "before-all": [
+                    "fe2ff4ae-9b09-4c6c-bf93-484bc307a942": [
                         "out"
                     ]
                 }
@@ -369,7 +355,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "before-all": {
+                        "fe2ff4ae-9b09-4c6c-bf93-484bc307a942": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/todoist/artifacts/test-flows/test-flow-section-crud.json
+++ b/src/appmixer/todoist/artifacts/test-flows/test-flow-section-crud.json
@@ -69,20 +69,6 @@
                 }
             }
         },
-        "d97c0b55-48ba-4890-a199-c9500b0b55ee": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 288,
-            "y": -48,
-            "source": {
-                "in": {
-                    "ec580364-78aa-4c3e-871b-c4319fbad233": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0",
-            "config": {}
-        },
         "2b337aac-678e-4152-9ba9-a0bfef2e18d4": {
             "type": "appmixer.todoist.core.CreateProject",
             "x": 496,
@@ -90,7 +76,7 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "d97c0b55-48ba-4890-a199-c9500b0b55ee": [
+                    "ec580364-78aa-4c3e-871b-c4319fbad233": [
                         "out"
                     ]
                 }
@@ -98,7 +84,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "d97c0b55-48ba-4890-a199-c9500b0b55ee": {
+                        "ec580364-78aa-4c3e-871b-c4319fbad233": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/todoist/artifacts/test-flows/test-flow-tasks-advanced.json
+++ b/src/appmixer/todoist/artifacts/test-flows/test-flow-tasks-advanced.json
@@ -66,20 +66,6 @@
                 }
             }
         },
-        "778067c5-fef2-4268-b839-57a73f2354a5": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 400,
-            "y": 192,
-            "source": {
-                "in": {
-                    "483c7a43-8d76-47e6-bde8-583e36c93c25": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0",
-            "config": {}
-        },
         "5b3b1f30-9be7-4f05-b9db-6e535226eaab": {
             "type": "appmixer.todoist.core.CreateTask",
             "x": 784,
@@ -95,7 +81,6 @@
             "config": {
                 "transform": {
                     "in": {
-                        "778067c5-fef2-4268-b839-57a73f2354a5": {},
                         "f6d1454f-2f48-422e-a912-6aae0442cf46": {
                             "out": {
                                 "type": "json2new",
@@ -134,7 +119,8 @@
                                     "projectId": "{{{1aa7dfa2-b862-452c-af50-f073df6e7057}}}"
                                 }
                             }
-                        }
+                        },
+                        "483c7a43-8d76-47e6-bde8-583e36c93c25": {}
                     }
                 }
             }
@@ -497,7 +483,7 @@
             "version": "1.0.0",
             "source": {
                 "in": {
-                    "778067c5-fef2-4268-b839-57a73f2354a5": [
+                    "483c7a43-8d76-47e6-bde8-583e36c93c25": [
                         "out"
                     ]
                 }
@@ -507,7 +493,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "778067c5-fef2-4268-b839-57a73f2354a5": {
+                        "483c7a43-8d76-47e6-bde8-583e36c93c25": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {

--- a/src/appmixer/unkey/artifacts/test-flows/test-flow.json
+++ b/src/appmixer/unkey/artifacts/test-flows/test-flow.json
@@ -24,7 +24,7 @@
             "y": -96,
             "source": {
                 "in": {
-                    "2461595d-7795-47f6-aca1-55a5a7a8a9df": [
+                    "06e7bdd6-17b4-4101-8733-6b4776a6bdfc": [
                         "out"
                     ]
                 }
@@ -33,7 +33,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "2461595d-7795-47f6-aca1-55a5a7a8a9df": {
+                        "06e7bdd6-17b4-4101-8733-6b4776a6bdfc": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -214,7 +214,7 @@
             "y": 384,
             "source": {
                 "in": {
-                    "2461595d-7795-47f6-aca1-55a5a7a8a9df": [
+                    "06e7bdd6-17b4-4101-8733-6b4776a6bdfc": [
                         "out"
                     ]
                 }
@@ -223,7 +223,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "2461595d-7795-47f6-aca1-55a5a7a8a9df": {
+                        "06e7bdd6-17b4-4101-8733-6b4776a6bdfc": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -513,19 +513,6 @@
                     }
                 }
             }
-        },
-        "2461595d-7795-47f6-aca1-55a5a7a8a9df": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 352,
-            "y": 240,
-            "source": {
-                "in": {
-                    "06e7bdd6-17b4-4101-8733-6b4776a6bdfc": [
-                        "out"
-                    ]
-                }
-            },
-            "version": "1.0.0"
         },
         "9e6f156d-214e-404d-a06a-705c10376bb2": {
             "type": "appmixer.utils.test.Assert",

--- a/src/appmixer/vapi/artifacts/test-flows/test-flow-squads.json
+++ b/src/appmixer/vapi/artifacts/test-flows/test-flow-squads.json
@@ -51,9 +51,9 @@
                 }
             }
         },
-        "22d27632-f226-48e3-ac14-dcfe271c5a52": {
-            "type": "appmixer.utils.test.BeforeAll",
-            "x": 656,
+        "create-squad": {
+            "type": "appmixer.vapi.core.CreateSquad",
+            "x": 816,
             "y": 320,
             "source": {
                 "in": {
@@ -62,24 +62,11 @@
                     ]
                 }
             },
-            "version": "1.0.0"
-        },
-        "create-squad": {
-            "type": "appmixer.vapi.core.CreateSquad",
-            "x": 816,
-            "y": 320,
-            "source": {
-                "in": {
-                    "22d27632-f226-48e3-ac14-dcfe271c5a52": [
-                        "out"
-                    ]
-                }
-            },
             "version": "1.0.0",
             "config": {
                 "transform": {
                     "in": {
-                        "22d27632-f226-48e3-ac14-dcfe271c5a52": {
+                        "27fe7676-6028-43d0-b16f-368cc2d8d0d6": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -557,7 +544,7 @@
             "y": 512,
             "source": {
                 "in": {
-                    "22d27632-f226-48e3-ac14-dcfe271c5a52": [
+                    "27fe7676-6028-43d0-b16f-368cc2d8d0d6": [
                         "out"
                     ]
                 }
@@ -566,7 +553,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "22d27632-f226-48e3-ac14-dcfe271c5a52": {
+                        "27fe7676-6028-43d0-b16f-368cc2d8d0d6": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -589,7 +576,7 @@
             "y": 640,
             "source": {
                 "in": {
-                    "22d27632-f226-48e3-ac14-dcfe271c5a52": [
+                    "27fe7676-6028-43d0-b16f-368cc2d8d0d6": [
                         "out"
                     ]
                 }
@@ -598,7 +585,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "22d27632-f226-48e3-ac14-dcfe271c5a52": {
+                        "27fe7676-6028-43d0-b16f-368cc2d8d0d6": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
@@ -697,7 +684,7 @@
             "y": 96,
             "source": {
                 "in": {
-                    "22d27632-f226-48e3-ac14-dcfe271c5a52": [
+                    "27fe7676-6028-43d0-b16f-368cc2d8d0d6": [
                         "out"
                     ]
                 }
@@ -706,7 +693,7 @@
             "config": {
                 "transform": {
                     "in": {
-                        "22d27632-f226-48e3-ac14-dcfe271c5a52": {
+                        "27fe7676-6028-43d0-b16f-368cc2d8d0d6": {
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {


### PR DESCRIPTION
## Why

The E2E flow shape is `OnStart -> setup -> component(s) -> Assert -> AfterAll -> ProcessE2EResults`. `appmixer.utils.test.BeforeAll` is deprecated (the `no-beforeall` validator rejects it), but 23 flows across 10 connectors (azuredevops, box, freshdesk, gohighlevel, MSPowerBI, ragieai, redis, todoist, unkey, vapi) still carried it — and AI flow generators kept copying the deprecated shape from these files into new connectors.

## What

Mechanical rewrite of the 23 flows: each BeforeAll node removed, downstream components re-wired to its upstream (`source.in`, `config.transform.in` and `$.{id}.` variable references updated). No assertions or test semantics changed.

Note: these legacy flows have pre-existing validator debt unrelated to BeforeAll (missing `errorHandling`, one non-UUID component id) — intentionally left out of scope; the e2e runner injects fail-fast `errorHandling` at upload time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQuR5FoLxkiuDDcFpZ2a5t