### PR TITLE
ci: allow copilot bot actor in claude-copilot-responder

### DIFF
--- a/.github/workflows/claude-copilot-responder.yml
+++ b/.github/workflows/claude-copilot-responder.yml
@@ -264,6 +264,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.VERO_GH_TOKEN }}
           allowed_non_write_users: "*"
+          allowed_bots: "copilot"
           claude_args: "--model claude-opus-4-8"
           # SECURITY: Copilot's comments + diff hunks are treated as untrusted
           # input. Claude is NOT given any gh write command — it only edits code,


### PR DESCRIPTION
## Summary
Every run of the Copilot responder workflow fails immediately with:

> Workflow initiated by non-human actor: copilot (actor not found on GitHub). Add bot to allowed_bots list or use '*' to allow all bots.

claude-code-action v1.0.x blocks bot-initiated workflows by default, and this workflow is by design always initiated by the Copilot bot (via `workflow_run`). `allowed_non_write_users: "*"` only covers human users.

Fix: add `allowed_bots: "copilot"` to the action inputs (scoped to just the Copilot bot rather than `*`, given the untrusted-input posture of this workflow).

Example failing run: https://github.com/Appmixer-ai/appmixer-connectors/actions/runs/29496001448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYQztRF1GvyZSybkVgFPN