### PR TITLE
xero: fix *META* lock exhaustion on long-running jobs (>15 min)

### DIFF
--- a/src/appmixer/xero/bundle.json
+++ b/src/appmixer/xero/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.xero",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "engine": ">=6.0.0",
     "changelog": {
         "1.0.0": [
@@ -52,6 +52,10 @@
             "Fixed swapped label/value pairs in output options (ListAccounts Account ID, GetOrganization External Links and Payment Terms).",
             "ListJournals: pagination is now handled internally using the Journals endpoint's offset mechanism (the endpoint ignores page-based pagination); the manual Offset input was removed.",
             "ListAccounts, ListContacts, ListJournals, GetOrganization: required Tenant ID input is validated with a clear error message."
+        ],
+        "1.6.4": [
+            "Fixed *META* lock exhaustion (\"Exceeded 30 attempts to lock the resource ...:locks:xero:<hash>\") on long-running jobs (>15 min) that repeatedly read the same account/query via the withCache list cache. Cache hits are now served without taking the lock, so warm-cache reads no longer contend; the lock is only used to dedupe the burst that populates a cold cache.",
+            "withCache: the lock is now released in every code path (cache hit, success and error), the release is awaited and guarded, and lock acquisition uses an explicit TTL (60s, documented) plus a longer retry budget. If the lock still cannot be acquired the call degrades to a direct fetch instead of failing the component, and lock acquisition/release failures are logged with the lock key."
         ]
     }
 }

--- a/src/appmixer/xero/commons.js
+++ b/src/appmixer/xero/commons.js
@@ -15,8 +15,10 @@ const DEFAULT_LIST_CACHE_TTL = 2 * 60 * 1000;
 //   must not linger forever, but it must comfortably outlive a full paginated fetch — a Xero list can be
 //   ~100 sequential pages, each of which may sit through a Retry-After backoff on a 429, so a fetch can
 //   legitimately take tens of seconds. 60s covers that with margin while still auto-recovering from a
-//   stale lock left by a dead worker (dead-lock detection). It is < the cache TTL, so a lock never
-//   outlives the value it guards.
+//   stale lock left by a dead worker (dead-lock detection). It is < the default cache TTL (120s), so
+//   under the default a lock never outlives the value it guards. (The cache TTL is configurable via
+//   context.config.listCacheTTL; if it is set below 60s the lock may outlive the cached value, which
+//   is harmless — a re-fetch simply re-populates the cache.)
 // - LOCK_RETRY_DELAY / LOCK_MAX_RETRY_COUNT: how long a waiter blocks before giving up. 500ms * 60 = 30s,
 //   which lets a waiter sit through a realistic fetch (including 429 backoff) instead of exhausting the
 //   framework default (30 attempts) and throwing. Combined with the fallback below, exceeding even this
