### PR TITLE
feat: add Latchshot connector

### DIFF
--- a/src/appmixer/latchshot/README.md
+++ b/src/appmixer/latchshot/README.md
@@ -1,0 +1,15 @@
+# Latchshot connector
+
+This connector renders public web pages through the fixed `https://latchshot.fly.dev` API and saves direct PNG, JPEG, or PDF response bytes as an Appmixer file.
+
+Create a recurring Free API key at <https://latchshot.fly.dev/?intent=appmixer#trial>. The Free plan renews to 100 successful renders at the start of each UTC calendar month and requires no card. Keep the API key only in Appmixer's connector authentication field.
+
+## Boundary
+
+- Public HTTP or HTTPS targets on ports 80 and 443 only.
+- No private pages, cookies, custom target headers, sessions, scripts, selectors, proxies, clicks, forms, CAPTCHA work, or anti-bot bypass.
+- Best-effort known-host ad, tracker, and chat blocking plus common cookie-banner and newsletter/signup/discount-popup hiding does not click, submit, or set state.
+- The connector validates the exact artifact media type, enforces a 15 MB limit, and stores the response in Appmixer through `saveFileStream`.
+- The target URL is sent to Latchshot, and the target page can observe Latchshot's rendering network. Latchshot keeps the artifact in memory for the request and does not provide a permanent artifact URL. Appmixer retention and access controls apply after the file is saved.
+
+The connector contains no checkout or payment action. `Get Usage` returns owner-managed continuation links, but opening a link starts neither payment nor implementation work. Latchshot is an independent service and is not affiliated with or endorsed by Appmixer.

