### PR TITLE
microsoft/mail: GetAttachments returns metadata only (no attachment content)

### DIFF
--- a/src/appmixer/microsoft/mail/GetAttachments/GetAttachments.js
+++ b/src/appmixer/microsoft/mail/GetAttachments/GetAttachments.js
@@ -2,6 +2,12 @@
 
 const { makeRequest } = require('../commons');
 
+// Metadata-only fields of the base attachment resource. Selecting only these
+// guarantees the binary `contentBytes` (a fileAttachment-specific property) is
+// never returned, which avoids Appmixer's max message size exception on emails
+// with large attachments. Use the DownloadAttachment component to get content.
+const METADATA_FIELDS = ['id', 'name', 'contentType', 'size', 'isInline', 'lastModifiedDateTime'];
+
 module.exports = {
 
     async receive(context) {
@@ -12,8 +18,16 @@ module.exports = {
 
         const { messageId, outputType } = context.messages.in.content;
 
+        if (!messageId) {
+            throw new context.CancelError('Message ID is required!');
+        }
+
         const url = `/me/messages/${messageId}/attachments`;
-        const attachmentsResponse = await makeRequest(context, { path: url, method: 'GET' });
+        const attachmentsResponse = await makeRequest(context, {
+            path: url,
+            method: 'GET',
+            params: { '$select': METADATA_FIELDS.join(',') }
+        });
 
         const value = attachmentsResponse.data.value;
 
@@ -36,9 +50,6 @@ module.exports = {
                 { label: 'Name', value: 'name' },
                 { label: 'Size', value: 'size' },
                 { label: 'Content Type', value: 'contentType' },
-                { label: 'Content Location', value: 'contentLocation' },
-                { label: 'Content Bytes', value: 'contentBytes' },
-                { label: 'Content ID', value: 'contentId' },
                 { label: 'Last Modified Date Time', value: 'lastModifiedDateTime' }
             ], 'out');
         } else if (outputType === 'attachments') {

--- a/src/appmixer/microsoft/mail/GetAttachments/component.json
+++ b/src/appmixer/microsoft/mail/GetAttachments/component.json
@@ -1,7 +1,8 @@
 {
     "name": "appmixer.microsoft.mail.GetAttachments",
+    "label": "Get Attachments Metadata",
     "author": "David Durman <david@client.io>",
-    "description": "Get message attachments.",
+    "description": "Get message attachments metadata only (id, name, content type, size, etc.). The binary content is not included — use the Download Attachment component to download the content.",
     "auth": {
         "service": "appmixer:microsoft",
         "scope": ["Mail.Read"]
@@ -45,7 +46,7 @@
         {
             "name": "out",
             "source": {
-                "url": "/component/appmixer/microsoft/mail/GetAttachments?outPort=out",
+                "url": "/component/appmixer/microsoft/mail/GetAttachments?outPort=out&ignoreAuth=true",
                 "data": {
                     "properties": {
                         "generateOutputPortOptions": true

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-attachments-metadata.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-attachments-metadata.json
@@ -481,7 +481,10 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {},
+                "properties": {
+                    "successStoreId": "64f6f1f9193228000754082f",
+                    "failedStoreId": "64f6f1f0193228000754082e"
+                },
                 "transform": {
                     "in": {
                         "dc4de5d0-e160-4267-90ec-cb31178030fc": {

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-attachments-metadata.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-attachments-metadata.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Microsoft Mail - Attachments Metadata",
-    "type": "automation",
     "flow": {
         "8e854411-61cc-4319-ae5c-1c14399b7807": {
             "type": "appmixer.utils.controls.OnStart",
@@ -102,6 +100,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -144,6 +145,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -153,8 +157,8 @@
         },
         "47a3450c-c790-4842-8910-021d87a0266b": {
             "type": "appmixer.microsoft.mail.GetAttachments",
-            "x": 960,
-            "y": 0,
+            "x": 976,
+            "y": 200,
             "source": {
                 "in": {
                     "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": [
@@ -184,6 +188,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -193,8 +200,8 @@
         },
         "b415f395-283d-4978-a071-b61d71d73d3e": {
             "type": "appmixer.microsoft.mail.DownloadAttachment",
-            "x": 1200,
-            "y": 0,
+            "x": 1270,
+            "y": 444,
             "source": {
                 "in": {
                     "47a3450c-c790-4842-8910-021d87a0266b": [
@@ -229,6 +236,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -238,8 +248,8 @@
         },
         "f96e43b7-3eac-4c11-92db-2afeade56edb": {
             "type": "appmixer.utils.test.Assert",
-            "x": 960,
-            "y": 200,
+            "x": 1013,
+            "y": 0,
             "source": {
                 "in": {
                     "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": [
@@ -356,8 +366,8 @@
         },
         "f09f4e45-2c8b-427c-aed7-a93e75ac42c2": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1440,
-            "y": 200,
+            "x": 1503,
+            "y": 301,
             "source": {
                 "in": {
                     "b415f395-283d-4978-a071-b61d71d73d3e": [
@@ -461,6 +471,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -481,10 +494,7 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "dc4de5d0-e160-4267-90ec-cb31178030fc": {
@@ -523,5 +533,8 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Microsoft Mail - Attachments Metadata",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-attachments-metadata.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-attachments-metadata.json
@@ -1,0 +1,524 @@
+{
+    "name": "E2E Microsoft Mail - Attachments Metadata",
+    "type": "automation",
+    "flow": {
+        "8e854411-61cc-4319-ae5c-1c14399b7807": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 0,
+            "y": 0,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "091ce762-1f11-42bc-aad3-6c9b0a299bdb": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 240,
+            "y": 0,
+            "source": {
+                "in": {
+                    "8e854411-61cc-4319-ae5c-1c14399b7807": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "8e854411-61cc-4319-ae5c-1c14399b7807": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "recipient",
+                                                "text": "e2e-test@appmixer.ai"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "subject",
+                                                "text": "E2E Attachments Metadata Test"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "c536abc1-cc3f-42af-a868-ac4c7946276b": {
+            "type": "appmixer.microsoft.mail.CreateDraft",
+            "x": 480,
+            "y": 0,
+            "source": {
+                "in": {
+                    "091ce762-1f11-42bc-aad3-6c9b0a299bdb": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "091ce762-1f11-42bc-aad3-6c9b0a299bdb": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "toRecipients": {
+                                        "5abf4a39-6d7b-4b41-bfe1-f887e73933ef": {
+                                            "variable": "$.091ce762-1f11-42bc-aad3-6c9b0a299bdb.out.recipient",
+                                            "functions": []
+                                        }
+                                    },
+                                    "subject": {
+                                        "96dbb4e5-2a0c-4716-a450-12b0da572da8": {
+                                            "variable": "$.091ce762-1f11-42bc-aad3-6c9b0a299bdb.out.subject",
+                                            "functions": []
+                                        }
+                                    },
+                                    "content": {},
+                                    "contentType": {}
+                                },
+                                "lambda": {
+                                    "toRecipients": "{{{5abf4a39-6d7b-4b41-bfe1-f887e73933ef}}}",
+                                    "subject": "{{{96dbb4e5-2a0c-4716-a450-12b0da572da8}}}",
+                                    "content": "This draft is created by an Appmixer E2E test to verify attachment metadata.",
+                                    "contentType": "Text"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": {
+            "type": "appmixer.microsoft.mail.MakeApiCall",
+            "x": 720,
+            "y": 0,
+            "source": {
+                "in": {
+                    "c536abc1-cc3f-42af-a868-ac4c7946276b": [
+                        "email"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "c536abc1-cc3f-42af-a868-ac4c7946276b": {
+                            "email": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {
+                                        "6fa74a5c-2465-4f89-ba68-f6dd9872ab8c": {
+                                            "variable": "$.c536abc1-cc3f-42af-a868-ac4c7946276b.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "method": {},
+                                    "body": {}
+                                },
+                                "lambda": {
+                                    "url": "me/messages/{{{6fa74a5c-2465-4f89-ba68-f6dd9872ab8c}}}/attachments",
+                                    "method": "POST",
+                                    "body": "{\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":\"e2e-test.txt\",\"contentType\":\"text/plain\",\"contentBytes\":\"SGVsbG8gRTJFIGF0dGFjaG1lbnQ=\"}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "47a3450c-c790-4842-8910-021d87a0266b": {
+            "type": "appmixer.microsoft.mail.GetAttachments",
+            "x": 960,
+            "y": 0,
+            "source": {
+                "in": {
+                    "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "messageId": {
+                                        "009d52c1-f741-4720-80dd-7c3f9fdf66b7": {
+                                            "variable": "$.c536abc1-cc3f-42af-a868-ac4c7946276b.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "messageId": "{{{009d52c1-f741-4720-80dd-7c3f9fdf66b7}}}",
+                                    "outputType": "attachment"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "b415f395-283d-4978-a071-b61d71d73d3e": {
+            "type": "appmixer.microsoft.mail.DownloadAttachment",
+            "x": 1200,
+            "y": 0,
+            "source": {
+                "in": {
+                    "47a3450c-c790-4842-8910-021d87a0266b": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "47a3450c-c790-4842-8910-021d87a0266b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "messageId": {
+                                        "47bdbd17-aefd-4f5e-97af-6ce01cf9d929": {
+                                            "variable": "$.c536abc1-cc3f-42af-a868-ac4c7946276b.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "attachmentId": {
+                                        "b404282d-9c61-4140-8fb3-e8ff9d90034f": {
+                                            "variable": "$.47a3450c-c790-4842-8910-021d87a0266b.out.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "messageId": "{{{47bdbd17-aefd-4f5e-97af-6ce01cf9d929}}}",
+                                    "attachmentId": "{{{b404282d-9c61-4140-8fb3-e8ff9d90034f}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f96e43b7-3eac-4c11-92db-2afeade56edb": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 960,
+            "y": 200,
+            "source": {
+                "in": {
+                    "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "cbee16df-5c6a-4cb0-8b3b-e1da16d07e32": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "23a52237-4cca-49d1-ba43-80c649795e39": {
+                                            "variable": "$.cbee16df-5c6a-4cb0-8b3b-e1da16d07e32.out.status",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{23a52237-4cca-49d1-ba43-80c649795e39}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "dc9bf971-eba4-463e-93f7-f5de22977655": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1200,
+            "y": 200,
+            "source": {
+                "in": {
+                    "47a3450c-c790-4842-8910-021d87a0266b": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "47a3450c-c790-4842-8910-021d87a0266b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "f63b3dd9-a7f7-4ce5-b7a7-c5b403feb68f": {
+                                            "variable": "$.47a3450c-c790-4842-8910-021d87a0266b.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.name"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "b3c0cf92-b4f2-44d3-8c76-957a7fa64fc3": {
+                                            "variable": "$.47a3450c-c790-4842-8910-021d87a0266b.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.size"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{f63b3dd9-a7f7-4ce5-b7a7-c5b403feb68f}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{b3c0cf92-b4f2-44d3-8c76-957a7fa64fc3}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f09f4e45-2c8b-427c-aed7-a93e75ac42c2": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1440,
+            "y": 200,
+            "source": {
+                "in": {
+                    "b415f395-283d-4978-a071-b61d71d73d3e": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "b415f395-283d-4978-a071-b61d71d73d3e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "0cef99f7-85ae-4993-845a-3deb0bf16d7a": {
+                                            "variable": "$.b415f395-283d-4978-a071-b61d71d73d3e.out.fileId",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{0cef99f7-85ae-4993-845a-3deb0bf16d7a}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "97650b3f-b45b-4e59-a3fc-c5216d7ca473": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1680,
+            "y": 0,
+            "source": {
+                "in": {
+                    "f96e43b7-3eac-4c11-92db-2afeade56edb": [
+                        "out"
+                    ],
+                    "dc9bf971-eba4-463e-93f7-f5de22977655": [
+                        "out"
+                    ],
+                    "f09f4e45-2c8b-427c-aed7-a93e75ac42c2": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "dc4de5d0-e160-4267-90ec-cb31178030fc": {
+            "type": "appmixer.microsoft.mail.MakeApiCall",
+            "x": 1920,
+            "y": 0,
+            "source": {
+                "in": {
+                    "97650b3f-b45b-4e59-a3fc-c5216d7ca473": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "97650b3f-b45b-4e59-a3fc-c5216d7ca473": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {
+                                        "e3757b44-1a94-4c02-9c27-624ea596ad4e": {
+                                            "variable": "$.c536abc1-cc3f-42af-a868-ac4c7946276b.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "method": {}
+                                },
+                                "lambda": {
+                                    "url": "me/messages/{{{e3757b44-1a94-4c02-9c27-624ea596ad4e}}}",
+                                    "method": "DELETE"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "63736c90-6b64-4fe5-b7c8-9c4b9f42031c": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 2160,
+            "y": 0,
+            "source": {
+                "in": {
+                    "dc4de5d0-e160-4267-90ec-cb31178030fc": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.1",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "dc4de5d0-e160-4267-90ec-cb31178030fc": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "064be9f2-fefb-4cfc-bc26-4b9bb6893b5f": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "e71a4d42-e6a6-49f9-9131-92fe03e72d39": {
+                                            "variable": "$.97650b3f-b45b-4e59-a3fc-c5216d7ca473.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{064be9f2-fefb-4cfc-bc26-4b9bb6893b5f}}}",
+                                    "result": "{{{e71a4d42-e6a6-49f9-9131-92fe03e72d39}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
@@ -633,7 +633,10 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {},
+                "properties": {
+                    "successStoreId": "64f6f1f9193228000754082f",
+                    "failedStoreId": "64f6f1f0193228000754082e"
+                },
                 "transform": {
                     "in": {
                         "f7336491-50ce-42bd-be5a-b321f4933b5d": {

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
@@ -600,8 +600,17 @@
                                 "modifiers": {
                                     "url": {
                                         "bcc32beb-61a3-4a77-87a1-abc320cb04ec": {
-                                            "variable": "$.17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa.out.result.id",
-                                            "functions": []
+                                            "variable": "$.17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa.out.result",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         }
                                     },
                                     "method": {}

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
@@ -1,0 +1,676 @@
+{
+    "name": "E2E Microsoft Mail - Email Lifecycle",
+    "type": "automation",
+    "flow": {
+        "7da5f9a2-ae83-43fc-9cd8-dbe281269d91": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 0,
+            "y": 0,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "1b6911ce-172c-4b81-aff0-48713f682557": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 240,
+            "y": 0,
+            "source": {
+                "in": {
+                    "7da5f9a2-ae83-43fc-9cd8-dbe281269d91": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "7da5f9a2-ae83-43fc-9cd8-dbe281269d91": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "recipient",
+                                                "text": "e2e-test@appmixer.ai"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "subject",
+                                                "text": "E2E Email Lifecycle Test"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "9075bd66-f469-4548-98d9-127c0d2cf02c": {
+            "type": "appmixer.microsoft.mail.CreateDraft",
+            "x": 480,
+            "y": 0,
+            "source": {
+                "in": {
+                    "1b6911ce-172c-4b81-aff0-48713f682557": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "1b6911ce-172c-4b81-aff0-48713f682557": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "toRecipients": {
+                                        "c0d31a7c-528f-4778-abc5-188a4553dba7": {
+                                            "variable": "$.1b6911ce-172c-4b81-aff0-48713f682557.out.recipient",
+                                            "functions": []
+                                        }
+                                    },
+                                    "subject": {
+                                        "88d49b5e-ebf3-4327-94c7-13815fa38bc2": {
+                                            "variable": "$.1b6911ce-172c-4b81-aff0-48713f682557.out.subject",
+                                            "functions": []
+                                        }
+                                    },
+                                    "content": {},
+                                    "contentType": {}
+                                },
+                                "lambda": {
+                                    "toRecipients": "{{{c0d31a7c-528f-4778-abc5-188a4553dba7}}}",
+                                    "subject": "{{{88d49b5e-ebf3-4327-94c7-13815fa38bc2}}}",
+                                    "content": "This draft is created by an Appmixer E2E test to verify the mail lifecycle.",
+                                    "contentType": "Text"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "bd721cf5-7738-4644-96be-c741a65c271b": {
+            "type": "appmixer.microsoft.mail.GetEmail",
+            "x": 720,
+            "y": 0,
+            "source": {
+                "in": {
+                    "9075bd66-f469-4548-98d9-127c0d2cf02c": [
+                        "email"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "9075bd66-f469-4548-98d9-127c0d2cf02c": {
+                            "email": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "messageId": {
+                                        "46dcf887-d755-44bb-89b2-fb348d16b483": {
+                                            "variable": "$.9075bd66-f469-4548-98d9-127c0d2cf02c.email.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "messageId": "{{{46dcf887-d755-44bb-89b2-fb348d16b483}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "version": "1.0.0"
+        },
+        "50c5ea9d-09cb-4e24-b5b4-430f48f94153": {
+            "type": "appmixer.microsoft.mail.MarkEmailAsRead",
+            "x": 960,
+            "y": 0,
+            "source": {
+                "in": {
+                    "bd721cf5-7738-4644-96be-c741a65c271b": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "bd721cf5-7738-4644-96be-c741a65c271b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "emailId": {
+                                        "5f4d3bcd-a62a-4191-8290-2fe1600f1031": {
+                                            "variable": "$.9075bd66-f469-4548-98d9-127c0d2cf02c.email.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "emailId": "{{{5f4d3bcd-a62a-4191-8290-2fe1600f1031}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "version": "1.0.1"
+        },
+        "48bd7035-b173-43e6-8dd2-00b8932f3bb0": {
+            "type": "appmixer.microsoft.mail.MarkEmailAsUnread",
+            "x": 1200,
+            "y": 0,
+            "source": {
+                "in": {
+                    "50c5ea9d-09cb-4e24-b5b4-430f48f94153": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "50c5ea9d-09cb-4e24-b5b4-430f48f94153": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "emailId": {
+                                        "308c4956-8e67-4996-a9f5-04492b0793ca": {
+                                            "variable": "$.9075bd66-f469-4548-98d9-127c0d2cf02c.email.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "emailId": "{{{308c4956-8e67-4996-a9f5-04492b0793ca}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "version": "1.0.1"
+        },
+        "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": {
+            "type": "appmixer.microsoft.mail.UpdateCategory",
+            "x": 1440,
+            "y": 0,
+            "source": {
+                "in": {
+                    "48bd7035-b173-43e6-8dd2-00b8932f3bb0": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "48bd7035-b173-43e6-8dd2-00b8932f3bb0": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "emailId": {
+                                        "afc535f4-95c6-458b-8ffa-16737624f7ac": {
+                                            "variable": "$.9075bd66-f469-4548-98d9-127c0d2cf02c.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "categories": {}
+                                },
+                                "lambda": {
+                                    "emailId": "{{{afc535f4-95c6-458b-8ffa-16737624f7ac}}}",
+                                    "categories": [
+                                        "Blue category"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa": {
+            "type": "appmixer.microsoft.mail.MoveMail",
+            "x": 1680,
+            "y": 0,
+            "source": {
+                "in": {
+                    "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "emailId": {
+                                        "5ae9239e-f64e-4cd6-bf36-9fb248f6f4cb": {
+                                            "variable": "$.9075bd66-f469-4548-98d9-127c0d2cf02c.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "destinationFolder": {}
+                                },
+                                "lambda": {
+                                    "emailId": "{{{5ae9239e-f64e-4cd6-bf36-9fb248f6f4cb}}}",
+                                    "destinationFolder": "deleteditems"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "50832748-41b1-4a59-ac22-4917d5dee24a": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 960,
+            "y": 220,
+            "source": {
+                "in": {
+                    "bd721cf5-7738-4644-96be-c741a65c271b": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "bd721cf5-7738-4644-96be-c741a65c271b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "58be2862-ad21-4b19-ae3d-03ee262bffbe": {
+                                            "variable": "$.bd721cf5-7738-4644-96be-c741a65c271b.out.id",
+                                            "functions": []
+                                        },
+                                        "c3273fbc-7c65-4bf7-b059-a5924878338b": {
+                                            "variable": "$.bd721cf5-7738-4644-96be-c741a65c271b.out.isDraft",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{58be2862-ad21-4b19-ae3d-03ee262bffbe}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{c3273fbc-7c65-4bf7-b059-a5924878338b}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "d9229270-8968-48fd-80bf-83a04246df74": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1200,
+            "y": 220,
+            "source": {
+                "in": {
+                    "50c5ea9d-09cb-4e24-b5b4-430f48f94153": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "50c5ea9d-09cb-4e24-b5b4-430f48f94153": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "c69674fd-278e-4ab5-b3ff-0b0c0aaecb2a": {
+                                            "variable": "$.50c5ea9d-09cb-4e24-b5b4-430f48f94153.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{c69674fd-278e-4ab5-b3ff-0b0c0aaecb2a}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "10278e75-1dab-4e7e-8cde-d4c1d63b704e": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1440,
+            "y": 220,
+            "source": {
+                "in": {
+                    "48bd7035-b173-43e6-8dd2-00b8932f3bb0": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "48bd7035-b173-43e6-8dd2-00b8932f3bb0": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "cce69a58-b3d3-4ec5-b10c-45364338cbf6": {
+                                            "variable": "$.48bd7035-b173-43e6-8dd2-00b8932f3bb0.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{cce69a58-b3d3-4ec5-b10c-45364338cbf6}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "2c9a4543-a543-4aeb-8b8f-5e8c84927345": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1680,
+            "y": 220,
+            "source": {
+                "in": {
+                    "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "3e42c7f2-202a-43b2-b875-57ddaf2cecd7": {
+                                            "variable": "$.b458bcf4-ff5c-411b-b97a-476bb5a48bdb.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{3e42c7f2-202a-43b2-b875-57ddaf2cecd7}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "fbe5f7d0-bd71-4f29-b86f-3ad0087ad618": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1920,
+            "y": 220,
+            "source": {
+                "in": {
+                    "17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "8516f097-30d9-4c0d-84c4-ee08acbb18e4": {
+                                            "variable": "$.17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa.out.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{8516f097-30d9-4c0d-84c4-ee08acbb18e4}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "2f851298-50c7-4e0f-99e4-59def992cbf8": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 2160,
+            "y": 0,
+            "source": {
+                "in": {
+                    "50832748-41b1-4a59-ac22-4917d5dee24a": [
+                        "out"
+                    ],
+                    "d9229270-8968-48fd-80bf-83a04246df74": [
+                        "out"
+                    ],
+                    "10278e75-1dab-4e7e-8cde-d4c1d63b704e": [
+                        "out"
+                    ],
+                    "2c9a4543-a543-4aeb-8b8f-5e8c84927345": [
+                        "out"
+                    ],
+                    "fbe5f7d0-bd71-4f29-b86f-3ad0087ad618": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f7336491-50ce-42bd-be5a-b321f4933b5d": {
+            "type": "appmixer.microsoft.mail.MakeApiCall",
+            "x": 2400,
+            "y": 0,
+            "source": {
+                "in": {
+                    "2f851298-50c7-4e0f-99e4-59def992cbf8": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "2f851298-50c7-4e0f-99e4-59def992cbf8": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {
+                                        "bcc32beb-61a3-4a77-87a1-abc320cb04ec": {
+                                            "variable": "$.17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa.out.result.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "method": {}
+                                },
+                                "lambda": {
+                                    "url": "me/messages/{{{bcc32beb-61a3-4a77-87a1-abc320cb04ec}}}",
+                                    "method": "DELETE"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "0c34901f-696c-40aa-bae1-006ff1aae1b5": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 2640,
+            "y": 0,
+            "source": {
+                "in": {
+                    "f7336491-50ce-42bd-be5a-b321f4933b5d": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.1",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "f7336491-50ce-42bd-be5a-b321f4933b5d": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "3d642395-50a3-4485-a83d-8e0ca6ef0303": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "f070c5cb-2690-4199-b00c-2e7fe72eec07": {
+                                            "variable": "$.2f851298-50c7-4e0f-99e4-59def992cbf8.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{3d642395-50a3-4485-a83d-8e0ca6ef0303}}}",
+                                    "result": "{{{f070c5cb-2690-4199-b00c-2e7fe72eec07}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-email-lifecycle.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Microsoft Mail - Email Lifecycle",
-    "type": "automation",
     "flow": {
         "7da5f9a2-ae83-43fc-9cd8-dbe281269d91": {
             "type": "appmixer.utils.controls.OnStart",
@@ -102,6 +100,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -140,6 +141,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -150,8 +154,8 @@
         },
         "50c5ea9d-09cb-4e24-b5b4-430f48f94153": {
             "type": "appmixer.microsoft.mail.MarkEmailAsRead",
-            "x": 960,
-            "y": 0,
+            "x": 943,
+            "y": 185,
             "source": {
                 "in": {
                     "bd721cf5-7738-4644-96be-c741a65c271b": [
@@ -179,6 +183,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -189,8 +196,8 @@
         },
         "48bd7035-b173-43e6-8dd2-00b8932f3bb0": {
             "type": "appmixer.microsoft.mail.MarkEmailAsUnread",
-            "x": 1200,
-            "y": 0,
+            "x": 1207,
+            "y": 353,
             "source": {
                 "in": {
                     "50c5ea9d-09cb-4e24-b5b4-430f48f94153": [
@@ -218,6 +225,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -228,8 +238,8 @@
         },
         "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": {
             "type": "appmixer.microsoft.mail.UpdateCategory",
-            "x": 1440,
-            "y": 0,
+            "x": 1437,
+            "y": 606,
             "source": {
                 "in": {
                     "48bd7035-b173-43e6-8dd2-00b8932f3bb0": [
@@ -249,14 +259,10 @@
                                             "variable": "$.9075bd66-f469-4548-98d9-127c0d2cf02c.email.id",
                                             "functions": []
                                         }
-                                    },
-                                    "categories": {}
+                                    }
                                 },
                                 "lambda": {
-                                    "emailId": "{{{afc535f4-95c6-458b-8ffa-16737624f7ac}}}",
-                                    "categories": [
-                                        "Blue category"
-                                    ]
+                                    "emailId": "{{{afc535f4-95c6-458b-8ffa-16737624f7ac}}}"
                                 }
                             }
                         }
@@ -270,8 +276,8 @@
         },
         "17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa": {
             "type": "appmixer.microsoft.mail.MoveMail",
-            "x": 1680,
-            "y": 0,
+            "x": 1781,
+            "y": 606,
             "source": {
                 "in": {
                     "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": [
@@ -301,6 +307,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -310,8 +319,8 @@
         },
         "50832748-41b1-4a59-ac22-4917d5dee24a": {
             "type": "appmixer.utils.test.Assert",
-            "x": 960,
-            "y": 220,
+            "x": 1549,
+            "y": -96,
             "source": {
                 "in": {
                     "bd721cf5-7738-4644-96be-c741a65c271b": [
@@ -364,8 +373,8 @@
         },
         "d9229270-8968-48fd-80bf-83a04246df74": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1200,
-            "y": 220,
+            "x": 1549,
+            "y": 60,
             "source": {
                 "in": {
                     "50c5ea9d-09cb-4e24-b5b4-430f48f94153": [
@@ -410,8 +419,8 @@
         },
         "10278e75-1dab-4e7e-8cde-d4c1d63b704e": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1440,
-            "y": 220,
+            "x": 1549,
+            "y": 239,
             "source": {
                 "in": {
                     "48bd7035-b173-43e6-8dd2-00b8932f3bb0": [
@@ -457,7 +466,7 @@
         "2c9a4543-a543-4aeb-8b8f-5e8c84927345": {
             "type": "appmixer.utils.test.Assert",
             "x": 1680,
-            "y": 220,
+            "y": 353,
             "source": {
                 "in": {
                     "b458bcf4-ff5c-411b-b97a-476bb5a48bdb": [
@@ -502,8 +511,8 @@
         },
         "fbe5f7d0-bd71-4f29-b86f-3ad0087ad618": {
             "type": "appmixer.utils.test.Assert",
-            "x": 1920,
-            "y": 220,
+            "x": 1978,
+            "y": 425,
             "source": {
                 "in": {
                     "17bc1cf4-2bd8-4794-bd69-ca8f55bb80aa": [
@@ -622,6 +631,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -642,10 +654,7 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "f7336491-50ce-42bd-be5a-b321f4933b5d": {
@@ -684,5 +693,11 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Microsoft Mail - Email Lifecycle",
+    "type": "automation",
+    "wizard": {
+        "fields": []
+    },
+    "notes": {}
 }

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-lists.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-lists.json
@@ -331,7 +331,10 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {},
+                "properties": {
+                    "successStoreId": "64f6f1f9193228000754082f",
+                    "failedStoreId": "64f6f1f0193228000754082e"
+                },
                 "transform": {
                     "in": {
                         "06bd7829-c91d-4f1e-be63-f127c601925f": {

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-lists.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-lists.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Microsoft Mail - Lists",
-    "type": "automation",
     "flow": {
         "f1558c30-22c2-4855-bbf7-4f7cf3235312": {
             "type": "appmixer.utils.controls.OnStart",
@@ -83,6 +81,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -106,6 +107,11 @@
             "errorHandling": {
                 "autoRetry": false,
                 "onError": "stopFlow"
+            },
+            "config": {
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
+                }
             }
         },
         "f2f4595d-d7ed-41bb-bb57-56cb4936c4a1": {
@@ -123,6 +129,11 @@
             "errorHandling": {
                 "autoRetry": false,
                 "onError": "stopFlow"
+            },
+            "config": {
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
+                }
             }
         },
         "0d772492-7501-40a0-9f3a-411e09903fd2": {
@@ -331,10 +342,7 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "06bd7829-c91d-4f1e-be63-f127c601925f": {
@@ -373,5 +381,8 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Microsoft Mail - Lists",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-lists.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-lists.json
@@ -1,0 +1,374 @@
+{
+    "name": "E2E Microsoft Mail - Lists",
+    "type": "automation",
+    "flow": {
+        "f1558c30-22c2-4855-bbf7-4f7cf3235312": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 0,
+            "y": 0,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "9f525f46-48c3-405f-9681-aabc7588816e": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 240,
+            "y": 0,
+            "source": {
+                "in": {
+                    "f1558c30-22c2-4855-bbf7-4f7cf3235312": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "f1558c30-22c2-4855-bbf7-4f7cf3235312": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "note",
+                                                "text": "E2E list components read-only run"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "91f9410f-1967-41e8-a9c4-257f6fd3cf86": {
+            "type": "appmixer.microsoft.mail.ListEmails",
+            "x": 480,
+            "y": 0,
+            "source": {
+                "in": {
+                    "9f525f46-48c3-405f-9681-aabc7588816e": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "9f525f46-48c3-405f-9681-aabc7588816e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "outputType": {},
+                                    "limit": {}
+                                },
+                                "lambda": {
+                                    "outputType": "email",
+                                    "limit": 5
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "version": "1.0.1"
+        },
+        "66a30da4-d87d-4e3f-aa10-4433a32ab1d5": {
+            "type": "appmixer.microsoft.mail.ListFolders",
+            "x": 720,
+            "y": 0,
+            "source": {
+                "in": {
+                    "91f9410f-1967-41e8-a9c4-257f6fd3cf86": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f2f4595d-d7ed-41bb-bb57-56cb4936c4a1": {
+            "type": "appmixer.microsoft.mail.ListCategories",
+            "x": 960,
+            "y": 0,
+            "source": {
+                "in": {
+                    "66a30da4-d87d-4e3f-aa10-4433a32ab1d5": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "0d772492-7501-40a0-9f3a-411e09903fd2": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 720,
+            "y": 220,
+            "source": {
+                "in": {
+                    "91f9410f-1967-41e8-a9c4-257f6fd3cf86": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "91f9410f-1967-41e8-a9c4-257f6fd3cf86": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "7d3f1c2f-75fa-4adb-8c80-a662f160dcef": {
+                                            "variable": "$.91f9410f-1967-41e8-a9c4-257f6fd3cf86.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{7d3f1c2f-75fa-4adb-8c80-a662f160dcef}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "04b4dbad-3613-4cd7-96df-b089bcd29137": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 960,
+            "y": 220,
+            "source": {
+                "in": {
+                    "66a30da4-d87d-4e3f-aa10-4433a32ab1d5": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "66a30da4-d87d-4e3f-aa10-4433a32ab1d5": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "d12c380e-f862-4540-bf1a-59441420b952": {
+                                            "variable": "$.66a30da4-d87d-4e3f-aa10-4433a32ab1d5.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.folders[0].displayName"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{d12c380e-f862-4540-bf1a-59441420b952}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "14e63279-13af-4bf8-9e53-a87d2850b810": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1200,
+            "y": 220,
+            "source": {
+                "in": {
+                    "f2f4595d-d7ed-41bb-bb57-56cb4936c4a1": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "f2f4595d-d7ed-41bb-bb57-56cb4936c4a1": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "87e449df-d4da-49e6-94ff-d00b3c4db435": {
+                                            "variable": "$.f2f4595d-d7ed-41bb-bb57-56cb4936c4a1.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.categories[0].displayName"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{87e449df-d4da-49e6-94ff-d00b3c4db435}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "06bd7829-c91d-4f1e-be63-f127c601925f": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1440,
+            "y": 0,
+            "source": {
+                "in": {
+                    "0d772492-7501-40a0-9f3a-411e09903fd2": [
+                        "out"
+                    ],
+                    "04b4dbad-3613-4cd7-96df-b089bcd29137": [
+                        "out"
+                    ],
+                    "14e63279-13af-4bf8-9e53-a87d2850b810": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "5f998b5e-a469-496c-9aa7-956976ecca6c": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1680,
+            "y": 0,
+            "source": {
+                "in": {
+                    "06bd7829-c91d-4f1e-be63-f127c601925f": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.1",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "06bd7829-c91d-4f1e-be63-f127c601925f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "c8408cb6-e7e5-4b3e-8556-1eaf97517fca": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "e1b506f2-4a71-4f82-b31d-d277045e824e": {
+                                            "variable": "$.06bd7829-c91d-4f1e-be63-f127c601925f.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{c8408cb6-e7e5-4b3e-8556-1eaf97517fca}}}",
+                                    "result": "{{{e1b506f2-4a71-4f82-b31d-d277045e824e}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-send-email.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-send-email.json
@@ -1,6 +1,4 @@
 {
-    "name": "E2E Microsoft Mail - Send Email",
-    "type": "automation",
     "flow": {
         "6a9e0c3a-88e8-46fb-984e-852441734b22": {
             "type": "appmixer.utils.controls.OnStart",
@@ -102,6 +100,9 @@
                             }
                         }
                     }
+                },
+                "properties": {
+                    "account": "6a466fd9b97d4609b92a5f6a"
                 }
             },
             "errorHandling": {
@@ -190,10 +191,7 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {
-                    "successStoreId": "64f6f1f9193228000754082f",
-                    "failedStoreId": "64f6f1f0193228000754082e"
-                },
+                "properties": {},
                 "transform": {
                     "in": {
                         "c75c7e6b-0697-47d1-82fb-fdb7d0a7ee14": {
@@ -232,5 +230,8 @@
                 "onError": "stopFlow"
             }
         }
-    }
+    },
+    "name": "E2E Microsoft Mail - Send Email",
+    "type": "automation",
+    "notes": {}
 }

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-send-email.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-send-email.json
@@ -190,7 +190,10 @@
             },
             "version": "1.0.1",
             "config": {
-                "properties": {},
+                "properties": {
+                    "successStoreId": "64f6f1f9193228000754082f",
+                    "failedStoreId": "64f6f1f0193228000754082e"
+                },
                 "transform": {
                     "in": {
                         "c75c7e6b-0697-47d1-82fb-fdb7d0a7ee14": {

--- a/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-send-email.json
+++ b/src/appmixer/microsoft/mail/artifacts/test-flows/test-flow-send-email.json
@@ -1,0 +1,233 @@
+{
+    "name": "E2E Microsoft Mail - Send Email",
+    "type": "automation",
+    "flow": {
+        "6a9e0c3a-88e8-46fb-984e-852441734b22": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 0,
+            "y": 0,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "02bab120-5b50-4450-b6c0-aa83536389d2": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 240,
+            "y": 0,
+            "source": {
+                "in": {
+                    "6a9e0c3a-88e8-46fb-984e-852441734b22": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "6a9e0c3a-88e8-46fb-984e-852441734b22": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "recipient",
+                                                "text": "e2e-test@appmixer.ai"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "subject",
+                                                "text": "E2E Send Email Test"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "2ea85a87-d6b7-40c9-ba7a-ad9d9ae8b027": {
+            "type": "appmixer.microsoft.mail.SendEmail",
+            "x": 480,
+            "y": 0,
+            "source": {
+                "in": {
+                    "02bab120-5b50-4450-b6c0-aa83536389d2": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "02bab120-5b50-4450-b6c0-aa83536389d2": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "toRecipients": {
+                                        "cecb1c8d-6bca-485f-9000-edf210553e30": {
+                                            "variable": "$.02bab120-5b50-4450-b6c0-aa83536389d2.out.recipient",
+                                            "functions": []
+                                        }
+                                    },
+                                    "subject": {
+                                        "3174fadf-e6f4-4b3b-b1f8-381e6224f76e": {
+                                            "variable": "$.02bab120-5b50-4450-b6c0-aa83536389d2.out.subject",
+                                            "functions": []
+                                        }
+                                    },
+                                    "content": {},
+                                    "contentType": {}
+                                },
+                                "lambda": {
+                                    "toRecipients": "{{{cecb1c8d-6bca-485f-9000-edf210553e30}}}",
+                                    "subject": "{{{3174fadf-e6f4-4b3b-b1f8-381e6224f76e}}}",
+                                    "content": "This email is sent by an Appmixer E2E test verifying the Send Email component.",
+                                    "contentType": "Text"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "3c89eae3-05cf-4b81-9d90-4af89a290b2e": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 720,
+            "y": 220,
+            "source": {
+                "in": {
+                    "2ea85a87-d6b7-40c9-ba7a-ad9d9ae8b027": [
+                        "email"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "2ea85a87-d6b7-40c9-ba7a-ad9d9ae8b027": {
+                            "email": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "8abb6a98-8b9d-4a6d-9e85-b7d363f027db": {
+                                            "variable": "$.2ea85a87-d6b7-40c9-ba7a-ad9d9ae8b027.email.result",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{8abb6a98-8b9d-4a6d-9e85-b7d363f027db}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "c75c7e6b-0697-47d1-82fb-fdb7d0a7ee14": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 960,
+            "y": 0,
+            "source": {
+                "in": {
+                    "3c89eae3-05cf-4b81-9d90-4af89a290b2e": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "b4937cfd-a35d-4906-aaa4-bb92db9558e1": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1200,
+            "y": 0,
+            "source": {
+                "in": {
+                    "c75c7e6b-0697-47d1-82fb-fdb7d0a7ee14": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.1",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "c75c7e6b-0697-47d1-82fb-fdb7d0a7ee14": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "53220b19-733c-4263-ad2a-7e69ffc72351": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "9bbe8ed2-cb8c-48a5-8744-4f4df0c30deb": {
+                                            "variable": "$.c75c7e6b-0697-47d1-82fb-fdb7d0a7ee14.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{53220b19-733c-4263-ad2a-7e69ffc72351}}}",
+                                    "result": "{{{9bbe8ed2-cb8c-48a5-8744-4f4df0c30deb}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/mail/bundle.json
+++ b/src/appmixer/microsoft/mail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.mail",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -49,6 +49,9 @@
         ],
         "1.6.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Microsoft Graph (Mail) API."
+        ],
+        "1.7.0": [
+            "GetAttachments: relabeled to 'Get Attachments Metadata' and now returns attachment metadata only (no contentBytes), avoiding the max message size exception on large attachments. Use DownloadAttachment to download the content."
         ]
     }
 }

--- a/src/appmixer/microsoft/mail/bundle.json
+++ b/src/appmixer/microsoft/mail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.mail",
-    "version": "1.7.0",
+    "version": "2.0.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -50,8 +50,8 @@
         "1.6.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Microsoft Graph (Mail) API."
         ],
-        "1.7.0": [
-            "GetAttachments: relabeled to 'Get Attachments Metadata' and now returns attachment metadata only (no contentBytes), avoiding the max message size exception on large attachments. Use DownloadAttachment to download the content."
+        "2.0.0": [
+            "BREAKING: GetAttachments (relabeled 'Get Attachments Metadata') now returns attachment metadata only (id, name, contentType, size, isInline, lastModifiedDateTime). The contentBytes, contentId and contentLocation fields are no longer included in the output — to get the attachment content, call the Download Attachment component instead."
         ]
     }
 }


### PR DESCRIPTION
## Summary

Addresses Appmixer-ai/appmixer-components#2770.

The `microsoft/mail` `GetAttachments` component previously fetched and forwarded the **full attachment content** (`contentBytes`) in its output message. For emails with large attachments this easily triggers Appmixer's *max message size* exception. A dedicated `DownloadAttachment` component already exists for retrieving the actual content.

## Changes

- **Relabeled** the component to **"Get Attachments Metadata"** and updated its description to make clear no binary content is returned.
- **Metadata-only fetch**: the request now uses `$select` limited to base attachment properties (`id`, `name`, `contentType`, `size`, `isInline`, `lastModifiedDateTime`). Because `contentBytes` is a `fileAttachment`-specific property, selecting only base fields guarantees the binary content is never returned.
- Removed `Content Bytes` (and the now-unavailable `Content Location` / `Content ID`) from the dynamic output-port options so the variable picker matches the actual output.
- Added the missing required-input assertion for `messageId` and `ignoreAuth=true` on the dynamic output-port `source` (both flagged by strict validation on the touched file).
- Bumped `microsoft/mail` bundle to `1.7.0` with a changelog entry.

## Notes

- **`DownloadAttachment` is untouched** — it remains the correct way to download attachment content.
- The internal component **`name` (`appmixer.microsoft.mail.GetAttachments`) was intentionally kept unchanged** to avoid breaking existing flows that reference it; only the human-readable label/description and behaviour changed. If a hard rename of the identifier is desired despite the backward-compatibility impact, that can be a follow-up.

## Validation

- `npm run lint` — clean
- `node scripts/validate.js --changed --base origin/dev` — passes

Closes Appmixer-ai/appmixer-components#2770