@@ -69,7 +71,7 @@ module.exports = {
         // never contend for the lock at all — this is what stops the *META* lock exhaustion. The lock is
         // only needed to dedupe the burst that populates a cold cache.
         const cachedBeforeLock = await context.staticCache.get(key);
-        if (cachedBeforeLock) {
+        if (cachedBeforeLock !== null && cachedBeforeLock !== undefined) {
             return cachedBeforeLock;
         }
 
@@ -99,7 +101,7 @@ module.exports = {
             // Re-check under the lock: a waiter that just got the lock may find the previous holder
             // already populated the cache.
             const cached = await context.staticCache.get(key);
-            if (cached) {
+            if (cached !== null && cached !== undefined) {
                 return cached;
             }
 

--- a/src/appmixer/xero/commons.js
+++ b/src/appmixer/xero/commons.js
@@ -8,6 +8,23 @@ const XeroClient = require('./XeroClient');
 // during normal flow execution, so 2 min staleness on list endpoints is an acceptable tradeoff.
 const DEFAULT_LIST_CACHE_TTL = 2 * 60 * 1000;
 
+// Lock settings for the withCache dedupe lock (key "xero:<hash>", i.e. the resource that surfaced as
+// *META*::locks:xero:<hash> in the "Exceeded 30 attempts to lock the resource" failures on long jobs).
+//
+// - LOCK_TTL: the lock is a dead-man's switch. If the holder crashes (or is killed) mid-fetch the lock
+//   must not linger forever, but it must comfortably outlive a full paginated fetch — a Xero list can be
+//   ~100 sequential pages, each of which may sit through a Retry-After backoff on a 429, so a fetch can
+//   legitimately take tens of seconds. 60s covers that with margin while still auto-recovering from a
+//   stale lock left by a dead worker (dead-lock detection). It is < the cache TTL, so a lock never
+//   outlives the value it guards.
+// - LOCK_RETRY_DELAY / LOCK_MAX_RETRY_COUNT: how long a waiter blocks before giving up. 500ms * 60 = 30s,
+//   which lets a waiter sit through a realistic fetch (including 429 backoff) instead of exhausting the
+//   framework default (30 attempts) and throwing. Combined with the fallback below, exceeding even this
+//   budget degrades gracefully rather than failing the component.
+const LOCK_TTL = 60 * 1000;
+const LOCK_RETRY_DELAY = 500;
+const LOCK_MAX_RETRY_COUNT = 60;
+
 function getCacheKey(obj) {
     return crypto
         .createHash('sha256')
@@ -47,10 +64,40 @@ module.exports = {
         const token = context.auth?.accessToken || context.accessToken;
         const key = 'xero:' + getCacheKey({ ...keyParts, token });
 
+        // Fast path: serve a warm cache without ever taking the lock. On long-running jobs the same
+        // account/query is read over and over, so the overwhelming majority of calls hit this path and
+        // never contend for the lock at all — this is what stops the *META* lock exhaustion. The lock is
+        // only needed to dedupe the burst that populates a cold cache.
+        const cachedBeforeLock = await context.staticCache.get(key);
+        if (cachedBeforeLock) {
+            return cachedBeforeLock;
+        }
+
+        // Cache miss: take the lock so a concurrent burst does not fire N duplicate paginated fetches
+        // (Xero has tight rate limits). Acquisition is best-effort — never fail the component just
+        // because the dedupe lock is contended/stale.
         let lock;
         try {
-            lock = await context.lock(key);
+            lock = await context.lock(key, {
+                ttl: LOCK_TTL,
+                retryDelay: LOCK_RETRY_DELAY,
+                maxRetryCount: LOCK_MAX_RETRY_COUNT
+            });
+        } catch (err) {
+            // Lock exhausted (e.g. a very slow holder or a leftover stale lock). Degrade gracefully to
+            // an un-deduplicated direct fetch: we lose only the burst dedupe, correctness is preserved,
+            // and the job keeps running instead of dying with "Exceeded N attempts to lock the resource".
+            await context.log({
+                step: 'xero:withCache lock acquisition failed — falling back to direct fetch',
+                key,
+                error: err.message
+            });
+            return fn();
+        }
 
+        try {
+            // Re-check under the lock: a waiter that just got the lock may find the previous holder
+            // already populated the cache.
             const cached = await context.staticCache.get(key);
             if (cached) {
                 return cached;
@@ -61,7 +108,14 @@ module.exports = {
             await context.staticCache.set(key, result, ttl);
             return result;
         } finally {
-            lock?.unlock();
+            // Always release the lock, in every path (cache hit, success, or fn() throwing). Awaited and
+            // guarded so a release failure is logged rather than swallowed, and can never mask the
+            // original result/error from the try block.
+            try {
+                await lock.unlock();
+            } catch (err) {
+                await context.log({ step: 'xero:withCache lock release failed', key, error: err.message });
+            }
         }
     },
 


### PR DESCRIPTION
## Summary

Fixes the `*META*` lock exhaustion reported on long-running Xero flows (>15 min) that use components like **List Contacts** and **Create Invoice** on the same account:

```
Exceeded 30 attempts to lock the resource "...xero:*META*::locks:xero:<hash>"
```

## Root cause

The reported symptom points at the OAuth token-refresh lock, but the actual lock in the error resource is the **`withCache` list cache** lock, not the token refresh lock:

- `commons.withCache` (added in 1.6.2) builds its lock key as `'xero:' + sha256(...)` — exactly the `locks:xero:<hash>` seen in the error. The token-refresh/webhook locks use different keys (`context.componentId`), which would not produce `xero:<hash>`.
- The hash is stable per account/query because the cache key is derived from `{ tenantId, url, params, token }` — matching the reporter's "stable hash for the same Xero account/connection".

The `withCache` implementation:
1. Took the lock on **every** call — including cache hits — and held it across the **entire paginated fetch** (a Xero list can be ~100 sequential pages, each of which may sit through a `Retry-After` 429 backoff).
2. Used the **framework default retry budget (30 attempts)**.
3. Released the lock with a **fire-and-forget** `lock?.unlock()` (not awaited).

On a long job that repeatedly reads the same account/query, concurrent callers serialize behind this one lock and exhaust their 30-attempt budget → the reported failure.

## What changed (`src/appmixer/xero/commons.js`)

- **Warm-cache reads no longer take the lock at all** (fast path). This removes essentially all lock contention on long jobs — the lock is now only used to dedupe the burst that populates a *cold* cache, so the short-job dedupe guarantee is preserved.
- **Lock released in every path** (cache hit, success, `fn()` throw); release is now **awaited and guarded** so a release failure is logged instead of swallowed and can never mask the original result/error.
- **Explicit, documented lock TTL (60s)** — long enough to outlive a full paginated fetch incl. 429 backoff, shorter than the cache TTL so a lock never outlives the value it guards. This TTL doubles as **dead-lock recovery**: a lock left by a crashed worker auto-expires.
- **Longer retry budget** (`retryDelay: 500ms × maxRetryCount: 60 = 30s`) instead of the default 30 attempts.
- **Graceful degradation**: if the lock still cannot be acquired, the call falls back to a direct (un-deduplicated) fetch instead of failing the component. Acquisition/release failures are logged with the lock key for diagnostics.

Version bumped to `1.6.4` with a changelog entry.

## Acceptance criteria
- [x] Long-running flows (>15 min, same account) no longer fail with META lock exhaustion — warm reads are lock-free and lock exhaustion degrades to a direct fetch.
- [x] Lock released in all code paths (happy path, error, cache hit).
- [x] Lock TTL documented with rationale in comments.
- [x] No regression on concurrent short jobs — the lock still dedupes the cold-cache population burst.

## Validation
- `npm run lint` — passes
- `node scripts/validate.js --changed --base origin/dev` — passes

## Note on untrusted issue content
The issue body contained no instructions attempting to alter this workflow, exfiltrate secrets, or change remotes; nothing was ignored on security grounds.

Closes Appmixer-ai/appmixer-components#2767