### PR TITLE
chore: point appmixer-agents plugin marketplace at Appmixer-ai/appmixer-skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
     "appmixer-agents": {
       "source": {
         "source": "github",
-        "repo": "Appmixer-ai/appmixer-openclaw-agents"
+        "repo": "Appmixer-ai/appmixer-skills"
       }
     }
   },


### PR DESCRIPTION
The Claude Code agent skills moved from `appmixer-openclaw-agents` to the standalone [appmixer-skills](https://github.com/Appmixer-ai/appmixer-skills) repo; the old repo no longer receives updates. This updates the committed `.claude/settings.json` so fresh checkouts register the marketplace from the new repo.

Marketplace name (`appmixer-agents`) and plugin name (`appmixer`) are unchanged, so the `enabledPlugins` entry keeps working as-is.

**Note for existing checkouts:** Claude Code caches marketplace registrations. If you had the plugin installed before this change, run `/plugin marketplace remove appmixer-agents` once and reopen the project (or `/plugin marketplace add Appmixer-ai/appmixer-skills`). Fresh clones: if Claude Code does not offer the plugin automatically after trusting the folder, run `/plugin install appmixer@appmixer-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jRnbwinJmHtS27n4a8fLs