--- a/src/appmixer/latchshot/artifacts/test/latchshot.test.js
+++ b/src/appmixer/latchshot/artifacts/test/latchshot.test.js
@@ -1,0 +1,235 @@
+'use strict';
+
+const assert = require('assert');
+
+const auth = require('../../auth');
+const getUsage = require('../../core/GetUsage/GetUsage');
+const makeApiCall = require('../../core/MakeApiCall/MakeApiCall');
+const renderPage = require('../../core/RenderPage/RenderPage');
+
+class CancelError extends Error {}
+
+function contextFor(content, httpRequest) {
+
+    const output = {};
+    return {
+        output,
+        auth: { apiKey: 'test-api-key-material' },
+        messages: { in: { content } },
+        httpRequest,
+        CancelError,
+        saveFileStream: async (filename, bytes) => {
+            output.saved = { filename, bytes };
+            return { fileId: 'file_123' };
+        },
+        sendJson: (data, port) => {
+            output.data = data;
+            output.port = port;
+            return { data, port };
+        }
+    };
+}
+
+describe('Latchshot connector', function() {
+
+    it('validates API keys without exposing them in profile information', async function() {
+
+        let request;
+        const context = {
+            apiKey: 'test-api-key-secret-material',
+            httpRequest: async (value) => {
+                request = value;
+                return { data: {} };
+            }
+        };
+
+        assert.strictEqual(await auth.definition.validate(context), true);
+        assert.strictEqual(request.url, 'https://latchshot.fly.dev/v1/usage');
+        assert.strictEqual(request.headers.Authorization, 'Bearer test-api-key-secret-material');
+
+        const profile = await auth.definition.requestProfileInfo(context);
+        assert(!profile.key.includes('secret_material'));
+        assert.strictEqual(profile.key, 'test-api...rial');
+    });
+
+    it('renders exact REST options and saves direct PNG bytes as an Appmixer file', async function() {
+
+        let request;
+        const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+        const context = contextFor({
+            url: 'https://example.com',
+            format: 'png',
+            width: 1280,
+            height: 720,
+            scale: 2,
+            fullPage: true,
+            waitUntil: 'networkidle',
+            delay: 500,
+            timeout: 20000,
+            darkMode: true,
+            reducedMotion: true,
+            blockAds: true,
+            blockTrackers: true,
+            blockChats: true,
+            hideCookieBanners: true,
+            hidePopups: true
+        }, async (value) => {
+            request = value;
+            return {
+                data: bytes,
+                headers: {
+                    'content-type': 'image/png',
+                    'content-length': String(bytes.length),
+                    'x-latchshot-render-ms': '412',
+                    'x-quota-remaining': '98'
+                }
+            };
+        });
+
+        await renderPage.receive(context);
+
+        assert.deepStrictEqual(request.data, {
+            url: 'https://example.com',
+            kind: 'screenshot',
+            format: 'png',
+            width: 1280,
+            height: 720,
+            scale: 2,
+            waitUntil: 'networkidle',
+            delay: 500,
+            timeout: 20000,
+            darkMode: true,
+            reducedMotion: true,
+            blockAds: true,
+            blockTrackers: true,
+            blockChats: true,
+            hideCookieBanners: true,
+            hidePopups: true,
+            fullPage: true
+        });
+        assert.strictEqual(request.headers.Authorization, 'Bearer test-api-key-material');
+        assert.strictEqual(request.responseType, 'arraybuffer');
+        assert.match(context.output.saved.filename, /^latchshot-\d+\.png$/);
+        assert.deepStrictEqual(context.output.saved.bytes, bytes);
+        assert.deepStrictEqual(context.output.data, {
+            fileId: 'file_123',
+            filename: context.output.saved.filename,
+            contentType: 'image/png',
+            fileSize: 4,
+            renderMs: 412,
+            quotaRemaining: 98
+        });
+    });
+
+    it('selects PDF rendering explicitly and rejects the wrong response type', async function() {
+
+        let request;
+        const context = contextFor({ url: 'https://example.com', format: 'pdf', paper: 'Letter', landscape: true }, async (value) => {
+            request = value;
+            return { data: Buffer.from('not a pdf'), headers: { 'content-type': 'image/png' } };
+        });
+
+        await assert.rejects(() => renderPage.receive(context), /instead of application\/pdf/);
+        assert.strictEqual(request.data.kind, 'pdf');
+        assert.strictEqual(request.data.format, 'pdf');
+        assert.strictEqual(request.data.paper, 'Letter');
+        assert.strictEqual(request.data.landscape, true);
+        assert(!Object.hasOwn(request.data, 'quality'));
+        assert(!Object.hasOwn(request.data, 'fullPage'));
+    });
+
+    it('rejects missing URLs and artifacts declared above 15 MB', async function() {
+
+        const missing = contextFor({}, async () => assert.fail('request should not run'));
+        await assert.rejects(() => renderPage.receive(missing), /Public Page URL is required/);
+
+        const oversized = contextFor({ url: 'https://example.com' }, async () => ({
+            data: Buffer.from([1]),
+            headers: {
+                'content-type': 'image/png',
+                'content-length': String(15 * 1024 * 1024 + 1)
+            }
+        }));
+        await assert.rejects(() => renderPage.receive(oversized), /exceeded the 15 MB/);
+    });
+
+    it('returns flattened read-only usage and owner-managed continuation links', async function() {
+
+        const context = contextFor({}, async () => ({
+            data: {
+                usage: {
+                    plan: 'trial',
+                    period: '2026-07',
+                    limit: 100,
+                    successful: 1,
+                    failed: 0,
+                    remaining: 99,
+                    resetAt: '2026-08-01T00:00:00.000Z'
+                },
+                links: {
+                    plans: 'https://latchshot.fly.dev/#pricing',
+                    requestPaidPlan: 'https://latchshot.fly.dev/#upgrade',
+                    implementationPilot: 'https://latchshot.fly.dev/implementation-pilot.html'
+                }
+            }
+        }));
+
+        await getUsage.receive(context);
+        assert.deepStrictEqual(context.output.data, {
+            plan: 'trial',
+            planName: 'Free',
+            period: '2026-07',
+            limit: 100,
+            successful: 1,
+            failed: 0,
+            remaining: 99,
+            resetAt: '2026-08-01T00:00:00.000Z',
+            plansUrl: 'https://latchshot.fly.dev/#pricing',
+            requestPaidPlanUrl: 'https://latchshot.fly.dev/#upgrade',
+            implementationPilotUrl: 'https://latchshot.fly.dev/implementation-pilot.html'
+        });
+    });
+
+    it('keeps generic API calls on the fixed origin and protects authorization', async function() {
+
+        let request;
+        const context = contextFor({
+            url: '/v1/usage',
+            method: 'GET',
+            parameters: [{ key: 'detail', value: 'summary' }],
+            headers: [
+                { key: 'Authorization', value: 'Bearer attacker' },
+                { key: 'X-Trace', value: 'test' }
+            ]
+        }, async (value) => {
+            request = value;
+            return {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+                data: { ok: true }
+            };
+        });
+
+        await makeApiCall.receive(context);
+        assert.strictEqual(request.url, 'https://latchshot.fly.dev/v1/usage');
+        assert.strictEqual(request.headers.Authorization, 'Bearer test-api-key-material');
+        assert.strictEqual(request.headers['X-Trace'], 'test');
+        assert.deepStrictEqual(request.params, { detail: 'summary' });
+
+        const offOrigin = contextFor({ url: 'https://example.com/v1/usage', method: 'GET' }, async () => assert.fail('request should not run'));
+        await assert.rejects(() => makeApiCall.receive(offOrigin), /must use https:\/\/latchshot\.fly\.dev/);
+    });
+
+    it('rejects invalid JSON bodies and binary generic responses', async function() {
+
+        const invalidBody = contextFor({ url: '/v1/usage', method: 'POST', body: '{' }, async () => assert.fail('request should not run'));
+        await assert.rejects(() => makeApiCall.receive(invalidBody), /must be valid JSON/);
+
+        const binary = contextFor({ url: '/v1/render', method: 'POST', body: '{}' }, async () => ({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: Buffer.from([1])
+        }));
+        await assert.rejects(() => makeApiCall.receive(binary), /Use Render Page/);
+    });
+});

