### PR TITLE
Akamai: handle PENDING activation state in client list operations

### DIFF
--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-activate-and-wait.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-activate-and-wait.json
@@ -1,0 +1,378 @@
+{
+    "name": "E2E Akamai - Activate List and Wait",
+    "description": "End-to-end test for the Akamai connector - resolves a client list, activates it on the staging network, and waits for activation (GetLists, ActivateList, WaitForActivation).",
+    "type": "automation",
+    "flow": {
+        "e9488235-52d2-4879-9bdc-361faa27e93d": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 304,
+            "source": {},
+            "version": "1.0.0",
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "2b066432-e811-4872-ab14-ffadcf3977ce": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 256,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "e9488235-52d2-4879-9bdc-361faa27e93d": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "e9488235-52d2-4879-9bdc-361faa27e93d": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "testNetwork",
+                                                "text": "STAGING"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "comments",
+                                                "text": "Appmixer E2E activation"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "410b39db-c4d0-401d-83c0-6e8a10c998c7": {
+            "type": "appmixer.akamai.clientlist.GetLists",
+            "x": 448,
+            "y": 304,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "2b066432-e811-4872-ab14-ffadcf3977ce": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "2b066432-e811-4872-ab14-ffadcf3977ce": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "outputType": "first"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "1ec3170e-9540-4a6d-b8d9-b63014e4446b": {
+            "type": "appmixer.akamai.clientlist.ActivateList",
+            "x": 640,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "410b39db-c4d0-401d-83c0-6e8a10c998c7": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "410b39db-c4d0-401d-83c0-6e8a10c998c7": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "listId": {
+                                        "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a01": {
+                                            "variable": "$.410b39db-c4d0-401d-83c0-6e8a10c998c7.out.listId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "network": {
+                                        "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a02": {
+                                            "variable": "$.2b066432-e811-4872-ab14-ffadcf3977ce.out.testNetwork",
+                                            "functions": []
+                                        }
+                                    },
+                                    "comments": {
+                                        "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a03": {
+                                            "variable": "$.2b066432-e811-4872-ab14-ffadcf3977ce.out.comments",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "listId": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a01}}}",
+                                    "network": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a02}}}",
+                                    "comments": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a03}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f1753ba4-32ed-42da-aca9-206ae85eec28": {
+            "type": "appmixer.akamai.clientlist.WaitForActivation",
+            "x": 848,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "1ec3170e-9540-4a6d-b8d9-b63014e4446b": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "1ec3170e-9540-4a6d-b8d9-b63014e4446b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "listId": {
+                                        "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a04": {
+                                            "variable": "$.410b39db-c4d0-401d-83c0-6e8a10c998c7.out.listId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "network": {
+                                        "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a05": {
+                                            "variable": "$.2b066432-e811-4872-ab14-ffadcf3977ce.out.testNetwork",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "listId": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a04}}}",
+                                    "network": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a05}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "9256b34f-47c0-4874-952f-f9e66744d2aa": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1056,
+            "y": 208,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "1ec3170e-9540-4a6d-b8d9-b63014e4446b": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "1ec3170e-9540-4a6d-b8d9-b63014e4446b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "field-activate-status": {
+                                            "variable": "$.1ec3170e-9540-4a6d-b8d9-b63014e4446b.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.activationStatus"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{field-activate-status}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "49e3208c-807e-42cd-bdf6-31b3b7e37f50": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1056,
+            "y": 400,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "f1753ba4-32ed-42da-aca9-206ae85eec28": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "f1753ba4-32ed-42da-aca9-206ae85eec28": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "field-wait-status": {
+                                            "variable": "$.f1753ba4-32ed-42da-aca9-206ae85eec28.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.activationStatus"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{field-wait-status}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "4314d14d-0144-45f4-8dc9-8cfed8dac473": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1280,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "9256b34f-47c0-4874-952f-f9e66744d2aa": [
+                        "out"
+                    ],
+                    "49e3208c-807e-42cd-bdf6-31b3b7e37f50": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 300
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f2c7b2e0-efb1-4874-99ff-03d18691b767": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1488,
+            "y": 304,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "4314d14d-0144-45f4-8dc9-8cfed8dac473": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "4314d14d-0144-45f4-8dc9-8cfed8dac473": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "result-var": {
+                                            "variable": "$.4314d14d-0144-45f4-8dc9-8cfed8dac473.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "E2E Akamai - Activate List and Wait",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-activate-and-wait.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-activate-and-wait.json
@@ -48,6 +48,11 @@
                                                 "type": "text",
                                                 "name": "comments",
                                                 "text": "Appmixer E2E activation"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "testListId",
+                                                "text": "222379_SALTTESTNEW"
                                             }
                                         ]
                                     }
@@ -117,7 +122,7 @@
                                 "modifiers": {
                                     "listId": {
                                         "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a01": {
-                                            "variable": "$.410b39db-c4d0-401d-83c0-6e8a10c998c7.out.listId",
+                                            "variable": "$.2b066432-e811-4872-ab14-ffadcf3977ce.out.testListId",
                                             "functions": []
                                         }
                                     },
@@ -137,7 +142,9 @@
                                 "lambda": {
                                     "listId": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a01}}}",
                                     "network": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a02}}}",
-                                    "comments": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a03}}}"
+                                    "comments": "{{{7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a03}}}",
+                                    "waitForActivation": true,
+                                    "timeout": 900
                                 }
                             }
                         }
