### PR TITLE
ai/openai AIAgent: fix null tool-result content crashing OpenAI call

### DIFF
--- a/src/appmixer/ai/openai/AIAgent/AIAgent.js
+++ b/src/appmixer/ai/openai/AIAgent/AIAgent.js
@@ -461,10 +461,21 @@ module.exports = {
 
                 const outputs = await this.callTools(context, message.tool_calls);
                 (outputs || []).forEach((output) => {
+                    // OpenAI requires 'content' to be a string. A tool chain may
+                    // produce no output (nothing mapped to ToolOutput's 'output'
+                    // field), in which case output.output is null/undefined and
+                    // OpenAI rejects the request with
+                    // "Invalid value for 'content': expected a string, got null.".
+                    let content = output.output;
+                    if (content === null || content === undefined) {
+                        content = '';
+                    } else if (typeof content !== 'string') {
+                        content = JSON.stringify(content);
+                    }
                     messages.push({
                         role: 'tool',
                         tool_call_id: output.tool_call_id,
-                        content: output.output
+                        content
                     });
                 });
 

--- a/src/appmixer/ai/openai/bundle.json
+++ b/src/appmixer/ai/openai/bundle.json
@@ -1,7 +1,7 @@
 {
     "name": "appmixer.ai.openai",
     "engine": ">=6.4",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "changelog": {
         "1.0.0": [
             "First version."
@@ -59,6 +59,9 @@
         ],
         "1.4.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the OpenAI API."
+        ],
+        "1.4.1": [
+            "AI Agent: fixed OpenAI API error \"Invalid value for 'content': expected a string, got null.\" that occurred when a tool chain produced no output. Tool results with null/undefined output are now coerced to a string before being sent to the model."
         ]
     }
 }


### PR DESCRIPTION
## Problem

Calling the **OpenAI AI Agent** component fails with:

```
400 Invalid value for 'content': expected a string, got null.
  param: messages.[6].content
```

## Root cause

When a tool chain connected to the agent's `tools` port produces **no output** (nothing mapped to `ToolOutput`'s `output` field), `ToolOutput.js` stores `{ output: undefined/null }`. In `AIAgent.agent()` that value was pushed straight into a `role: 'tool'` message as its `content`. OpenAI requires `content` to be a string and rejects `null` — the index (`messages.[6]`) is just the position of the offending tool-result message in a multi-turn tool conversation.

## Fix

Coerce tool-result content to a string before adding it to the messages array:
- `null` / `undefined` → `''`
- non-string (object/array/number/bool) → `JSON.stringify(...)`
- string → unchanged

Also covers the MCP edge case where `JSON.stringify(undefined)` returns `undefined`.

Bumped bundle to **1.4.1** with a changelog entry.

## Testing

- `node --check` passes on the edited file.
- Standalone assertion test covers all coercion cases (null, undefined, string, number, object, array, bool) — every result is a string.
- Existing `AIAgent.test.js` only exercises `mcpCallTool`/`isMCPserver`; the changed path is unaffected. (The connector's `openai` dependency is installed per-connector at build time, so the full unit-test runner can't load the module in a plain checkout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)