--- a/src/appmixer/latchshot/auth.js
+++ b/src/appmixer/latchshot/auth.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const lib = require('./lib');
+
+module.exports = {
+
+    type: 'apiKey',
+
+    definition: {
+
+        tokenType: 'authentication-token',
+
+        auth: {
+            apiKey: {
+                type: 'text',
+                name: 'API Key',
+                tooltip: 'Create a recurring Free API key at <a href="https://latchshot.fly.dev/?intent=appmixer#trial" target="_blank">latchshot.fly.dev</a>. Keep the <code>ls_live_...</code> value only in this authentication field.'
+            }
+        },
+
+        requestProfileInfo: async (context) => {
+
+            const apiKey = context.apiKey || '';
+            return {
+                key: apiKey.length > 8
+                    ? `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}`
+                    : 'Latchshot API key'
+            };
+        },
+
+        accountNameFromProfileInfo: 'key',
+
+        validate: async (context) => {
+
+            await context.httpRequest({
+                method: 'GET',
+                url: `${lib.BASE_URL}/v1/usage`,
+                headers: {
+                    Authorization: `Bearer ${context.apiKey}`
+                }
+            });
+            return true;
+        }
+    }
+};

--- a/src/appmixer/latchshot/bundle.json
+++ b/src/appmixer/latchshot/bundle.json
@@ -1,0 +1,9 @@
+{
+    "name": "appmixer.latchshot",
+    "version": "1.0.0",
+    "changelog": {
+        "1.0.0": [
+            "Initial version."
+        ]
+    }
+}

--- a/src/appmixer/latchshot/core/GetUsage/GetUsage.js
+++ b/src/appmixer/latchshot/core/GetUsage/GetUsage.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const lib = require('../../lib');
+
+module.exports = {
+
+    async receive(context) {
+
+        const { data } = await context.httpRequest({
+            method: 'GET',
+            url: `${lib.BASE_URL}/v1/usage`,
+            headers: lib.authHeaders(context)
+        });
+
+        if (!data?.usage || !data?.links || typeof data.usage.plan !== 'string') {
+            throw new context.CancelError('Latchshot returned an invalid usage response.');
+        }
+
+        const plan = data.usage.plan;
+        const planName = plan === 'trial' ? 'Free' : `${plan.slice(0, 1).toUpperCase()}${plan.slice(1)}`;
+
+        return context.sendJson({
+            plan,
+            planName,
+            period: data.usage.period,
+            limit: data.usage.limit,
+            successful: data.usage.successful,
+            failed: data.usage.failed,
+            remaining: data.usage.remaining,
+            resetAt: data.usage.resetAt,
+            plansUrl: data.links.plans,
+            requestPaidPlanUrl: data.links.requestPaidPlan,
+            implementationPilotUrl: data.links.implementationPilot
+        }, 'out');
+    }
+};