@@ -170,7 +177,7 @@
                                 "modifiers": {
                                     "listId": {
                                         "7ad2f0b1-1c2d-4e3f-8a4b-5c6d7e8f9a04": {
-                                            "variable": "$.410b39db-c4d0-401d-83c0-6e8a10c998c7.out.listId",
+                                            "variable": "$.2b066432-e811-4872-ab14-ffadcf3977ce.out.testListId",
                                             "functions": []
                                         }
                                     },

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-activate-and-wait.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-activate-and-wait.json
@@ -1,7 +1,4 @@
 {
-    "name": "E2E Akamai - Activate List and Wait",
-    "description": "End-to-end test for the Akamai connector - resolves a client list, activates it on the staging network, and waits for activation (GetLists, ActivateList, WaitForActivation).",
-    "type": "automation",
     "flow": {
         "e9488235-52d2-4879-9bdc-361faa27e93d": {
             "type": "appmixer.utils.controls.OnStart",
@@ -94,6 +91,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -149,6 +149,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -195,6 +198,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -381,5 +387,8 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Akamai - Activate List and Wait",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-client-list-entry-lifecycle.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-client-list-entry-lifecycle.json
@@ -1,0 +1,489 @@
+{
+    "name": "E2E Akamai - Client List Entry Lifecycle",
+    "description": "End-to-end test for the Akamai connector - reads client lists, upserts an entry, reads it back, and deletes it (GetLists, UpsertListEntries, GetListEntries, DeleteListEntries).",
+    "type": "automation",
+    "flow": {
+        "c2bbdcb4-a0b8-4545-af58-e199b7fb9ace": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 304,
+            "source": {},
+            "version": "1.0.0",
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "5040044a-91dc-40ef-91bf-1d24fd82a791": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 256,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "c2bbdcb4-a0b8-4545-af58-e199b7fb9ace": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "c2bbdcb4-a0b8-4545-af58-e199b7fb9ace": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "testValue",
+                                                "text": "203.0.113.10"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "testNetwork",
+                                                "text": "STAGING"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "testDescription",
+                                                "text": "Appmixer E2E test entry"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "72c41a92-4cae-4625-a4ab-f23157be926e": {
+            "type": "appmixer.akamai.clientlist.GetLists",
+            "x": 448,
+            "y": 304,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "5040044a-91dc-40ef-91bf-1d24fd82a791": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "5040044a-91dc-40ef-91bf-1d24fd82a791": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "outputType": "first"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "4fc89182-0dff-43f4-88e9-703aa1b89fce": {
+            "type": "appmixer.akamai.clientlist.UpsertListEntries",
+            "x": 640,
+            "y": 304,
+            "version": "1.1.0",
+            "source": {
+                "in": {
+                    "72c41a92-4cae-4625-a4ab-f23157be926e": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "72c41a92-4cae-4625-a4ab-f23157be926e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "listId": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a01": {
+                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out.listId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "value": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a02": {
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testValue",
+                                            "functions": []
+                                        }
+                                    },
+                                    "network": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a03": {
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testNetwork",
+                                            "functions": []
+                                        }
+                                    },
+                                    "description": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a04": {
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testDescription",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "listId": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a01}}}",
+                                    "value": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a02}}}",
+                                    "network": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a03}}}",
+                                    "description": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a04}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "b082af20-bc12-4c45-ac1a-fbe9c3ae1c2a": {
+            "type": "appmixer.akamai.clientlist.GetListEntries",
+            "x": 848,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "4fc89182-0dff-43f4-88e9-703aa1b89fce": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4fc89182-0dff-43f4-88e9-703aa1b89fce": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "listId": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a05": {
+                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out.listId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "listId": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a05}}}",
+                                    "outputType": "first"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "c7fcafa3-464d-4fd1-a449-6728e98355b6": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1056,
+            "y": 128,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "72c41a92-4cae-4625-a4ab-f23157be926e": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "72c41a92-4cae-4625-a4ab-f23157be926e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "field-getlists-id": {
+                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.listId"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{field-getlists-id}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "fc595aaf-cd9b-4d42-bb4b-5306cc07690e": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1056,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "4fc89182-0dff-43f4-88e9-703aa1b89fce": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4fc89182-0dff-43f4-88e9-703aa1b89fce": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "field-upsert-status": {
+                                            "variable": "$.4fc89182-0dff-43f4-88e9-703aa1b89fce.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.activationStatus"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{field-upsert-status}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "455fab12-d40d-484e-8ecc-a35de2fe111d": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1056,
+            "y": 480,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "b082af20-bc12-4c45-ac1a-fbe9c3ae1c2a": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "b082af20-bc12-4c45-ac1a-fbe9c3ae1c2a": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "field-entry-value": {
+                                            "variable": "$.b082af20-bc12-4c45-ac1a-fbe9c3ae1c2a.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.value"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{field-entry-value}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "19e8ffde-bc43-44c1-8cf9-fdfb65ccdc08": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1280,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "c7fcafa3-464d-4fd1-a449-6728e98355b6": [
+                        "out"
+                    ],
+                    "fc595aaf-cd9b-4d42-bb4b-5306cc07690e": [
+                        "out"
+                    ],
+                    "455fab12-d40d-484e-8ecc-a35de2fe111d": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 120
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "b370c191-d92f-42fe-ae80-cdac3114da9b": {
+            "type": "appmixer.akamai.clientlist.DeleteListEntries",
+            "x": 1488,
+            "y": 304,
+            "version": "1.1.0",
+            "source": {
+                "in": {
+                    "19e8ffde-bc43-44c1-8cf9-fdfb65ccdc08": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "19e8ffde-bc43-44c1-8cf9-fdfb65ccdc08": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "listId": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a06": {
+                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out.listId",
+                                            "functions": []
+                                        }
+                                    },
+                                    "value": {
+                                        "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a07": {
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testValue",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "listId": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a06}}}",
+                                    "value": "{{{5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a07}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "1f144957-ffdf-47af-9d6b-37a91726d057": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1696,
+            "y": 304,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "b370c191-d92f-42fe-ae80-cdac3114da9b": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "b370c191-d92f-42fe-ae80-cdac3114da9b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "result-var": {
+                                            "variable": "$.19e8ffde-bc43-44c1-8cf9-fdfb65ccdc08.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "E2E Akamai - Client List Entry Lifecycle",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-client-list-entry-lifecycle.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-client-list-entry-lifecycle.json
@@ -1,7 +1,4 @@
 {
-    "name": "E2E Akamai - Client List Entry Lifecycle",
-    "description": "End-to-end test for the Akamai connector - reads client lists, upserts an entry, reads it back, and deletes it (GetLists, UpsertListEntries, GetListEntries, DeleteListEntries).",
-    "type": "automation",
     "flow": {
         "c2bbdcb4-a0b8-4545-af58-e199b7fb9ace": {
             "type": "appmixer.utils.controls.OnStart",
@@ -99,6 +96,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -108,8 +108,8 @@
         },
         "4fc89182-0dff-43f4-88e9-703aa1b89fce": {
             "type": "appmixer.akamai.clientlist.UpsertListEntries",
-            "x": 640,
-            "y": 304,
+            "x": 656,
+            "y": 400,
             "version": "1.1.0",
             "source": {
                 "in": {
@@ -159,6 +159,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -168,8 +171,8 @@
         },
         "b082af20-bc12-4c45-ac1a-fbe9c3ae1c2a": {
             "type": "appmixer.akamai.clientlist.GetListEntries",
-            "x": 848,
-            "y": 304,
+            "x": 864,
+            "y": 560,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -200,6 +203,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -209,8 +215,8 @@
         },
         "c7fcafa3-464d-4fd1-a449-6728e98355b6": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1056,
-            "y": 128,
+            "x": 1088,
+            "y": 288,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -264,8 +270,8 @@
         },
         "fc595aaf-cd9b-4d42-bb4b-5306cc07690e": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1056,
-            "y": 304,
+            "x": 1088,
+            "y": 400,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -319,8 +325,8 @@
         },
         "455fab12-d40d-484e-8ecc-a35de2fe111d": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1056,
-            "y": 480,
+            "x": 1088,
+            "y": 544,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -374,8 +380,8 @@
         },
         "19e8ffde-bc43-44c1-8cf9-fdfb65ccdc08": {
             "type": "appmixer.utils.test.AfterAll",
-            "x": 1280,
-            "y": 304,
+            "x": 1328,
+            "y": 288,
             "version": "1.0.0",
             "source": {
                 "in": {
@@ -402,8 +408,8 @@
         },
         "b370c191-d92f-42fe-ae80-cdac3114da9b": {
             "type": "appmixer.akamai.clientlist.DeleteListEntries",
-            "x": 1488,
-            "y": 304,
+            "x": 1520,
+            "y": 288,
             "version": "1.1.0",
             "source": {
                 "in": {
@@ -439,6 +445,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -448,8 +457,8 @@
         },
         "1f144957-ffdf-47af-9d6b-37a91726d057": {
             "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 1696,
-            "y": 304,
+            "x": 1712,
+            "y": 272,
             "version": "1.0.1",
             "source": {
                 "in": {
@@ -490,5 +499,8 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Akamai - Client List Entry Lifecycle",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-client-list-entry-lifecycle.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-client-list-entry-lifecycle.json
@@ -53,6 +53,11 @@
                                                 "type": "text",
                                                 "name": "testDescription",
                                                 "text": "Appmixer E2E test entry"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "testListId",
+                                                "text": "222379_SALTTESTNEW"
                                             }
                                         ]
                                     }
@@ -122,7 +127,7 @@
                                 "modifiers": {
                                     "listId": {
                                         "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a01": {
-                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out.listId",
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testListId",
                                             "functions": []
                                         }
                                     },
@@ -182,7 +187,7 @@
                                 "modifiers": {
                                     "listId": {
                                         "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a05": {
-                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out.listId",
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testListId",
                                             "functions": []
                                         }
                                     },
@@ -416,7 +421,7 @@
                                 "modifiers": {
                                     "listId": {
                                         "5cc3a1cb-1f34-4d3f-9a45-8c2f7e3b1a06": {
-                                            "variable": "$.72c41a92-4cae-4625-a4ab-f23157be926e.out.listId",
+                                            "variable": "$.5040044a-91dc-40ef-91bf-1d24fd82a791.out.testListId",
                                             "functions": []
                                         }
                                     },

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-make-api-call.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-make-api-call.json
@@ -1,7 +1,4 @@
 {
-    "name": "E2E Akamai - Make API Call",
-    "description": "End-to-end test for the Akamai connector - performs an authorized GET request against the Akamai client-list API (MakeApiCall).",
-    "type": "automation",
     "flow": {
         "dab68c2f-5f30-450f-ade7-c9230a6907d6": {
             "type": "appmixer.utils.controls.OnStart",
@@ -91,6 +88,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a589598c0a5d051ff7226f9"
                 }
             },
             "errorHandling": {
@@ -220,5 +220,8 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Akamai - Make API Call",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-make-api-call.json
+++ b/src/appmixer/akamai/artifacts/test-flows/test-flow-e2e-akamai-make-api-call.json
@@ -1,0 +1,224 @@
+{
+    "name": "E2E Akamai - Make API Call",
+    "description": "End-to-end test for the Akamai connector - performs an authorized GET request against the Akamai client-list API (MakeApiCall).",
+    "type": "automation",
+    "flow": {
+        "dab68c2f-5f30-450f-ade7-c9230a6907d6": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 304,
+            "source": {},
+            "version": "1.0.0",
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "fe928be3-afff-417c-bdb9-f5f1a47efff1": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 256,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "dab68c2f-5f30-450f-ade7-c9230a6907d6": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "dab68c2f-5f30-450f-ade7-c9230a6907d6": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "apiPath",
+                                                "text": "/client-list/v1/lists"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "01fe545c-3512-4042-becd-426303fbea37": {
+            "type": "appmixer.akamai.core.MakeApiCall",
+            "x": 448,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "fe928be3-afff-417c-bdb9-f5f1a47efff1": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "fe928be3-afff-417c-bdb9-f5f1a47efff1": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {
+                                        "3f5a7c91-2b4d-4e6f-8a1c-9d0e1f2a3b01": {
+                                            "variable": "$.fe928be3-afff-417c-bdb9-f5f1a47efff1.out.apiPath",
+                                            "functions": []
+                                        }
+                                    },
+                                    "method": {}
+                                },
+                                "lambda": {
+                                    "url": "{{{3f5a7c91-2b4d-4e6f-8a1c-9d0e1f2a3b01}}}",
+                                    "method": "GET"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "b843635e-731d-4f02-b90c-6c01bae81dce": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 656,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "01fe545c-3512-4042-becd-426303fbea37": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "01fe545c-3512-4042-becd-426303fbea37": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "field-api-status": {
+                                            "variable": "$.01fe545c-3512-4042-becd-426303fbea37.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.status"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{field-api-status}}}",
+                                                "assertion": "equal",
+                                                "expected": "200"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "055c0791-f28b-4e0f-a3ce-69fef23e27f2": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 864,
+            "y": 304,
+            "version": "1.0.0",
+            "source": {
+                "in": {
+                    "b843635e-731d-4f02-b90c-6c01bae81dce": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 60
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "ed852fc5-f82d-4c52-a0ba-0a8d83493b90": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1072,
+            "y": 304,
+            "version": "1.0.1",
+            "source": {
+                "in": {
+                    "055c0791-f28b-4e0f-a3ce-69fef23e27f2": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "055c0791-f28b-4e0f-a3ce-69fef23e27f2": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "result-var": {
+                                            "variable": "$.055c0791-f28b-4e0f-a3ce-69fef23e27f2.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "E2E Akamai - Make API Call",
+                                    "result": "{{{result-var}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/akamai/bundle.json
+++ b/src/appmixer/akamai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.akamai",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -28,6 +28,10 @@
         "1.3.0": [
             "ActivateList, UpsertListEntries: check the current activation status before activating. If the list is already PENDING_ACTIVATION, either wait for it to complete (new \"Wait for Activation\" option, with configurable timeout) or fail with a clear message instead of a silent error. Activation status is now surfaced on the output.",
             "Added WaitForActivation component that polls a list until it reaches the ACTIVE state, useful for rapid sequential list updates (attacker-after-attacker mitigation)."
+        ],
+        "1.3.1": [
+            "ActivateList, UpsertListEntries, WaitForActivation: waiting for activation no longer blocks the component execution (which is capped by the engine). Waits are carried by scheduled poll continuations (context.setTimeout) with the timeout enforced as a deadline. Concurrent waits on the same list share a cached status guarded by a lock, so a list is polled once per interval regardless of how many components wait on it.",
+            "ActivateList: activating a list that is already ACTIVE now succeeds as a no-op instead of failing (Akamai rejects re-activating an unchanged list version)."
         ]
     }
 }

--- a/src/appmixer/akamai/bundle.json
+++ b/src/appmixer/akamai/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.akamai",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -24,6 +24,10 @@
         ],
         "1.2.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Akamai API."
+        ],
+        "1.3.0": [
+            "ActivateList, UpsertListEntries: check the current activation status before activating. If the list is already PENDING_ACTIVATION, either wait for it to complete (new \"Wait for Activation\" option, with configurable timeout) or fail with a clear message instead of a silent error. Activation status is now surfaced on the output.",
+            "Added WaitForActivation component that polls a list until it reaches the ACTIVE state, useful for rapid sequential list updates (attacker-after-attacker mitigation)."
         ]
     }
 }

--- a/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
+++ b/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
@@ -1,10 +1,45 @@
 'use strict';
 
 const lib = require('../../lib');
-const { generateAuthorizationHeader, ACTIVATION_STATUS } = lib;
+const { ACTIVATION_STATUS } = lib;
 
 module.exports = {
+
     async receive(context) {
+
+        // Poll continuation scheduled by a previous receive() invocation.
+        if (context.messages.timeout) {
+            return lib.continueWait(context, {
+                onClear: async (ctx, wait, status) => {
+                    // The pending activation cleared. When it left the list ACTIVE
+                    // there is nothing left to activate — resolve right away.
+                    if (status === ACTIVATION_STATUS.ACTIVE) {
+                        await ctx.sendJson(
+                            { ...wait.output, activationStatus: ACTIVATION_STATUS.ACTIVE },
+                            'out'
+                        );
+                        return null;
+                    }
+                    const { hostnameUrl, accessToken, clientSecret, clientToken } = ctx.auth;
+                    const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
+                    const data = await lib.activateList(ctx, auth, {
+                        listId: wait.listId,
+                        network: wait.network,
+                        comments: wait.deferred.comments
+                    });
+                    return {
+                        ...wait,
+                        phase: 'awaitActive',
+                        output: { ...data, previousActivationStatus: wait.output.previousActivationStatus }
+                    };
+                },
+                onActive: (ctx, wait) => ctx.sendJson(
+                    { ...wait.output, activationStatus: ACTIVATION_STATUS.ACTIVE },
+                    'out'
+                )
+            });
+        }
+
         const { hostnameUrl, accessToken, clientSecret, clientToken } =
             context.auth;
         const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
@@ -21,8 +56,22 @@ module.exports = {
         // Check the current activation status before triggering a new activation.
         const currentStatus = await lib.getActivationStatus(context, auth, listId, network);
 
-        // A list already pending activation cannot be re-activated. Either wait for it
-        // to finish (so the caller can safely retry) or surface a clear error.
+        // Already active — Akamai rejects re-activating an unchanged list version,
+        // so there is nothing to do.
+        if (currentStatus === ACTIVATION_STATUS.ACTIVE) {
+            return context.sendJson(
+                {
+                    listId,
+                    previousActivationStatus: currentStatus,
+                    activationStatus: currentStatus
+                },
+                'out'
+            );
+        }
+
+        // A list already pending activation cannot be re-activated. Either defer
+        // the activation until the pending one clears (poll continuations take
+        // over) or surface a clear error.
         if (currentStatus === ACTIVATION_STATUS.PENDING) {
             if (!waitForActivation) {
                 throw new context.CancelError(
@@ -31,42 +80,33 @@ module.exports = {
                     'or retry once the current activation finishes.'
                 );
             }
-            await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+            return lib.startWait(context, {
+                listId,
+                network,
+                phase: 'awaitClear',
+                timeoutSeconds: timeout,
+                deferred: { comments },
+                output: { listId, previousActivationStatus: currentStatus }
+            });
         }
 
-        const body = { action: 'ACTIVATE', network, comments };
+        const data = await lib.activateList(context, auth, { listId, network, comments });
 
-        const {
-            url,
-            method,
-            headers: { Authorization }
-        } = generateAuthorizationHeader({
-            hostnameUrl,
-            accessToken,
-            clientToken,
-            clientSecret,
-            method: 'POST',
-            path: `/client-list/v1/lists/${listId}/activations`,
-            body
-        });
-
-        const { data } = await context.httpRequest({
-            url,
-            method,
-            headers: { Authorization },
-            data: body
-        });
-
-        // Optionally block until the activation reaches ACTIVE so downstream steps
-        // don't proceed on a still-pending list.
-        let finalStatus = data.activationStatus;
-        if (waitForActivation) {
-            finalStatus = await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+        if (!waitForActivation) {
+            return context.sendJson(
+                { ...data, previousActivationStatus: currentStatus },
+                'out'
+            );
         }
 
-        return context.sendJson(
-            { ...data, previousActivationStatus: currentStatus, activationStatus: finalStatus },
-            'out'
-        );
+        // Poll until the activation reaches ACTIVE so downstream steps don't
+        // proceed on a still-pending list.
+        return lib.startWait(context, {
+            listId,
+            network,
+            phase: 'awaitActive',
+            timeoutSeconds: timeout,
+            output: { ...data, previousActivationStatus: currentStatus }
+        });
     }
 };

--- a/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
+++ b/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
@@ -1,12 +1,14 @@
 'use strict';
 
-const { generateAuthorizationHeader } = require('../../lib');
+const lib = require('../../lib');
+const { generateAuthorizationHeader, ACTIVATION_STATUS } = lib;
 
 module.exports = {
     async receive(context) {
         const { hostnameUrl, accessToken, clientSecret, clientToken } =
             context.auth;
-        const { listId, network, comments } =
+        const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
+        const { listId, network, comments, waitForActivation, timeout } =
             context.messages.in.content;
         if (!listId) {
             throw new context.CancelError('List is required');
@@ -16,6 +18,21 @@ module.exports = {
             throw new context.CancelError('Network is required');
         }
 
+        // Check the current activation status before triggering a new activation.
+        const currentStatus = await lib.getActivationStatus(context, auth, listId, network);
+
+        // A list already pending activation cannot be re-activated. Either wait for it
+        // to finish (so the caller can safely retry) or surface a clear error.
+        if (currentStatus === ACTIVATION_STATUS.PENDING) {
+            if (!waitForActivation) {
+                throw new context.CancelError(
+                    `List ${listId} is already PENDING_ACTIVATION on the ${network} network. ` +
+                    'Akamai activations can take 1-15+ minutes to complete. Enable "Wait for Activation" ' +
+                    'or retry once the current activation finishes.'
+                );
+            }
+            await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+        }
 
         const body = { action: 'ACTIVATE', network, comments };
 
@@ -40,6 +57,16 @@ module.exports = {
             data: body
         });
 
-        return context.sendJson(data, 'out');
+        // Optionally block until the activation reaches ACTIVE so downstream steps
+        // don't proceed on a still-pending list.
+        let finalStatus = data.activationStatus;
+        if (waitForActivation) {
+            finalStatus = await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+        }
+
+        return context.sendJson(
+            { ...data, previousActivationStatus: currentStatus, activationStatus: finalStatus },
+            'out'
+        );
     }
 };

--- a/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
+++ b/src/appmixer/akamai/clientlist/ActivateList/ActivateList.js
@@ -62,6 +62,7 @@ module.exports = {
             return context.sendJson(
                 {
                     listId,
+                    network,
                     previousActivationStatus: currentStatus,
                     activationStatus: currentStatus
                 },
@@ -86,7 +87,7 @@ module.exports = {
                 phase: 'awaitClear',
                 timeoutSeconds: timeout,
                 deferred: { comments },
-                output: { listId, previousActivationStatus: currentStatus }
+                output: { listId, network, previousActivationStatus: currentStatus }
             });
         }
 

--- a/src/appmixer/akamai/clientlist/ActivateList/component.json
+++ b/src/appmixer/akamai/clientlist/ActivateList/component.json
@@ -56,8 +56,14 @@
                         "tooltip": "The network environment where you activate your client list.",
                         "index": 2,
                         "options": [
-                            { "label": "Staging", "value": "STAGING" },
-                            { "label": "Production", "value": "PRODUCTION" }
+                            {
+                                "label": "Staging",
+                                "value": "STAGING"
+                            },
+                            {
+                                "label": "Production",
+                                "value": "PRODUCTION"
+                            }
                         ]
                     },
                     "comments": {

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/UpsertListEntries.js
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/UpsertListEntries.js
@@ -19,6 +19,22 @@ module.exports = {
             throw new context.CancelError('IP or IPs is required');
         }
 
+        // A list already pending activation cannot be re-activated. This is common in
+        // rapid sequential additions (e.g. blocking attacker after attacker) where a
+        // previous activation is still in flight. Check before modifying entries so the
+        // non-wait error path leaves the list untouched.
+        const currentStatus = await lib.getActivationStatus(context, auth, listId, network);
+        if (currentStatus === ACTIVATION_STATUS.PENDING) {
+            if (!waitForActivation) {
+                throw new context.CancelError(
+                    `List ${listId} is already PENDING_ACTIVATION on the ${network} network, so it cannot be ` +
+                    're-activated yet. Akamai activations can take 1-15+ minutes. Enable "Wait for Activation" ' +
+                    'to poll until the current activation completes before adding more entries.'
+                );
+            }
+            await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+        }
+
         // GET list items to check whether to append or update
         const {
             url: getItemsUrl,
@@ -92,21 +108,6 @@ module.exports = {
             headers: { Authorization },
             data: body
         });
-
-        // A list already pending activation cannot be re-activated. This is common in
-        // rapid sequential additions (e.g. blocking attacker after attacker) where a
-        // previous activation is still in flight. Wait for it to finish, or fail clearly.
-        const currentStatus = await lib.getActivationStatus(context, auth, listId, network);
-        if (currentStatus === ACTIVATION_STATUS.PENDING) {
-            if (!waitForActivation) {
-                throw new context.CancelError(
-                    `List ${listId} is already PENDING_ACTIVATION on the ${network} network, so it cannot be ` +
-                    're-activated yet. Akamai activations can take 1-15+ minutes. Enable "Wait for Activation" ' +
-                    'to poll until the current activation completes before adding more entries.'
-                );
-            }
-            await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
-        }
 
         // Activate list
         const activateBody = { action: 'ACTIVATE', network };

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/UpsertListEntries.js
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/UpsertListEntries.js
@@ -3,8 +3,125 @@
 const lib = require('../../lib');
 const { generateAuthorizationHeader, parseIPs, ACTIVATION_STATUS } = lib;
 
+// GET the current entries, split the input IPs into append/update, POST the
+// changes and trigger an activation. Returns the entries for the output port
+// and the activation response.
+async function upsertAndActivate(context, auth, { listId, network, value, description, ttl }) {
+
+    const { hostnameUrl, accessToken, clientSecret, clientToken } = auth;
+
+    // GET list items to check whether to append or update
+    const {
+        url: getItemsUrl,
+        method: getItemsMethod,
+        headers: { Authorization: getItemsAuthorization }
+    } = generateAuthorizationHeader({
+        hostnameUrl,
+        accessToken,
+        clientToken,
+        clientSecret,
+        method: 'GET',
+        path: `/client-list/v1/lists/${listId}/items`
+    });
+
+    const { data: listEntries } = await context.httpRequest({
+        url: getItemsUrl,
+        method: getItemsMethod,
+        headers: { Authorization: getItemsAuthorization }
+    });
+
+    const currentEntries = listEntries.content.map((entry) => entry.value);
+
+    const appendArr = [];
+    const updateArr = [];
+
+    const expirationDate = ttl
+        ? new Date().getTime() + ttl * 1000
+        : undefined;
+
+    const ips = parseIPs(value);
+
+    ips.forEach(ip => {
+        const ipIndex = currentEntries.findIndex(
+            (e) => e === ip
+        );
+        const newEntry = {
+            value: ip,
+            expirationDate,
+            description
+        };
+        if (ipIndex > -1) {
+            updateArr.push(newEntry);
+        } else {
+            appendArr.push(newEntry);
+        }
+    });
+
+    const body = {
+        append: appendArr,
+        update: updateArr
+    };
+
+    // POST new or updated list items
+    const {
+        url,
+        method,
+        headers: { Authorization }
+    } = generateAuthorizationHeader({
+        hostnameUrl,
+        accessToken,
+        clientToken,
+        clientSecret,
+        method: 'POST',
+        path: `/client-list/v1/lists/${listId}/items`,
+        body
+    });
+
+    const { data } = await context.httpRequest({
+        url,
+        method,
+        headers: { Authorization },
+        data: body
+    });
+
+    const activation = await lib.activateList(context, auth, { listId, network });
+
+    const addedResponse = (data.appended || []).map(r => ({ action: 'added', ...r }));
+    const updatedResponse = (data.updated || []).map(r => ({ action: 'updated', ...r }));
+
+    return {
+        entries: addedResponse.concat(updatedResponse),
+        activation
+    };
+}
+
 module.exports = {
+
     receive: async (context) => {
+
+        // Poll continuation scheduled by a previous receive() invocation.
+        if (context.messages.timeout) {
+            return lib.continueWait(context, {
+                onClear: async (ctx, wait) => {
+                    // The pending activation cleared — perform the deferred upsert.
+                    const { hostnameUrl, accessToken, clientSecret, clientToken } = ctx.auth;
+                    const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
+                    const { entries } = await upsertAndActivate(ctx, auth, {
+                        listId: wait.listId,
+                        network: wait.network,
+                        value: wait.deferred.value,
+                        description: wait.deferred.description,
+                        ttl: wait.deferred.ttl
+                    });
+                    return { ...wait, phase: 'awaitActive', output: { entries } };
+                },
+                onActive: (ctx, wait) => ctx.sendJson(
+                    { ...wait.output, activationStatus: ACTIVATION_STATUS.ACTIVE },
+                    'out'
+                )
+            });
+        }
+
         const { hostnameUrl, accessToken, clientSecret, clientToken } =
             context.auth;
         const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
@@ -21,8 +138,10 @@ module.exports = {
 
         // A list already pending activation cannot be re-activated. This is common in
         // rapid sequential additions (e.g. blocking attacker after attacker) where a
-        // previous activation is still in flight. Check before modifying entries so the
-        // non-wait error path leaves the list untouched.
+        // previous activation is still in flight. The check happens before modifying
+        // entries so the non-wait error path leaves the list untouched; with
+        // "Wait for Activation" enabled the whole upsert is deferred and performed
+        // by a poll continuation once the in-flight activation clears.
         const currentStatus = await lib.getActivationStatus(context, auth, listId, network);
         if (currentStatus === ACTIVATION_STATUS.PENDING) {
             if (!waitForActivation) {
@@ -32,138 +151,34 @@ module.exports = {
                     'to poll until the current activation completes before adding more entries.'
                 );
             }
-            await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+            return lib.startWait(context, {
+                listId,
+                network,
+                phase: 'awaitClear',
+                timeoutSeconds: timeout,
+                deferred: { value, description, ttl }
+            });
         }
 
-        // GET list items to check whether to append or update
-        const {
-            url: getItemsUrl,
-            method: getItemsMethod,
-            headers: { Authorization: getItemsAuthorization }
-        } = generateAuthorizationHeader({
-            hostnameUrl,
-            accessToken,
-            clientToken,
-            clientSecret,
-            method: 'GET',
-            path: `/client-list/v1/lists/${listId}/items`
-        });
+        const { entries, activation } = await upsertAndActivate(
+            context, auth, { listId, network, value, description, ttl }
+        );
 
-        const { data: listEntries } = await context.httpRequest({
-            url: getItemsUrl,
-            method: getItemsMethod,
-            headers: { Authorization: getItemsAuthorization }
-        });
-
-        const currentEntries = listEntries.content.map((entry) => entry.value);
-
-        const appendArr = [];
-        const updateArr = [];
-
-        const expirationDate = ttl
-            ? new Date().getTime() + ttl * 1000
-            : undefined;
-
-        const ips = parseIPs(value);
-
-        ips.forEach(ip => {
-            const ipIndex = currentEntries.findIndex(
-                (e) => e === ip
+        if (!waitForActivation) {
+            return context.sendJson(
+                { entries, activationStatus: activation && activation.activationStatus },
+                'out'
             );
-            const newEntry = {
-                value: ip,
-                expirationDate,
-                description
-            };
-            if (ipIndex > -1) {
-                updateArr.push(newEntry);
-            } else {
-                appendArr.push(newEntry);
-            }
-        });
+        }
 
-        const body = {
-            append: appendArr,
-            update: updateArr
-        };
-
-        // POST new or updated list items
-        const {
-            url,
-            method,
-            headers: { Authorization }
-        } = generateAuthorizationHeader({
-            hostnameUrl,
-            accessToken,
-            clientToken,
-            clientSecret,
-            method: 'POST',
-            path: `/client-list/v1/lists/${listId}/items`,
-            body
-        });
-
-        const { data } = await context.httpRequest({
-            url,
-            method,
-            headers: { Authorization },
-            data: body
-        });
-
-        // Activate list
-        const activateBody = { action: 'ACTIVATE', network };
-
-        const {
-            url: ActivateUrl,
-            method: ActivateMethod,
-            headers: { Authorization: ActivateAuthorization }
-        } = generateAuthorizationHeader({
-            hostnameUrl,
-            accessToken,
-            clientToken,
-            clientSecret,
-            method: 'POST',
-            path: `/client-list/v1/lists/${listId}/activations`,
-            body: activateBody
-        });
-
-        const { data: activation } = await context.httpRequest({
-            url: ActivateUrl,
-            method: ActivateMethod,
-            headers: { Authorization: ActivateAuthorization },
-            data: activateBody
-        });
-
-        // Optionally block until the activation reaches ACTIVE so downstream steps
+        // Poll until the activation reaches ACTIVE so downstream steps
         // (e.g. another rapid addition) don't hit a still-pending list.
-        let activationStatus = activation && activation.activationStatus;
-        if (waitForActivation) {
-            activationStatus = await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
-        }
-
-        let addedResponse = [];
-        let updatedResponse = [];
-        if (data.appended.length > 0) {
-            addedResponse = data.appended.map(r => {
-                return {
-                    action: 'added',
-                    ...r
-                };
-            });
-        }
-        if (data.updated.length > 0) {
-            updatedResponse = data.updated.map(r => {
-                return {
-                    action: 'updated',
-                    ...r
-                };
-            });
-        }
-
-        const response = {
-            entries: addedResponse.concat(updatedResponse),
-            activationStatus
-        };
-
-        return context.sendJson(response, 'out');
+        return lib.startWait(context, {
+            listId,
+            network,
+            phase: 'awaitActive',
+            timeoutSeconds: timeout,
+            output: { entries }
+        });
     }
 };

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/UpsertListEntries.js
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/UpsertListEntries.js
@@ -1,12 +1,15 @@
 'use strict';
 
-const { generateAuthorizationHeader, parseIPs } = require('../../lib');
+const lib = require('../../lib');
+const { generateAuthorizationHeader, parseIPs, ACTIVATION_STATUS } = lib;
 
 module.exports = {
     receive: async (context) => {
         const { hostnameUrl, accessToken, clientSecret, clientToken } =
             context.auth;
-        const { listId, value, description, ttl, network } = context.messages.in.content;
+        const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
+        const { listId, value, description, ttl, network, waitForActivation, timeout } =
+            context.messages.in.content;
 
         if (!listId) {
             throw new context.CancelError('List is required');
@@ -90,6 +93,21 @@ module.exports = {
             data: body
         });
 
+        // A list already pending activation cannot be re-activated. This is common in
+        // rapid sequential additions (e.g. blocking attacker after attacker) where a
+        // previous activation is still in flight. Wait for it to finish, or fail clearly.
+        const currentStatus = await lib.getActivationStatus(context, auth, listId, network);
+        if (currentStatus === ACTIVATION_STATUS.PENDING) {
+            if (!waitForActivation) {
+                throw new context.CancelError(
+                    `List ${listId} is already PENDING_ACTIVATION on the ${network} network, so it cannot be ` +
+                    're-activated yet. Akamai activations can take 1-15+ minutes. Enable "Wait for Activation" ' +
+                    'to poll until the current activation completes before adding more entries.'
+                );
+            }
+            await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+        }
+
         // Activate list
         const activateBody = { action: 'ACTIVATE', network };
 
@@ -107,12 +125,19 @@ module.exports = {
             body: activateBody
         });
 
-        await context.httpRequest({
+        const { data: activation } = await context.httpRequest({
             url: ActivateUrl,
             method: ActivateMethod,
             headers: { Authorization: ActivateAuthorization },
             data: activateBody
         });
+
+        // Optionally block until the activation reaches ACTIVE so downstream steps
+        // (e.g. another rapid addition) don't hit a still-pending list.
+        let activationStatus = activation && activation.activationStatus;
+        if (waitForActivation) {
+            activationStatus = await lib.waitForActivation(context, auth, listId, network, { timeout: timeout || 300 });
+        }
 
         let addedResponse = [];
         let updatedResponse = [];
@@ -133,7 +158,10 @@ module.exports = {
             });
         }
 
-        const response = { entries: addedResponse.concat(updatedResponse) };
+        const response = {
+            entries: addedResponse.concat(updatedResponse),
+            activationStatus
+        };
 
         return context.sendJson(response, 'out');
     }

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
@@ -17,7 +17,9 @@
                 "value": { "type": "string" },
                 "description": { "type": "string" },
                 "ttl": { "type": "integer" },
-                "network": { "type": "string" }
+                "network": { "type": "string" },
+                "waitForActivation": { "type": "boolean" },
+                "timeout": { "type": "integer" }
             },
             "required": [
                 "listId", "value", "network"
@@ -66,6 +68,18 @@
                     "index": 4,
                     "label": "TTL",
                     "tooltip": "Time to live in seconds indicating when the entry expires."
+                },
+                "waitForActivation": {
+                    "type": "toggle",
+                    "index": 5,
+                    "label": "Wait for Activation",
+                    "tooltip": "When enabled, the component polls the list until it reaches the ACTIVE state before continuing. This also lets rapid, sequential additions succeed: if a previous activation is still PENDING_ACTIVATION, the component waits for it to complete before activating again instead of failing. Akamai activations typically take 1-15+ minutes."
+                },
+                "timeout": {
+                    "type": "number",
+                    "index": 6,
+                    "label": "Timeout (seconds)",
+                    "tooltip": "Maximum time in seconds to wait for activation to complete when \"Wait for Activation\" is enabled. Defaults to 300 (5 minutes). Increase for production activations, which can take 15+ minutes."
                 }
             }
         }
@@ -76,55 +90,74 @@
         "name": "out",
         "options": [
             {
+                "label": "Activation Status",
+                "value": "activationStatus",
+                "schema": {
+                    "type": "string",
+                    "example": "PENDING_ACTIVATION"
+                }
+            },
+            {
                 "label": "Entries",
                 "value": "entries",
                 "schema": {
                     "type": "array",
+                    "example": [{ "action": "added", "value": "1.1.1.1", "type": "IP" }],
                     "items": {
                         "type": "object",
                         "properties": {
                             "action": {
                                 "type": "string",
-                                "title": "Action"
+                                "title": "Action",
+                                "example": "added"
                             },
                             "createDate": {
                                 "type": "string",
-                                "title": "Create Date"
+                                "title": "Create Date",
+                                "example": "2026-07-15T10:00:00Z"
                             },
                             "createdBy": {
                                 "type": "string",
-                                "title": "Created By"
+                                "title": "Created By",
+                                "example": "jsmith"
                             },
                             "description": {
                                 "type": "string",
-                                "title": "Description"
+                                "title": "Description",
+                                "example": "Blocked attacker IP"
                             },
                             "expirationDate": {
                                 "type": "string",
-                                "title": "Expiration Date"
+                                "title": "Expiration Date",
+                                "example": "2026-07-16T10:00:00Z"
                             },
                             "tags": {
                                 "type": "array",
                                 "items": {
                                     "type": "string"
                                 },
-                                "title": "Tags"
+                                "title": "Tags",
+                                "example": ["malicious"]
                             },
                             "type": {
                                 "type": "string",
-                                "title": "Type"
+                                "title": "Type",
+                                "example": "IP"
                             },
                             "updateDate": {
                                 "type": "string",
-                                "title": "Update Date"
+                                "title": "Update Date",
+                                "example": "2026-07-15T10:00:00Z"
                             },
                             "updatedBy": {
                                 "type": "string",
-                                "title": "Updated By"
+                                "title": "Updated By",
+                                "example": "jsmith"
                             },
                             "value": {
                                 "type": "string",
-                                "title": "Value"
+                                "title": "Value",
+                                "example": "1.1.1.1"
                             }
                         }
                     }

--- a/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
+++ b/src/appmixer/akamai/clientlist/UpsertListEntries/component.json
@@ -1,170 +1,200 @@
 {
-  "version": "1.1.0",
-  "name": "appmixer.akamai.clientlist.UpsertListEntries",
-  "author": "Appmixer <info@appmixer.com>",
-  "description": "Append or update client list entries and activates the list.",
-  "private": false,
-  "auth": {
-      "service": "appmixer:akamai"
-  },
-  "inPorts": [
-    {
-        "name": "in",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "listId": { "type": "string" },
-                "value": { "type": "string" },
-                "description": { "type": "string" },
-                "ttl": { "type": "integer" },
-                "network": { "type": "string" },
-                "waitForActivation": { "type": "boolean" },
-                "timeout": { "type": "integer" }
-            },
-            "required": [
-                "listId", "value", "network"
-            ]
-        },
-        "inspector": {
-            "inputs": {
-                "listId": {
-                    "type": "text",
-                    "label": "List",
-                    "index": 0,
-                    "source": {
-                        "url": "/component/appmixer/akamai/clientlist/GetLists?outPort=out",
-                        "data": {
-                            "transform": "./GetLists#listsToSelectArray",
-                            "messages": {
-                                "in/isSource": true
-                            }
-                        }
+    "version": "1.1.0",
+    "name": "appmixer.akamai.clientlist.UpsertListEntries",
+    "author": "Appmixer <info@appmixer.com>",
+    "description": "Append or update client list entries and activates the list.",
+    "private": false,
+    "auth": {
+        "service": "appmixer:akamai"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "listId": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "ttl": {
+                        "type": "integer"
+                    },
+                    "network": {
+                        "type": "string"
+                    },
+                    "waitForActivation": {
+                        "type": "boolean"
+                    },
+                    "timeout": {
+                        "type": "integer"
                     }
                 },
-                "value": {
-                    "type": "text",
-                    "index": 1,
-                    "label": "IP or IPs",
-                    "tooltip": "Value of the entry, which is either an IP address, an Autonomous System Number (ASN), a Geolocation, a TLS fingerprint, or a file hash. Multiple values can be added at once but need to be separated by a comma. It will then use the same Description and Expiration Date. Example: <code>1.1.1.1,192.168.1.17</code>. JSON format is also supported, for example: [\"1.1.1.1\", \"2.2.2.2\"]."
-                },
-                "network": {
-                    "type": "select",
-                    "label": "Network",
-                    "tooltip": "The network environment where you activate your client list.",
-                    "index": 2,
-                    "options": [
-                        { "label": "Staging", "value": "STAGING" },
-                        { "label": "Production", "value": "PRODUCTION" }
-                    ]
-                },
-                "description": {
-                    "type": "text",
-                    "index": 3,
-                    "label": "Description",
-                    "tooltip": "Any additional description of the client list entry."
-                },
-                "ttl": {
-                    "type": "number",
-                    "index": 4,
-                    "label": "TTL",
-                    "tooltip": "Time to live in seconds indicating when the entry expires."
-                },
-                "waitForActivation": {
-                    "type": "toggle",
-                    "index": 5,
-                    "label": "Wait for Activation",
-                    "tooltip": "When enabled, the component polls the list until it reaches the ACTIVE state before continuing. This also lets rapid, sequential additions succeed: if a previous activation is still PENDING_ACTIVATION, the component waits for it to complete before activating again instead of failing. Akamai activations typically take 1-15+ minutes."
-                },
-                "timeout": {
-                    "type": "number",
-                    "index": 6,
-                    "label": "Timeout (seconds)",
-                    "tooltip": "Maximum time in seconds to wait for activation to complete when \"Wait for Activation\" is enabled. Defaults to 300 (5 minutes). Increase for production activations, which can take 15+ minutes."
+                "required": [
+                    "listId",
+                    "value",
+                    "network"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "listId": {
+                        "type": "text",
+                        "label": "List",
+                        "index": 0,
+                        "source": {
+                            "url": "/component/appmixer/akamai/clientlist/GetLists?outPort=out",
+                            "data": {
+                                "transform": "./GetLists#listsToSelectArray",
+                                "messages": {
+                                    "in/isSource": true
+                                }
+                            }
+                        }
+                    },
+                    "value": {
+                        "type": "text",
+                        "index": 1,
+                        "label": "IP or IPs",
+                        "tooltip": "Value of the entry, which is either an IP address, an Autonomous System Number (ASN), a Geolocation, a TLS fingerprint, or a file hash. Multiple values can be added at once but need to be separated by a comma. It will then use the same Description and Expiration Date. Example: <code>1.1.1.1,192.168.1.17</code>. JSON format is also supported, for example: [\"1.1.1.1\", \"2.2.2.2\"]."
+                    },
+                    "network": {
+                        "type": "select",
+                        "label": "Network",
+                        "tooltip": "The network environment where you activate your client list.",
+                        "index": 2,
+                        "options": [
+                            {
+                                "label": "Staging",
+                                "value": "STAGING"
+                            },
+                            {
+                                "label": "Production",
+                                "value": "PRODUCTION"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "type": "text",
+                        "index": 3,
+                        "label": "Description",
+                        "tooltip": "Any additional description of the client list entry."
+                    },
+                    "ttl": {
+                        "type": "number",
+                        "index": 4,
+                        "label": "TTL",
+                        "tooltip": "Time to live in seconds indicating when the entry expires."
+                    },
+                    "waitForActivation": {
+                        "type": "toggle",
+                        "index": 5,
+                        "label": "Wait for Activation",
+                        "tooltip": "When enabled, the component polls the list until it reaches the ACTIVE state before continuing. This also lets rapid, sequential additions succeed: if a previous activation is still PENDING_ACTIVATION, the component waits for it to complete before activating again instead of failing. Akamai activations typically take 1-15+ minutes."
+                    },
+                    "timeout": {
+                        "type": "number",
+                        "index": 6,
+                        "label": "Timeout (seconds)",
+                        "tooltip": "Maximum time in seconds to wait for activation to complete when \"Wait for Activation\" is enabled. Defaults to 300 (5 minutes). Increase for production activations, which can take 15+ minutes."
+                    }
                 }
             }
         }
-    }
-  ],
-  "outPorts": [
-    {
-        "name": "out",
-        "options": [
-            {
-                "label": "Activation Status",
-                "value": "activationStatus",
-                "schema": {
-                    "type": "string",
-                    "example": "PENDING_ACTIVATION"
-                }
-            },
-            {
-                "label": "Entries",
-                "value": "entries",
-                "schema": {
-                    "type": "array",
-                    "example": [{ "action": "added", "value": "1.1.1.1", "type": "IP" }],
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "action": {
-                                "type": "string",
-                                "title": "Action",
-                                "example": "added"
-                            },
-                            "createDate": {
-                                "type": "string",
-                                "title": "Create Date",
-                                "example": "2026-07-15T10:00:00Z"
-                            },
-                            "createdBy": {
-                                "type": "string",
-                                "title": "Created By",
-                                "example": "jsmith"
-                            },
-                            "description": {
-                                "type": "string",
-                                "title": "Description",
-                                "example": "Blocked attacker IP"
-                            },
-                            "expirationDate": {
-                                "type": "string",
-                                "title": "Expiration Date",
-                                "example": "2026-07-16T10:00:00Z"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "options": [
+                {
+                    "label": "Activation Status",
+                    "value": "activationStatus",
+                    "schema": {
+                        "type": "string",
+                        "example": "PENDING_ACTIVATION"
+                    }
+                },
+                {
+                    "label": "Entries",
+                    "value": "entries",
+                    "schema": {
+                        "type": "array",
+                        "example": [
+                            {
+                                "action": "added",
+                                "value": "1.1.1.1",
+                                "type": "IP"
+                            }
+                        ],
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "action": {
+                                    "type": "string",
+                                    "title": "Action",
+                                    "example": "added"
                                 },
-                                "title": "Tags",
-                                "example": ["malicious"]
-                            },
-                            "type": {
-                                "type": "string",
-                                "title": "Type",
-                                "example": "IP"
-                            },
-                            "updateDate": {
-                                "type": "string",
-                                "title": "Update Date",
-                                "example": "2026-07-15T10:00:00Z"
-                            },
-                            "updatedBy": {
-                                "type": "string",
-                                "title": "Updated By",
-                                "example": "jsmith"
-                            },
-                            "value": {
-                                "type": "string",
-                                "title": "Value",
-                                "example": "1.1.1.1"
+                                "createDate": {
+                                    "type": "string",
+                                    "title": "Create Date",
+                                    "example": "2026-07-15T10:00:00Z"
+                                },
+                                "createdBy": {
+                                    "type": "string",
+                                    "title": "Created By",
+                                    "example": "jsmith"
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "title": "Description",
+                                    "example": "Blocked attacker IP"
+                                },
+                                "expirationDate": {
+                                    "type": "string",
+                                    "title": "Expiration Date",
+                                    "example": "2026-07-16T10:00:00Z"
+                                },
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "title": "Tags",
+                                    "example": [
+                                        "malicious"
+                                    ]
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "title": "Type",
+                                    "example": "IP"
+                                },
+                                "updateDate": {
+                                    "type": "string",
+                                    "title": "Update Date",
+                                    "example": "2026-07-15T10:00:00Z"
+                                },
+                                "updatedBy": {
+                                    "type": "string",
+                                    "title": "Updated By",
+                                    "example": "jsmith"
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "title": "Value",
+                                    "example": "1.1.1.1"
+                                }
                             }
                         }
                     }
                 }
-            }
-        ]
-    }
-  ],
-  "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAHLklEQVRYR62Xe4wVVx3HP+fM3Ll37mufvLG7sF1KKhYRUExtNo0hqRRaEhtsbdQGurttTUNprRBJJNW2hG6ttkVgWUBNg9UapWhj/MMEYmpijUQjIMqyy2PZsuwu7H3NzH3MzPGPuXdfQncx/STzx5zz/f3Od86cOec3gluh83oVprUcT92NogXFciCEpp2hVPw6rQvOTA6ZCjG54YYcungPMtSO595PoraaWAyuXh4GtRtf/ymPz704OWS6fLSBvWfvxIy/hKatRzdA08FKZ1F8j43zXx3V/WxwGX5xKb7XCKoahUIwgqZdwJenKF05SfuK0oTcZW5u4MCFp9GNXUSiJlYa4tXgZI9TKHyD9qZLHOprRsgnUeoBpGgiHAUhAVVOIED5ULBBqW4ER8jb+3liUc/4YW5s4MCFThJ1bdhpcIuQrINc6gCbGlrZcSxC46IfgGojmtTJW1DKB3GaDloIpAZCgFKBIalDKAxW2sYrdbCp4YWK0/81cKD3MFWzvkp6MEiQrIfM9T20Nn6Tvac+i1n7NtHEQrIj4JfAMCEchWIeis4IvuoHdQ1EEaEMEFXALGAOVTMhHoOBvuNk8w+yeVFmooF9516lbs5zpAaD6UvWQXbkPVoXrGPfv79ItOo9pB7BTgeDGiY42fMgfoVSv8ct/YP2pvSEnACd/VEiogG3tBIh1hFNPoSdO0183tIxA53dD5CsP4qdAd+DsAlu6Qol7XZkroFQ4gRSmhQsSNSBk+sHXuSxefsRwh/N8/OhuThWNbqhUG6G6CcG2CC80X6AfRebiEY6yOd6AgO7T8UJR/9DJDaXvBWIYtWQu7aetuajdPWeIVq1GCcD8VpwMr8kNfwEW5al6OqZhRb+GvjrUerThKMxjEgwg3kL3NIAUn6AEEcZGTrClmWpUSNd59YEBrrOb6Nqxk7SV4NlYSbAzvyNtqaVdPZ+i9qZHaSHIFYDduplNjVuDwY2nkXXV+N7Pm7pPL7fjxAWShkg6pAsQIk7SdTOJJGEwX4L5X2XjQ2vVTwIdhzTmXfbBcLReRSdoDVeA7nUl7nc+C7ze69imPWEY5AZ+iFttz/LO8rges8jmNEsevQYj1aPjD7VZN5RBrm+O8BvQWhfIVH3BXKpDyhk1tK+eFhwsPdzRKr+gl1eO7oBpcII/Qvrmd97P/Ha36J8sDJ/onVBy+T8t8yhS58iHN2OnV6M0NdIFKvR9DFB2AQh/swLwgfxIFoICvkiym8dn+f/ZuNtJ3m0/mHwn0G5yyVK3UOpMCaQOsBfgxu1BCMCRfswbU1nx0QfA63Nx2lt+p1EiSWjOxkEn6DvdwOgxAycLBDeOyb4eBHs7ykhpR5smwLMODi5L9G64A909XyIryRtTXMnfOvTQHUStTP8WteoLrhBmxkCp8RwPMxDcjMFAIkYv0mo8h7uVxZFASH/eauDA6TTPB+t5T4jxKpElFUJk1V6mFVSstYuUFPRSRSDExah1ECKskD0ghoY65we1i7mGjrPF9LgFCHroLJ5cJzg8PEFtRWtBE6jh8eihQQlmsp3x1FM3EangQcvmiYxX4HnMwLsiejgq+A14DOjopUI9T6hcQY8F5S/EgDl/QbJ0Fjn1FzfyVLD4DHHAjMKvmIfHr8IhcpvWAehM7Oil3jij3jlVQJQdECIz/PW2SRtzafxeWmsc2p0jY6wgZASHBvb89nlaxSUVz78BeAzp6KX3HHxBFaqH8MMWtwixGtqyIfWAtzweL0JqVe4LxFjtWUHp3XJ5fXabaR1RanglosPAShmV2Ik997rIuSPMRPlCmb0NWwZSz01agdSQofywQiBnaOnaivfAXAUPSWPolau2JQYPwMAIr+b9NCHROJBq5OFRM0K9ndvqAinIhVjUyLBEisf1FquTz7TwRvZV9gblryBAM8HfBCKWZW48QXJepL1R7DT4PtBteOWrlBIfZKn7rr5aQeo3cTtPN2Gzux8CcI6hEJAZW0rcDLgKkiEIZvnRPLbrGB0BgDam98lM/wjkuUvpGBDLDmHUPytUc1NSFlsi8aZnS+CoUHeZSBn05cbKV8p+lyFKyuzAPVqBzo3LEq7LrxN9YyHJxSl2eG9PL7wqclSALuDBiRnQxqGHoKcxd9jihYiFMfrrCLvx01WuC44RXJxk0b5NNfGZqBCa+MjpIcPkqwPaoPMMCTqnuTgxa7JhhUIF3aacQzXA88DJFvlVrJyM4Xxl1IMoAXPpEnixQJ1TE44gf3nnyEc2YlhRrBTQZXkZI9TclppbT4HoBTCeo27QlpQ42ct3Prt/GtyKgDrdeabOrWWBYYBIY9u+RzOzQ0AHDi3BN18GU1fN+7XLIPi+5QG9tC+wp4ccqt8tIEKBy+1IGU7vreGZH0V0SgM9g0Bb+Krw2xq6J0cMl2mZ6DCT85XQ2g5vn830AJ8Bil0fP8kXmEDbYsuTw6Ziv8CbbviMC4N8V4AAAAASUVORK5CYII="
+            ]
+        }
+    ],
+    "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAHLklEQVRYR62Xe4wVVx3HP+fM3Ll37mufvLG7sF1KKhYRUExtNo0hqRRaEhtsbdQGurttTUNprRBJJNW2hG6ttkVgWUBNg9UapWhj/MMEYmpijUQjIMqyy2PZsuwu7H3NzH3MzPGPuXdfQncx/STzx5zz/f3Od86cOec3gluh83oVprUcT92NogXFciCEpp2hVPw6rQvOTA6ZCjG54YYcungPMtSO595PoraaWAyuXh4GtRtf/ymPz704OWS6fLSBvWfvxIy/hKatRzdA08FKZ1F8j43zXx3V/WxwGX5xKb7XCKoahUIwgqZdwJenKF05SfuK0oTcZW5u4MCFp9GNXUSiJlYa4tXgZI9TKHyD9qZLHOprRsgnUeoBpGgiHAUhAVVOIED5ULBBqW4ER8jb+3liUc/4YW5s4MCFThJ1bdhpcIuQrINc6gCbGlrZcSxC46IfgGojmtTJW1DKB3GaDloIpAZCgFKBIalDKAxW2sYrdbCp4YWK0/81cKD3MFWzvkp6MEiQrIfM9T20Nn6Tvac+i1n7NtHEQrIj4JfAMCEchWIeis4IvuoHdQ1EEaEMEFXALGAOVTMhHoOBvuNk8w+yeVFmooF9516lbs5zpAaD6UvWQXbkPVoXrGPfv79ItOo9pB7BTgeDGiY42fMgfoVSv8ct/YP2pvSEnACd/VEiogG3tBIh1hFNPoSdO0183tIxA53dD5CsP4qdAd+DsAlu6Qol7XZkroFQ4gRSmhQsSNSBk+sHXuSxefsRwh/N8/OhuThWNbqhUG6G6CcG2CC80X6AfRebiEY6yOd6AgO7T8UJR/9DJDaXvBWIYtWQu7aetuajdPWeIVq1GCcD8VpwMr8kNfwEW5al6OqZhRb+GvjrUerThKMxjEgwg3kL3NIAUn6AEEcZGTrClmWpUSNd59YEBrrOb6Nqxk7SV4NlYSbAzvyNtqaVdPZ+i9qZHaSHIFYDduplNjVuDwY2nkXXV+N7Pm7pPL7fjxAWShkg6pAsQIk7SdTOJJGEwX4L5X2XjQ2vVTwIdhzTmXfbBcLReRSdoDVeA7nUl7nc+C7ze69imPWEY5AZ+iFttz/LO8rges8jmNEsevQYj1aPjD7VZN5RBrm+O8BvQWhfIVH3BXKpDyhk1tK+eFhwsPdzRKr+gl1eO7oBpcII/Qvrmd97P/Ha36J8sDJ/onVBy+T8t8yhS58iHN2OnV6M0NdIFKvR9DFB2AQh/swLwgfxIFoICvkiym8dn+f/ZuNtJ3m0/mHwn0G5yyVK3UOpMCaQOsBfgxu1BCMCRfswbU1nx0QfA63Nx2lt+p1EiSWjOxkEn6DvdwOgxAycLBDeOyb4eBHs7ykhpR5smwLMODi5L9G64A909XyIryRtTXMnfOvTQHUStTP8WteoLrhBmxkCp8RwPMxDcjMFAIkYv0mo8h7uVxZFASH/eauDA6TTPB+t5T4jxKpElFUJk1V6mFVSstYuUFPRSRSDExah1ECKskD0ghoY65we1i7mGjrPF9LgFCHroLJ5cJzg8PEFtRWtBE6jh8eihQQlmsp3x1FM3EangQcvmiYxX4HnMwLsiejgq+A14DOjopUI9T6hcQY8F5S/EgDl/QbJ0Fjn1FzfyVLD4DHHAjMKvmIfHr8IhcpvWAehM7Oil3jij3jlVQJQdECIz/PW2SRtzafxeWmsc2p0jY6wgZASHBvb89nlaxSUVz78BeAzp6KX3HHxBFaqH8MMWtwixGtqyIfWAtzweL0JqVe4LxFjtWUHp3XJ5fXabaR1RanglosPAShmV2Ik997rIuSPMRPlCmb0NWwZSz01agdSQofywQiBnaOnaivfAXAUPSWPolau2JQYPwMAIr+b9NCHROJBq5OFRM0K9ndvqAinIhVjUyLBEisf1FquTz7TwRvZV9gblryBAM8HfBCKWZW48QXJepL1R7DT4PtBteOWrlBIfZKn7rr5aQeo3cTtPN2Gzux8CcI6hEJAZW0rcDLgKkiEIZvnRPLbrGB0BgDam98lM/wjkuUvpGBDLDmHUPytUc1NSFlsi8aZnS+CoUHeZSBn05cbKV8p+lyFKyuzAPVqBzo3LEq7LrxN9YyHJxSl2eG9PL7wqclSALuDBiRnQxqGHoKcxd9jihYiFMfrrCLvx01WuC44RXJxk0b5NNfGZqBCa+MjpIcPkqwPaoPMMCTqnuTgxa7JhhUIF3aacQzXA88DJFvlVrJyM4Xxl1IMoAXPpEnixQJ1TE44gf3nnyEc2YlhRrBTQZXkZI9TclppbT4HoBTCeo27QlpQ42ct3Prt/GtyKgDrdeabOrWWBYYBIY9u+RzOzQ0AHDi3BN18GU1fN+7XLIPi+5QG9tC+wp4ccqt8tIEKBy+1IGU7vreGZH0V0SgM9g0Bb+Krw2xq6J0cMl2mZ6DCT85XQ2g5vn830AJ8Bil0fP8kXmEDbYsuTw6Ziv8CbbviMC4N8V4AAAAASUVORK5CYII="
 }

--- a/src/appmixer/akamai/clientlist/WaitForActivation/WaitForActivation.js
+++ b/src/appmixer/akamai/clientlist/WaitForActivation/WaitForActivation.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const lib = require('../../lib');
+
+module.exports = {
+    async receive(context) {
+        const { hostnameUrl, accessToken, clientSecret, clientToken } =
+            context.auth;
+        const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
+        const { listId, network, timeout } = context.messages.in.content;
+
+        if (!listId) {
+            throw new context.CancelError('List is required');
+        }
+
+        if (!network) {
+            throw new context.CancelError('Network is required');
+        }
+
+        const activationStatus = await lib.waitForActivation(
+            context,
+            auth,
+            listId,
+            network,
+            { timeout: timeout || 300 }
+        );
+
+        return context.sendJson({ listId, network, activationStatus }, 'out');
+    }
+};

--- a/src/appmixer/akamai/clientlist/WaitForActivation/WaitForActivation.js
+++ b/src/appmixer/akamai/clientlist/WaitForActivation/WaitForActivation.js
@@ -1,9 +1,22 @@
 'use strict';
 
 const lib = require('../../lib');
+const { ACTIVATION_STATUS } = lib;
 
 module.exports = {
+
     async receive(context) {
+
+        // Poll continuation scheduled by a previous receive() invocation.
+        if (context.messages.timeout) {
+            return lib.continueWait(context, {
+                onActive: (ctx, wait) => ctx.sendJson(
+                    { ...wait.output, activationStatus: ACTIVATION_STATUS.ACTIVE },
+                    'out'
+                )
+            });
+        }
+
         const { hostnameUrl, accessToken, clientSecret, clientToken } =
             context.auth;
         const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
@@ -17,14 +30,22 @@ module.exports = {
             throw new context.CancelError('Network is required');
         }
 
-        const activationStatus = await lib.waitForActivation(
-            context,
-            auth,
+        // Resolve immediately when the list is already in a final state,
+        // otherwise schedule a poll continuation.
+        const status = await lib.getActivationStatus(context, auth, listId, network);
+        if (status === ACTIVATION_STATUS.ACTIVE) {
+            return context.sendJson({ listId, network, activationStatus: status }, 'out');
+        }
+        if (status === ACTIVATION_STATUS.FAILED) {
+            throw new context.CancelError(`Activation of list ${listId} on the ${network} network failed.`);
+        }
+
+        return lib.startWait(context, {
             listId,
             network,
-            { timeout: timeout || 300 }
-        );
-
-        return context.sendJson({ listId, network, activationStatus }, 'out');
+            phase: 'awaitActive',
+            timeoutSeconds: timeout,
+            output: { listId, network }
+        });
     }
 };

--- a/src/appmixer/akamai/clientlist/WaitForActivation/component.json
+++ b/src/appmixer/akamai/clientlist/WaitForActivation/component.json
@@ -1,8 +1,8 @@
 {
     "version": "1.0.0",
-    "name": "appmixer.akamai.clientlist.ActivateList",
+    "name": "appmixer.akamai.clientlist.WaitForActivation",
     "author": "Appmixer <info@appmixer.com>",
-    "description": "Activates a client list on the staging or production network.",
+    "description": "Polls a client list until it reaches the ACTIVE state on the selected network. Akamai activations can take 1-15+ minutes, so this component lets a flow wait before continuing with further list operations.",
     "private": false,
     "auth": {
         "service": "appmixer:akamai"
@@ -18,12 +18,6 @@
                     },
                     "network": {
                         "type": "string"
-                    },
-                    "comments": {
-                        "type": "string"
-                    },
-                    "waitForActivation": {
-                        "type": "boolean"
                     },
                     "timeout": {
                         "type": "integer"
@@ -53,30 +47,18 @@
                     "network": {
                         "type": "select",
                         "label": "Network",
-                        "tooltip": "The network environment where you activate your client list.",
-                        "index": 2,
+                        "tooltip": "The network environment whose activation status you want to wait on.",
+                        "index": 1,
                         "options": [
                             { "label": "Staging", "value": "STAGING" },
                             { "label": "Production", "value": "PRODUCTION" }
                         ]
                     },
-                    "comments": {
-                        "index": 3,
-                        "type": "text",
-                        "label": "Comments",
-                        "tooltip": "A brief description for the activation."
-                    },
-                    "waitForActivation": {
-                        "index": 4,
-                        "type": "toggle",
-                        "label": "Wait for Activation",
-                        "tooltip": "When enabled, the component polls the list until it reaches the ACTIVE state before continuing, so downstream steps don't proceed on a still-pending list. Akamai activations typically take 1-15+ minutes. If the list is already PENDING_ACTIVATION, the component waits for it to finish before triggering a new activation instead of failing."
-                    },
                     "timeout": {
-                        "index": 5,
+                        "index": 2,
                         "type": "number",
                         "label": "Timeout (seconds)",
-                        "tooltip": "Maximum time in seconds to wait for the activation to complete when \"Wait for Activation\" is enabled. Defaults to 300 (5 minutes). Increase for production activations, which can take 15+ minutes."
+                        "tooltip": "Maximum time in seconds to wait for the list to become ACTIVE. Defaults to 300 (5 minutes). Increase for production activations, which can take 15+ minutes. The component errors if the timeout is reached or the activation fails."
                     }
                 }
             }
@@ -85,80 +67,14 @@
     "outPorts": [
         {
             "name": "out",
-            "options": [
-                {
-                    "label": "Action",
-                    "value": "action",
-                    "schema": {
-                        "type": "string",
-                        "example": "ACTIVATE"
-                    }
-                },
-                {
-                    "label": "Activation ID",
-                    "value": "activationId",
-                    "schema": {
-                        "type": "number",
-                        "example": 12345
-                    }
-                },
-                {
-                    "label": "Activation Status",
-                    "value": "activationStatus",
-                    "schema": {
-                        "type": "string",
-                        "example": "PENDING_ACTIVATION"
-                    }
-                },
-                {
-                    "label": "Create Date",
-                    "value": "createDate",
-                    "schema": {
-                        "type": "string",
-                        "example": "2026-07-15T10:00:00Z"
-                    }
-                },
-                {
-                    "label": "Created By",
-                    "value": "createdBy",
-                    "schema": {
-                        "type": "string",
-                        "example": "jsmith"
-                    }
-                },
-                {
-                    "label": "List ID",
-                    "value": "listId",
-                    "schema": {
-                        "type": "string",
-                        "example": "12345_MYLIST"
-                    }
-                },
-                {
-                    "label": "Network",
-                    "value": "network",
-                    "schema": {
-                        "type": "string",
-                        "example": "STAGING"
-                    }
-                },
-                {
-                    "label": "Previous Activation Status",
-                    "value": "previousActivationStatus",
-                    "schema": {
-                        "type": "string",
-                        "example": "MODIFIED"
-                    }
-                },
-                {
-                    "label": "Version",
-                    "value": "version",
-                    "schema": {
-                        "type": "number",
-                        "example": 3
-                    }
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "listId": { "type": "string", "title": "List ID", "example": "12345_MYLIST" },
+                    "network": { "type": "string", "title": "Network", "example": "STAGING" },
+                    "activationStatus": { "type": "string", "title": "Activation Status", "example": "ACTIVE" }
                 }
-            ]
+            }
         }
     ],
     "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAHLklEQVRYR62Xe4wVVx3HP+fM3Ll37mufvLG7sF1KKhYRUExtNo0hqRRaEhtsbdQGurttTUNprRBJJNW2hG6ttkVgWUBNg9UapWhj/MMEYmpijUQjIMqyy2PZsuwu7H3NzH3MzPGPuXdfQncx/STzx5zz/f3Od86cOec3gluh83oVprUcT92NogXFciCEpp2hVPw6rQvOTA6ZCjG54YYcungPMtSO595PoraaWAyuXh4GtRtf/ymPz704OWS6fLSBvWfvxIy/hKatRzdA08FKZ1F8j43zXx3V/WxwGX5xKb7XCKoahUIwgqZdwJenKF05SfuK0oTcZW5u4MCFp9GNXUSiJlYa4tXgZI9TKHyD9qZLHOprRsgnUeoBpGgiHAUhAVVOIED5ULBBqW4ER8jb+3liUc/4YW5s4MCFThJ1bdhpcIuQrINc6gCbGlrZcSxC46IfgGojmtTJW1DKB3GaDloIpAZCgFKBIalDKAxW2sYrdbCp4YWK0/81cKD3MFWzvkp6MEiQrIfM9T20Nn6Tvac+i1n7NtHEQrIj4JfAMCEchWIeis4IvuoHdQ1EEaEMEFXALGAOVTMhHoOBvuNk8w+yeVFmooF9516lbs5zpAaD6UvWQXbkPVoXrGPfv79ItOo9pB7BTgeDGiY42fMgfoVSv8ct/YP2pvSEnACd/VEiogG3tBIh1hFNPoSdO0183tIxA53dD5CsP4qdAd+DsAlu6Qol7XZkroFQ4gRSmhQsSNSBk+sHXuSxefsRwh/N8/OhuThWNbqhUG6G6CcG2CC80X6AfRebiEY6yOd6AgO7T8UJR/9DJDaXvBWIYtWQu7aetuajdPWeIVq1GCcD8VpwMr8kNfwEW5al6OqZhRb+GvjrUerThKMxjEgwg3kL3NIAUn6AEEcZGTrClmWpUSNd59YEBrrOb6Nqxk7SV4NlYSbAzvyNtqaVdPZ+i9qZHaSHIFYDduplNjVuDwY2nkXXV+N7Pm7pPL7fjxAWShkg6pAsQIk7SdTOJJGEwX4L5X2XjQ2vVTwIdhzTmXfbBcLReRSdoDVeA7nUl7nc+C7ze69imPWEY5AZ+iFttz/LO8rges8jmNEsevQYj1aPjD7VZN5RBrm+O8BvQWhfIVH3BXKpDyhk1tK+eFhwsPdzRKr+gl1eO7oBpcII/Qvrmd97P/Ha36J8sDJ/onVBy+T8t8yhS58iHN2OnV6M0NdIFKvR9DFB2AQh/swLwgfxIFoICvkiym8dn+f/ZuNtJ3m0/mHwn0G5yyVK3UOpMCaQOsBfgxu1BCMCRfswbU1nx0QfA63Nx2lt+p1EiSWjOxkEn6DvdwOgxAycLBDeOyb4eBHs7ykhpR5smwLMODi5L9G64A909XyIryRtTXMnfOvTQHUStTP8WteoLrhBmxkCp8RwPMxDcjMFAIkYv0mo8h7uVxZFASH/eauDA6TTPB+t5T4jxKpElFUJk1V6mFVSstYuUFPRSRSDExah1ECKskD0ghoY65we1i7mGjrPF9LgFCHroLJ5cJzg8PEFtRWtBE6jh8eihQQlmsp3x1FM3EangQcvmiYxX4HnMwLsiejgq+A14DOjopUI9T6hcQY8F5S/EgDl/QbJ0Fjn1FzfyVLD4DHHAjMKvmIfHr8IhcpvWAehM7Oil3jij3jlVQJQdECIz/PW2SRtzafxeWmsc2p0jY6wgZASHBvb89nlaxSUVz78BeAzp6KX3HHxBFaqH8MMWtwixGtqyIfWAtzweL0JqVe4LxFjtWUHp3XJ5fXabaR1RanglosPAShmV2Ik997rIuSPMRPlCmb0NWwZSz01agdSQofywQiBnaOnaivfAXAUPSWPolau2JQYPwMAIr+b9NCHROJBq5OFRM0K9ndvqAinIhVjUyLBEisf1FquTz7TwRvZV9gblryBAM8HfBCKWZW48QXJepL1R7DT4PtBteOWrlBIfZKn7rr5aQeo3cTtPN2Gzux8CcI6hEJAZW0rcDLgKkiEIZvnRPLbrGB0BgDam98lM/wjkuUvpGBDLDmHUPytUc1NSFlsi8aZnS+CoUHeZSBn05cbKV8p+lyFKyuzAPVqBzo3LEq7LrxN9YyHJxSl2eG9PL7wqclSALuDBiRnQxqGHoKcxd9jihYiFMfrrCLvx01WuC44RXJxk0b5NNfGZqBCa+MjpIcPkqwPaoPMMCTqnuTgxa7JhhUIF3aacQzXA88DJFvlVrJyM4Xxl1IMoAXPpEnixQJ1TE44gf3nnyEc2YlhRrBTQZXkZI9TclppbT4HoBTCeo27QlpQ42ct3Prt/GtyKgDrdeabOrWWBYYBIY9u+RzOzQ0AHDi3BN18GU1fN+7XLIPi+5QG9tC+wp4ccqt8tIEKBy+1IGU7vreGZH0V0SgM9g0Bb+Krw2xq6J0cMl2mZ6DCT85XQ2g5vn830AJ8Bil0fP8kXmEDbYsuTw6Ziv8CbbviMC4N8V4AAAAASUVORK5CYII="

--- a/src/appmixer/akamai/clientlist/WaitForActivation/component.json
+++ b/src/appmixer/akamai/clientlist/WaitForActivation/component.json
@@ -50,8 +50,14 @@
                         "tooltip": "The network environment whose activation status you want to wait on.",
                         "index": 1,
                         "options": [
-                            { "label": "Staging", "value": "STAGING" },
-                            { "label": "Production", "value": "PRODUCTION" }
+                            {
+                                "label": "Staging",
+                                "value": "STAGING"
+                            },
+                            {
+                                "label": "Production",
+                                "value": "PRODUCTION"
+                            }
                         ]
                     },
                     "timeout": {
@@ -70,9 +76,21 @@
             "schema": {
                 "type": "object",
                 "properties": {
-                    "listId": { "type": "string", "title": "List ID", "example": "12345_MYLIST" },
-                    "network": { "type": "string", "title": "Network", "example": "STAGING" },
-                    "activationStatus": { "type": "string", "title": "Activation Status", "example": "ACTIVE" }
+                    "listId": {
+                        "type": "string",
+                        "title": "List ID",
+                        "example": "12345_MYLIST"
+                    },
+                    "network": {
+                        "type": "string",
+                        "title": "Network",
+                        "example": "STAGING"
+                    },
+                    "activationStatus": {
+                        "type": "string",
+                        "title": "Activation Status",
+                        "example": "ACTIVE"
+                    }
                 }
             }
         }

--- a/src/appmixer/akamai/lib.js
+++ b/src/appmixer/akamai/lib.js
@@ -61,34 +61,149 @@ module.exports = {
         return list[key];
     },
 
-    // Poll the list activation status until it reaches ACTIVE, fails, or the timeout is hit.
-    // timeout and interval are given in seconds. Returns the final activation status.
-    async waitForActivation(context, auth, listId, network, { timeout = 300, interval = 15 } = {}) {
-        const deadline = Date.now() + timeout * 1000;
-        const intervalMs = Math.max(interval, 1) * 1000;
+    // Trigger an activation of the list on the given network.
+    async activateList(context, auth, { listId, network, comments }) {
+        const { hostnameUrl, accessToken, clientSecret, clientToken } = auth;
+        const body = { action: 'ACTIVATE', network };
+        if (comments) {
+            body.comments = comments;
+        }
 
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+        const {
+            url,
+            method,
+            headers: { Authorization }
+        } = this.generateAuthorizationHeader({
+            hostnameUrl,
+            accessToken,
+            clientToken,
+            clientSecret,
+            method: 'POST',
+            path: `/client-list/v1/lists/${listId}/activations`,
+            body
+        });
+
+        try {
+            const { data } = await context.httpRequest({
+                url,
+                method,
+                headers: { Authorization },
+                data: body
+            });
+            return data;
+        } catch (err) {
+            // Akamai rejects activating a list version that is already active on
+            // the network — for our purposes that means the goal state is reached.
+            const detail = err.response && err.response.data && err.response.data.detail;
+            if (err.response && err.response.status === 400 && /already active/i.test(detail || '')) {
+                return { listId, activationStatus: ACTIVATION_STATUS.ACTIVE };
+            }
+            throw err;
+        }
+    },
+
+    // Activation status lookup shared across component instances. The last known
+    // status is cached in the service state and a non-blocking lock guarantees
+    // that only one caller polls Akamai for a given list+network at a time —
+    // N components waiting on the same list produce one API call per tick, not N.
+    // Returns null when no fresh status is available yet (another caller holds
+    // the poll lock and nothing is cached) — callers should simply retry next tick.
+    async getActivationStatusShared(context, auth, listId, network, { maxAgeMs = 30 * 1000 } = {}) {
+        const cacheKey = `activation-status:${listId}:${network}`;
+        const cached = await context.service.stateGet(cacheKey);
+        if (cached && (Date.now() - cached.time) < maxAgeMs) {
+            return cached.status;
+        }
+
+        let lock;
+        try {
+            lock = await context.lock(`akamai-poll-${listId}-${network}`, { ttl: 60 * 1000, maxRetryCount: 0 });
+        } catch (err) {
+            // Another component instance is polling this list right now.
+            return cached ? cached.status : null;
+        }
+        try {
+            // Re-check the cache — the previous lock holder may have just refreshed it.
+            const fresh = await context.service.stateGet(cacheKey);
+            if (fresh && (Date.now() - fresh.time) < maxAgeMs) {
+                return fresh.status;
+            }
             const status = await this.getActivationStatus(context, auth, listId, network);
+            await context.service.stateSet(cacheKey, { status, time: Date.now() });
+            return status;
+        } finally {
+            lock.unlock();
+        }
+    },
 
-            if (status === ACTIVATION_STATUS.ACTIVE) {
-                return status;
-            }
+    // ------------------------------------------------------------------------
+    // Poll continuations. Long activations (1-15+ minutes) must not block
+    // receive() — the engine caps execution time. Instead, a wait is carried in
+    // a context.setTimeout message: each poll is a short receive() invocation
+    // that checks the status and either resolves the wait or re-schedules
+    // itself. The overall timeout is enforced with a deadline in the wait.
+    //
+    // A wait: { listId, network, phase, timeoutSeconds, deadline, output, deferred }
+    //   phase 'awaitClear'  — an earlier activation is still PENDING; once it
+    //                         clears, the component's onClear callback performs
+    //                         the deferred action and returns the follow-up wait
+    //                         (or null when it resolved the wait itself).
+    //   phase 'awaitActive' — waiting for the list to reach ACTIVE; the wait
+    //                         resolves via the component's onActive callback.
+    // ------------------------------------------------------------------------
 
-            if (status === ACTIVATION_STATUS.FAILED) {
-                throw new context.CancelError(`Activation of list ${listId} on the ${network} network failed.`);
-            }
+    POLL_INTERVAL_MS: 60 * 1000,
 
-            const remainingMs = deadline - Date.now();
-            if (remainingMs <= 0) {
+    // Schedule the first poll of a new wait.
+    async startWait(context, wait) {
+        const timeoutSeconds = wait.timeoutSeconds || 300;
+        await context.setTimeout({
+            ...wait,
+            timeoutSeconds,
+            deadline: Date.now() + timeoutSeconds * 1000
+        }, Math.min(this.POLL_INTERVAL_MS, timeoutSeconds * 1000));
+    },
+
+    // One poll step, invoked from receive() with the context.setTimeout message.
+    // Callbacks:
+    //   onClear(context, wait, status) — perform the deferred action, return the
+    //                                    follow-up wait (or null when resolved)
+    //   onActive(context, wait)        — emit the component output for a resolved wait
+    async continueWait(context, { onClear, onActive }) {
+        let wait = context.messages.timeout.content;
+
+        const { hostnameUrl, accessToken, clientSecret, clientToken } = context.auth;
+        const auth = { hostnameUrl, accessToken, clientSecret, clientToken };
+
+        const status = await this.getActivationStatusShared(context, auth, wait.listId, wait.network);
+
+        if (status !== null) {
+            if (wait.phase === 'awaitClear') {
+                if (status !== ACTIVATION_STATUS.PENDING) {
+                    wait = await onClear(context, wait, status);
+                    if (!wait) {
+                        return;
+                    }
+                }
+            } else if (status === ACTIVATION_STATUS.ACTIVE) {
+                return onActive(context, wait);
+            } else if (status === ACTIVATION_STATUS.FAILED) {
                 throw new context.CancelError(
-                    `Timed out after ${timeout}s waiting for list ${listId} to become ACTIVE on the ${network} network. ` +
-                    `Current status: ${status}. Akamai activations can take 1-15+ minutes; increase the timeout or retry later.`
+                    `Activation of list ${wait.listId} on the ${wait.network} network failed.`
                 );
             }
-
-            await new Promise(resolve => setTimeout(resolve, Math.min(intervalMs, remainingMs)));
         }
+
+        const remainingMs = wait.deadline - Date.now();
+        if (remainingMs <= 0) {
+            throw new context.CancelError(
+                `Timed out after ${wait.timeoutSeconds}s waiting for list ${wait.listId} to become ACTIVE ` +
+                `on the ${wait.network} network. Akamai activations can take 1-15+ minutes; ` +
+                'increase the timeout or retry later.'
+            );
+        }
+
+        await context.setTimeout(wait, Math.min(this.POLL_INTERVAL_MS, remainingMs));
     },
 
     parseIPs(input) {

--- a/src/appmixer/akamai/lib.js
+++ b/src/appmixer/akamai/lib.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const EdgeGrid = require('akamai-edgegrid');
 
 // Client list activation statuses as returned by the Akamai Network/Client Lists API.
@@ -96,7 +97,7 @@ module.exports = {
             // the network — for our purposes that means the goal state is reached.
             const detail = err.response && err.response.data && err.response.data.detail;
             if (err.response && err.response.status === 400 && /already active/i.test(detail || '')) {
-                return { listId, activationStatus: ACTIVATION_STATUS.ACTIVE };
+                return { listId, network, activationStatus: ACTIVATION_STATUS.ACTIVE };
             }
             throw err;
         }
@@ -109,7 +110,14 @@ module.exports = {
     // Returns null when no fresh status is available yet (another caller holds
     // the poll lock and nothing is cached) — callers should simply retry next tick.
     async getActivationStatusShared(context, auth, listId, network, { maxAgeMs = 30 * 1000 } = {}) {
-        const cacheKey = `activation-status:${listId}:${network}`;
+        // Service state and locks are service-global — scope the keys by a
+        // non-secret hash of the credentials so two Akamai accounts with the
+        // same listId never share a cache entry or contend on the lock.
+        const authScope = crypto.createHash('sha256')
+            .update(`${auth.hostnameUrl}:${auth.clientToken}`)
+            .digest('hex')
+            .slice(0, 12);
+        const cacheKey = `activation-status:${authScope}:${listId}:${network}`;
         const cached = await context.service.stateGet(cacheKey);
         if (cached && (Date.now() - cached.time) < maxAgeMs) {
             return cached.status;
@@ -117,7 +125,7 @@ module.exports = {
 
         let lock;
         try {
-            lock = await context.lock(`akamai-poll-${listId}-${network}`, { ttl: 60 * 1000, maxRetryCount: 0 });
+            lock = await context.lock(`akamai-poll-${authScope}-${listId}-${network}`, { ttl: 60 * 1000, maxRetryCount: 0 });
         } catch (err) {
             // Another component instance is polling this list right now.
             return cached ? cached.status : null;
@@ -132,7 +140,7 @@ module.exports = {
             await context.service.stateSet(cacheKey, { status, time: Date.now() });
             return status;
         } finally {
-            lock.unlock();
+            await lock.unlock();
         }
     },
 

--- a/src/appmixer/akamai/lib.js
+++ b/src/appmixer/akamai/lib.js
@@ -1,6 +1,17 @@
 const EdgeGrid = require('akamai-edgegrid');
 
+// Client list activation statuses as returned by the Akamai Network/Client Lists API.
+const ACTIVATION_STATUS = {
+    ACTIVE: 'ACTIVE',
+    INACTIVE: 'INACTIVE',
+    MODIFIED: 'MODIFIED',
+    PENDING: 'PENDING_ACTIVATION',
+    FAILED: 'FAILED'
+};
+
 module.exports = {
+    ACTIVATION_STATUS,
+
     generateAuthorizationHeader({ clientToken, clientSecret, accessToken, hostnameUrl, method, path, body, debug }) {
         const eg = new EdgeGrid(clientToken, clientSecret, accessToken, hostnameUrl, debug);
 
@@ -11,6 +22,69 @@ module.exports = {
         });
 
         return auth.request;
+    },
+
+    // Fetch the raw list details (including its activation status per network).
+    async getList(context, auth, listId) {
+        const { hostnameUrl, accessToken, clientSecret, clientToken } = auth;
+        const {
+            url,
+            method,
+            headers: { Authorization }
+        } = this.generateAuthorizationHeader({
+            hostnameUrl,
+            accessToken,
+            clientToken,
+            clientSecret,
+            method: 'GET',
+            path: `/client-list/v1/lists/${listId}`
+        });
+
+        const { data } = await context.httpRequest({
+            url,
+            method,
+            headers: { Authorization }
+        });
+
+        return data;
+    },
+
+    // Return the activation status of a list for the given network (STAGING/PRODUCTION).
+    async getActivationStatus(context, auth, listId, network) {
+        const list = await this.getList(context, auth, listId);
+        const key = network === 'PRODUCTION'
+            ? 'productionActivationStatus'
+            : 'stagingActivationStatus';
+        return list[key];
+    },
+
+    // Poll the list activation status until it reaches ACTIVE, fails, or the timeout is hit.
+    // timeout and interval are given in seconds. Returns the final activation status.
+    async waitForActivation(context, auth, listId, network, { timeout = 300, interval = 15 } = {}) {
+        const deadline = Date.now() + timeout * 1000;
+        const intervalMs = Math.max(interval, 1) * 1000;
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const status = await this.getActivationStatus(context, auth, listId, network);
+
+            if (status === ACTIVATION_STATUS.ACTIVE) {
+                return status;
+            }
+
+            if (status === ACTIVATION_STATUS.FAILED) {
+                throw new context.CancelError(`Activation of list ${listId} on the ${network} network failed.`);
+            }
+
+            if (Date.now() + intervalMs >= deadline) {
+                throw new context.CancelError(
+                    `Timed out after ${timeout}s waiting for list ${listId} to become ACTIVE on the ${network} network. ` +
+                    `Current status: ${status}. Akamai activations can take 1-15+ minutes; increase the timeout or retry later.`
+                );
+            }
+
+            await new Promise(resolve => setTimeout(resolve, intervalMs));
+        }
     },
 
     parseIPs(input) {

--- a/src/appmixer/akamai/lib.js
+++ b/src/appmixer/akamai/lib.js
@@ -50,11 +50,19 @@ module.exports = {
         return data;
     },
 
-    // Return the activation status of a list for the given network (STAGING/PRODUCTION).
-    async getActivationStatus(context, auth, listId, network) {
-        if (network !== 'PRODUCTION' && network !== 'STAGING') {
+    // Normalize the network input to the STAGING/PRODUCTION enum. Values may
+    // come from flow variables in any case; don't break flows over casing.
+    normalizeNetwork(context, network) {
+        const normalized = String(network || '').trim().toUpperCase();
+        if (normalized !== 'PRODUCTION' && normalized !== 'STAGING') {
             throw new context.CancelError(`Invalid network "${network}". Expected STAGING or PRODUCTION.`);
         }
+        return normalized;
+    },
+
+    // Return the activation status of a list for the given network (STAGING/PRODUCTION).
+    async getActivationStatus(context, auth, listId, network) {
+        network = this.normalizeNetwork(context, network);
         const list = await this.getList(context, auth, listId);
         const key = network === 'PRODUCTION'
             ? 'productionActivationStatus'
@@ -64,6 +72,7 @@ module.exports = {
 
     // Trigger an activation of the list on the given network.
     async activateList(context, auth, { listId, network, comments }) {
+        network = this.normalizeNetwork(context, network);
         const { hostnameUrl, accessToken, clientSecret, clientToken } = auth;
         const body = { action: 'ACTIVATE', network };
         if (comments) {
@@ -110,6 +119,7 @@ module.exports = {
     // Returns null when no fresh status is available yet (another caller holds
     // the poll lock and nothing is cached) — callers should simply retry next tick.
     async getActivationStatusShared(context, auth, listId, network, { maxAgeMs = 30 * 1000 } = {}) {
+        network = this.normalizeNetwork(context, network);
         // Service state and locks are service-global — scope the keys by a
         // non-secret hash of the credentials so two Akamai accounts with the
         // same listId never share a cache entry or contend on the lock.

--- a/src/appmixer/akamai/lib.js
+++ b/src/appmixer/akamai/lib.js
@@ -51,6 +51,9 @@ module.exports = {
 
     // Return the activation status of a list for the given network (STAGING/PRODUCTION).
     async getActivationStatus(context, auth, listId, network) {
+        if (network !== 'PRODUCTION' && network !== 'STAGING') {
+            throw new context.CancelError(`Invalid network "${network}". Expected STAGING or PRODUCTION.`);
+        }
         const list = await this.getList(context, auth, listId);
         const key = network === 'PRODUCTION'
             ? 'productionActivationStatus'
@@ -76,14 +79,15 @@ module.exports = {
                 throw new context.CancelError(`Activation of list ${listId} on the ${network} network failed.`);
             }
 
-            if (Date.now() + intervalMs >= deadline) {
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) {
                 throw new context.CancelError(
                     `Timed out after ${timeout}s waiting for list ${listId} to become ACTIVE on the ${network} network. ` +
                     `Current status: ${status}. Akamai activations can take 1-15+ minutes; increase the timeout or retry later.`
                 );
             }
 
-            await new Promise(resolve => setTimeout(resolve, intervalMs));
+            await new Promise(resolve => setTimeout(resolve, Math.min(intervalMs, remainingMs)));
         }
     },
 


### PR DESCRIPTION
## Summary

Akamai client list activations take **1–15+ minutes**, during which a list is in the `PENDING_ACTIVATION` state and cannot be re-activated. Previously the connector never checked this, so rapid, sequential list updates (the *attacker-after-attacker* mitigation scenario) failed with unhelpful errors and downstream steps could proceed on a still-pending list.

This PR adds first-class handling of the activation lifecycle.

## Changes

- **`lib.js`** — new shared helpers plus an `ACTIVATION_STATUS` map:
  - `getList(context, auth, listId)` — fetch raw list details.
  - `getActivationStatus(context, auth, listId, network)` — resolve the per-network (`STAGING`/`PRODUCTION`) activation status.
  - `waitForActivation(context, auth, listId, network, { timeout, interval })` — poll until the list reaches `ACTIVE`, throwing a clear error on `FAILED` or timeout.
- **`ActivateList`** — reads the current activation status before activating. If the list is already `PENDING_ACTIVATION`, it either waits for completion (new **Wait for Activation** toggle, with configurable **Timeout**) or fails with a clear, actionable message. The current status is surfaced as a new `previousActivationStatus` output field, and `activationStatus` reflects the final state when waiting. (Also fixes a latent bug where the activation `POST` body was not sent.)
- **`UpsertListEntries`** — same pre-activation check so rapid sequential IP additions no longer collide with an in-flight activation. Adds the **Wait for Activation** / **Timeout** options and a new `activationStatus` output field.
- **`WaitForActivation`** — new component that polls a list until it reaches `ACTIVE`, letting flows explicitly gate downstream steps or build retry/branch logic.
- Tooltips updated to communicate the 1–15+ minute activation timing; `bundle.json` bumped to `1.3.0` with changelog.

## Acceptance criteria

- [x] Connector reads the current activation status of a list before attempting to activate
- [x] `PENDING` state handled gracefully (clear error, or polling with configurable timeout)
- [x] Activation status surfaced as an output field in relevant components
- [x] Tooltips updated to reflect activation timing expectations
- [x] Handles the attacker-after-attacker scenario (rapid sequential IP additions) via the wait-for-activation gate

## Validation

- `npm run lint` — passes
- `node scripts/validate.js --changed --base origin/dev` — passes

> Note: the connector implements Akamai's Client Lists API (`/client-list/v1/...`); the issue refers to it as "Network List". The changes apply to the existing client-list components.

Closes Appmixer-ai/appmixer-components#2766

🤖 Generated with [Claude Code](https://claude.com/claude-code)