--- a/src/appmixer/latchshot/core/GetUsage/component.json
+++ b/src/appmixer/latchshot/core/GetUsage/component.json
@@ -1,0 +1,99 @@
+{
+    "name": "appmixer.latchshot.core.GetUsage",
+    "author": "Latchshot <andy@osmosis.ai>",
+    "description": "Read the current Latchshot plan and successful-render quota. This action consumes no render quota and does not initiate payment, an upgrade, or implementation work.",
+    "version": "1.0.0",
+    "private": false,
+    "auth": {
+        "service": "appmixer:latchshot"
+    },
+    "quota": {
+        "manager": "appmixer:latchshot",
+        "resources": "requests",
+        "scope": {
+            "userId": "{{userId}}"
+        }
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {}
+            },
+            "inspector": {
+                "inputs": {}
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "plan": {
+                        "type": "string",
+                        "title": "Plan",
+                        "example": "trial"
+                    },
+                    "planName": {
+                        "type": "string",
+                        "title": "Plan Name",
+                        "example": "Free"
+                    },
+                    "period": {
+                        "type": "string",
+                        "title": "UTC Calendar Month",
+                        "example": "2026-07"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "title": "Successful Render Allowance",
+                        "example": 100
+                    },
+                    "successful": {
+                        "type": "integer",
+                        "title": "Successful Renders",
+                        "example": 1
+                    },
+                    "failed": {
+                        "type": "integer",
+                        "title": "Failed Renders",
+                        "example": 0
+                    },
+                    "remaining": {
+                        "type": "integer",
+                        "title": "Successful Renders Remaining",
+                        "example": 99
+                    },
+                    "resetAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Reset At",
+                        "example": "2026-08-01T00:00:00.000Z"
+                    },
+                    "plansUrl": {
+                        "type": "string",
+                        "format": "uri",
+                        "title": "Plan Details URL",
+                        "example": "https://latchshot.fly.dev/#pricing"
+                    },
+                    "requestPaidPlanUrl": {
+                        "type": "string",
+                        "format": "uri",
+                        "title": "Owner-Managed Paid Plan Request URL",
+                        "example": "https://latchshot.fly.dev/#upgrade"
+                    },
+                    "implementationPilotUrl": {
+                        "type": "string",
+                        "format": "uri",
+                        "title": "Optional Implementation Pilot URL",
+                        "example": "https://latchshot.fly.dev/implementation-pilot.html"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTIiIGZpbGw9IiMxNTVmNzgiLz4KICA8cGF0aCBkPSJNMjEgMTVoLTd2MzRoN000MyAxNWg3djM0aC03IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNiZWU5NDQiLz4KPC9zdmc+Cg=="
+}

--- a/src/appmixer/latchshot/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/latchshot/core/MakeApiCall/MakeApiCall.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const lib = require('../../lib');
+
+function kvToObject(rows, blockedHeaders = []) {
+
+    if (!Array.isArray(rows)) return {};
+    const blocked = new Set(blockedHeaders.map((value) => value.toLowerCase()));
+    const result = {};
+
+    for (const row of rows) {
+        if (!row || typeof row.key !== 'string' || !row.key) continue;
+        if (blocked.has(row.key.toLowerCase())) continue;
+        result[row.key] = row.value;
+    }
+    return result;
+}
+
+module.exports = {
+
+    async receive(context) {
+
+        const { url, method, headers, parameters, body } = context.messages.in.content;
+        if (!url) {
+            throw new context.CancelError('API Endpoint URL is required!');
+        }
+        if (!method) {
+            throw new context.CancelError('HTTP Method is required!');
+        }
+
+        const request = {
+            method,
+            url: lib.apiUrl(url, context),
+            headers: {
+                ...kvToObject(headers, ['authorization', 'host', 'content-length']),
+                ...lib.authHeaders(context)
+            }
+        };
+
+        const query = kvToObject(parameters);
+        if (Object.keys(query).length > 0) {
+            request.params = query;
+        }
+
+        if (body) {
+            try {
+                request.data = typeof body === 'object' ? body : JSON.parse(body);
+            } catch (error) {
+                throw new context.CancelError('Request Body must be valid JSON.');
+            }
+            request.headers['Content-Type'] = 'application/json';
+        }
+
+        const response = await context.httpRequest(request);
+        const contentType = String(response.headers?.['content-type'] || '').toLowerCase();
+        if (!contentType.includes('json')) {
+            throw new context.CancelError('This component supports JSON responses only. Use Render Page for PNG, JPEG, or PDF artifacts.');
+        }
+
+        return context.sendJson({
+            status: response.status,
+            headers: response.headers,
+            body: response.data
+        }, 'out');
+    }
+};

--- a/src/appmixer/latchshot/core/MakeApiCall/component.json
+++ b/src/appmixer/latchshot/core/MakeApiCall/component.json
@@ -1,0 +1,141 @@
+{
+    "name": "appmixer.latchshot.core.MakeApiCall",
+    "author": "Latchshot <andy@osmosis.ai>",
+    "description": "Perform an authorized JSON API call to the fixed Latchshot origin. Use Render Page for PNG, JPEG, or PDF responses.",
+    "version": "1.0.0",
+    "private": false,
+    "auth": {
+        "service": "appmixer:latchshot"
+    },
+    "quota": {
+        "manager": "appmixer:latchshot",
+        "resources": "requests",
+        "scope": {
+            "userId": "{{userId}}"
+        }
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "type": "string",
+                        "enum": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    },
+                    "parameters": {
+                        "type": "string"
+                    },
+                    "body": {
+                        "type": "string"
+                    },
+                    "headers": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "url",
+                    "method"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "url": {
+                        "type": "text",
+                        "index": 1,
+                        "label": "API Endpoint Path",
+                        "tooltip": "Enter a path relative to <code>https://latchshot.fly.dev</code>, such as <code>/v1/usage</code>, or a full URL on that exact origin."
+                    },
+                    "method": {
+                        "type": "select",
+                        "index": 2,
+                        "label": "HTTP Method",
+                        "defaultValue": "GET",
+                        "options": [
+                            {
+                                "label": "GET",
+                                "value": "GET"
+                            },
+                            {
+                                "label": "POST",
+                                "value": "POST"
+                            },
+                            {
+                                "label": "PUT",
+                                "value": "PUT"
+                            },
+                            {
+                                "label": "PATCH",
+                                "value": "PATCH"
+                            },
+                            {
+                                "label": "DELETE",
+                                "value": "DELETE"
+                            }
+                        ]
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Query Parameters",
+                        "index": 3,
+                        "tooltip": "Optional query parameters."
+                    },
+                    "body": {
+                        "type": "textarea",
+                        "index": 4,
+                        "label": "Request Body",
+                        "tooltip": "Optional JSON object. Use Render Page instead when the response is an image or PDF."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "addLabel": "Add item",
+                        "removeLabel": "Remove item",
+                        "label": "Request Headers",
+                        "index": 5,
+                        "tooltip": "Optional headers. Authorization, Host, and Content-Length cannot be overridden."
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "options": [
+                {
+                    "label": "Status Code",
+                    "value": "status"
+                },
+                {
+                    "label": "Response Headers",
+                    "value": "headers"
+                },
+                {
+                    "label": "Response Body",
+                    "value": "body",
+                    "schema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            ]
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTIiIGZpbGw9IiMxNTVmNzgiLz4KICA8cGF0aCBkPSJNMjEgMTVoLTd2MzRoN000MyAxNWg3djM0aC03IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNiZWU5NDQiLz4KPC9zdmc+Cg=="
+}

--- a/src/appmixer/latchshot/core/RenderPage/RenderPage.js
+++ b/src/appmixer/latchshot/core/RenderPage/RenderPage.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const lib = require('../../lib');
+
+const MAX_FILE_BYTES = 15 * 1024 * 1024;
+const CONTENT_TYPES = {
+    png: 'image/png',
+    jpeg: 'image/jpeg',
+    pdf: 'application/pdf'
+};
+
+module.exports = {
+
+    async receive(context) {
+
+        const input = context.messages.in.content;
+        if (!input.url) {
+            throw new context.CancelError('Public Page URL is required!');
+        }
+
+        const format = input.format || 'png';
+        const body = {
+            url: input.url,
+            kind: format === 'pdf' ? 'pdf' : 'screenshot',
+            format,
+            width: input.width ?? 1440,
+            height: input.height ?? 900,
+            scale: input.scale ?? 1,
+            waitUntil: input.waitUntil || 'domcontentloaded',
+            delay: input.delay ?? 0,
+            timeout: input.timeout ?? 15000,
+            darkMode: input.darkMode ?? false,
+            reducedMotion: input.reducedMotion ?? true,
+            blockAds: input.blockAds ?? false,
+            blockTrackers: input.blockTrackers ?? false,
+            blockChats: input.blockChats ?? false,
+            hideCookieBanners: input.hideCookieBanners ?? false,
+            hidePopups: input.hidePopups ?? false
+        };
+
+        if (format === 'jpeg') {
+            body.quality = input.quality ?? 85;
+            body.fullPage = input.fullPage ?? false;
+        } else if (format === 'png') {
+            body.fullPage = input.fullPage ?? false;
+        } else {
+            body.paper = input.paper || 'A4';
+            body.landscape = input.landscape ?? false;
+        }
+
+        const response = await context.httpRequest({
+            method: 'POST',
+            url: `${lib.BASE_URL}/v1/render`,
+            headers: {
+                ...lib.authHeaders(context),
+                'Content-Type': 'application/json'
+            },
+            data: body,
+            responseType: 'arraybuffer',
+            maxContentLength: MAX_FILE_BYTES,
+            maxBodyLength: MAX_FILE_BYTES
+        });
+
+        const contentType = String(response.headers?.['content-type'] || '').split(';', 1)[0].trim().toLowerCase();
+        if (contentType !== CONTENT_TYPES[format]) {
+            throw new context.CancelError(`Latchshot returned ${contentType || 'an unknown media type'} instead of ${CONTENT_TYPES[format]}.`);
+        }
+
+        const declaredLength = lib.optionalIntegerHeader(response.headers, 'content-length');
+        if (declaredLength !== undefined && declaredLength > MAX_FILE_BYTES) {
+            throw new context.CancelError('Latchshot artifact exceeded the 15 MB connector limit.');
+        }
+
+        const bytes = Buffer.isBuffer(response.data) ? response.data : Buffer.from(response.data);
+        if (bytes.length === 0) {
+            throw new context.CancelError('Latchshot returned an empty artifact.');
+        }
+        if (bytes.length > MAX_FILE_BYTES) {
+            throw new context.CancelError('Latchshot artifact exceeded the 15 MB connector limit.');
+        }
+
+        const extension = format === 'jpeg' ? 'jpg' : format;
+        const filename = `latchshot-${Date.now()}.${extension}`;
+        const file = await context.saveFileStream(filename, bytes);
+
+        return context.sendJson({
+            fileId: file.fileId,
+            filename,
+            contentType,
+            fileSize: bytes.length,
+            renderMs: lib.optionalIntegerHeader(response.headers, 'x-latchshot-render-ms'),
+            quotaRemaining: lib.optionalIntegerHeader(response.headers, 'x-quota-remaining')
+        }, 'out');
+    }
+};

--- a/src/appmixer/latchshot/core/RenderPage/component.json
+++ b/src/appmixer/latchshot/core/RenderPage/component.json
@@ -1,0 +1,337 @@
+{
+    "name": "appmixer.latchshot.core.RenderPage",
+    "author": "Latchshot <andy@osmosis.ai>",
+    "description": "Capture a PNG, JPEG, or PDF of a public HTTP(S) page and store the direct response bytes as an Appmixer file. Private pages, cookies, custom headers, scripts, selectors, proxies, and interactions are not supported.",
+    "version": "1.0.0",
+    "private": false,
+    "auth": {
+        "service": "appmixer:latchshot"
+    },
+    "quota": {
+        "manager": "appmixer:latchshot",
+        "resources": "requests",
+        "scope": {
+            "userId": "{{userId}}"
+        }
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": [
+                            "png",
+                            "jpeg",
+                            "pdf"
+                        ]
+                    },
+                    "width": {
+                        "type": "integer",
+                        "minimum": 320,
+                        "maximum": 2560
+                    },
+                    "height": {
+                        "type": "integer",
+                        "minimum": 240,
+                        "maximum": 1440
+                    },
+                    "scale": {
+                        "type": "integer",
+                        "enum": [
+                            1,
+                            2
+                        ]
+                    },
+                    "quality": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100
+                    },
+                    "fullPage": {
+                        "type": "boolean"
+                    },
+                    "waitUntil": {
+                        "type": "string",
+                        "enum": [
+                            "domcontentloaded",
+                            "load",
+                            "networkidle"
+                        ]
+                    },
+                    "delay": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 3000
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "minimum": 3000,
+                        "maximum": 30000
+                    },
+                    "darkMode": {
+                        "type": "boolean"
+                    },
+                    "reducedMotion": {
+                        "type": "boolean"
+                    },
+                    "blockAds": {
+                        "type": "boolean"
+                    },
+                    "blockTrackers": {
+                        "type": "boolean"
+                    },
+                    "blockChats": {
+                        "type": "boolean"
+                    },
+                    "hideCookieBanners": {
+                        "type": "boolean"
+                    },
+                    "hidePopups": {
+                        "type": "boolean"
+                    },
+                    "paper": {
+                        "type": "string",
+                        "enum": [
+                            "A4",
+                            "Letter",
+                            "Legal"
+                        ]
+                    },
+                    "landscape": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "url"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "url": {
+                        "type": "text",
+                        "label": "Public Page URL",
+                        "index": 1,
+                        "tooltip": "Public HTTP or HTTPS URL on port 80 or 443. Do not send private, signed, credential-bearing, or customer-only URLs."
+                    },
+                    "format": {
+                        "type": "select",
+                        "label": "Format",
+                        "index": 2,
+                        "defaultValue": "png",
+                        "options": [
+                            {
+                                "label": "PNG",
+                                "value": "png"
+                            },
+                            {
+                                "label": "JPEG",
+                                "value": "jpeg"
+                            },
+                            {
+                                "label": "PDF",
+                                "value": "pdf"
+                            }
+                        ]
+                    },
+                    "width": {
+                        "type": "number",
+                        "label": "Viewport Width",
+                        "index": 3,
+                        "defaultValue": 1440,
+                        "tooltip": "Viewport width from 320 to 2560 CSS pixels."
+                    },
+                    "height": {
+                        "type": "number",
+                        "label": "Viewport Height",
+                        "index": 4,
+                        "defaultValue": 900,
+                        "tooltip": "Viewport height from 240 to 1440 CSS pixels."
+                    },
+                    "scale": {
+                        "type": "select",
+                        "label": "Device Scale",
+                        "index": 5,
+                        "defaultValue": 1,
+                        "options": [
+                            {
+                                "label": "1x",
+                                "value": 1
+                            },
+                            {
+                                "label": "2x",
+                                "value": 2
+                            }
+                        ]
+                    },
+                    "quality": {
+                        "type": "number",
+                        "label": "JPEG Quality",
+                        "index": 6,
+                        "defaultValue": 85,
+                        "tooltip": "JPEG encoding quality from 1 to 100. Ignored for PNG and PDF."
+                    },
+                    "fullPage": {
+                        "type": "toggle",
+                        "label": "Full Page",
+                        "index": 7,
+                        "defaultValue": false,
+                        "tooltip": "Capture the bounded full document height for PNG or JPEG output."
+                    },
+                    "waitUntil": {
+                        "type": "select",
+                        "label": "Wait Until",
+                        "index": 8,
+                        "defaultValue": "domcontentloaded",
+                        "options": [
+                            {
+                                "label": "DOM Content Loaded",
+                                "value": "domcontentloaded"
+                            },
+                            {
+                                "label": "Load",
+                                "value": "load"
+                            },
+                            {
+                                "label": "Network Idle",
+                                "value": "networkidle"
+                            }
+                        ]
+                    },
+                    "delay": {
+                        "type": "number",
+                        "label": "Extra Delay (ms)",
+                        "index": 9,
+                        "defaultValue": 0,
+                        "tooltip": "Extra wait from 0 to 3000 milliseconds after page readiness."
+                    },
+                    "timeout": {
+                        "type": "number",
+                        "label": "Navigation Timeout (ms)",
+                        "index": 10,
+                        "defaultValue": 15000,
+                        "tooltip": "Navigation timeout from 3000 to 30000 milliseconds."
+                    },
+                    "darkMode": {
+                        "type": "toggle",
+                        "label": "Dark Mode",
+                        "index": 11,
+                        "defaultValue": false
+                    },
+                    "reducedMotion": {
+                        "type": "toggle",
+                        "label": "Reduced Motion",
+                        "index": 12,
+                        "defaultValue": true
+                    },
+                    "blockAds": {
+                        "type": "toggle",
+                        "label": "Block Known Ad Hosts",
+                        "index": 13,
+                        "defaultValue": false
+                    },
+                    "blockTrackers": {
+                        "type": "toggle",
+                        "label": "Block Known Tracker Hosts",
+                        "index": 14,
+                        "defaultValue": false
+                    },
+                    "blockChats": {
+                        "type": "toggle",
+                        "label": "Block Known Chat Widgets",
+                        "index": 15,
+                        "defaultValue": false
+                    },
+                    "hideCookieBanners": {
+                        "type": "toggle",
+                        "label": "Hide Common Cookie Banners",
+                        "index": 16,
+                        "defaultValue": false,
+                        "tooltip": "Best-effort hiding only. Latchshot does not click consent or set consent state."
+                    },
+                    "hidePopups": {
+                        "type": "toggle",
+                        "label": "Hide Common Signup Popups",
+                        "index": 17,
+                        "defaultValue": false,
+                        "tooltip": "Best-effort hiding of common newsletter, signup, and discount overlays without interaction."
+                    },
+                    "paper": {
+                        "type": "select",
+                        "label": "PDF Paper",
+                        "index": 18,
+                        "defaultValue": "A4",
+                        "options": [
+                            {
+                                "label": "A4",
+                                "value": "A4"
+                            },
+                            {
+                                "label": "Letter",
+                                "value": "Letter"
+                            },
+                            {
+                                "label": "Legal",
+                                "value": "Legal"
+                            }
+                        ]
+                    },
+                    "landscape": {
+                        "type": "toggle",
+                        "label": "PDF Landscape",
+                        "index": 19,
+                        "defaultValue": false
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "fileId": {
+                        "type": "string",
+                        "format": "appmixer-file-id",
+                        "title": "Appmixer File ID",
+                        "example": "64f6f1f9193228000754082f"
+                    },
+                    "filename": {
+                        "type": "string",
+                        "title": "File Name",
+                        "example": "latchshot-1784548800000.png"
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "title": "Content Type",
+                        "example": "image/png"
+                    },
+                    "fileSize": {
+                        "type": "integer",
+                        "title": "File Size (bytes)",
+                        "example": 45231
+                    },
+                    "renderMs": {
+                        "type": "integer",
+                        "title": "Render Time (ms)",
+                        "example": 834
+                    },
+                    "quotaRemaining": {
+                        "type": "integer",
+                        "title": "Monthly Successful Renders Remaining",
+                        "example": 99
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTIiIGZpbGw9IiMxNTVmNzgiLz4KICA8cGF0aCBkPSJNMjEgMTVoLTd2MzRoN000MyAxNWg3djM0aC03IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNiZWU5NDQiLz4KPC9zdmc+Cg=="
+}

--- a/src/appmixer/latchshot/lib.js
+++ b/src/appmixer/latchshot/lib.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const BASE_URL = 'https://latchshot.fly.dev';
+
+module.exports = {
+
+    BASE_URL,
+
+    authHeaders(context) {
+
+        return {
+            Authorization: `Bearer ${context.auth.apiKey}`
+        };
+    },
+
+    apiUrl(value, context) {
+
+        let url;
+        try {
+            url = new URL(value, BASE_URL);
+        } catch (error) {
+            throw new context.CancelError('API Endpoint URL is invalid!');
+        }
+
+        if (url.origin !== BASE_URL || url.username || url.password) {
+            throw new context.CancelError('API Endpoint URL must use https://latchshot.fly.dev.');
+        }
+
+        url.hash = '';
+        return url.toString();
+    },
+
+    optionalIntegerHeader(headers, name) {
+
+        const value = headers?.[name];
+        if (value === undefined || value === null || !/^\d+$/.test(String(value))) {
+            return undefined;
+        }
+        return Number(value);
+    }
+};

--- a/src/appmixer/latchshot/quota.js
+++ b/src/appmixer/latchshot/quota.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+    rules: [
+        {
+            limit: 120,
+            window: 1000 * 60,
+            throttling: 'window-sliding',
+            queueing: 'fifo',
+            resource: 'requests',
+            scope: 'userId'
+        }
+    ]
+};

--- a/src/appmixer/latchshot/service.json
+++ b/src/appmixer/latchshot/service.json
@@ -1,0 +1,8 @@
+{
+    "name": "appmixer.latchshot",
+    "label": "Latchshot",
+    "category": "applications",
+    "description": "Capture guarded screenshots and PDFs of public web pages and store the returned artifact as an Appmixer file.",
+    "version": "1.0.0",
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTIiIGZpbGw9IiMxNTVmNzgiLz4KICA8cGF0aCBkPSJNMjEgMTVoLTd2MzRoN000MyAxNWg3djM0aC03IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNSIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNiZWU5NDQiLz4KPC9zdmc+Cg=="
+}


### PR DESCRIPTION
## Summary

- add authenticated Render Page, Get Usage, and fixed-origin Make API Call components
- store direct PNG, JPEG, and PDF response bytes through Appmixer file storage
- validate media type, enforce a 15 MB artifact limit, and expose render/quota diagnostics
- document the public-page boundary, Appmixer retention boundary, and unsupported private browser automation

## Disclosure and commercial boundary

I maintain Latchshot. It is an independent external service and is not affiliated with or endorsed by Appmixer.

The connector contains no checkout or payment action. The recurring Free plan is available without a card, and higher-plan or implementation links remain owner-managed. The API key is stored only through Appmixer connector authentication.

## Validation

- 7 focused unit tests pass
- strict changed-file connector validation passes with 0 failures and 0 warnings
- ESLint passes
- JavaScript syntax and JSON parsing checks pass
- staged diff and secret-pattern checks pass