### PR TITLE
quickbooks(minor): rewrite triggers for AuthHub compatibility (listener-based routing)

### DIFF
--- a/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
+++ b/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
@@ -8,43 +8,17 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
-        const realmId = context.profileInfo.companyId;
-        await context.log({ step: 'Registering listener', eventName, realmId });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        try {
-            await context.addListener(eventName, { realmId });
-        } catch (error) {
-            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
-            await context.log({ step: 'addListener failed', eventName, error: error.message });
-        }
-        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
-        // listener, so register through the plugin route which writes the registration
-        // itself. Remove once the engine persists listeners. See routes.js.
-        // The public API origin must come from the component (getWebhookUrl) — the plugin
-        // route sees only the internal hostname when called through callAppmixer.
-        const apiOrigin = new URL(context.getWebhookUrl()).origin;
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners',
-            method: 'POST',
-            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
-        });
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
         await context.log({ step: 'Unregistering listener', eventName });
-        try {
-            await context.removeListener(eventName);
-        } catch (error) {
-            await context.log({ step: 'removeListener failed', eventName, error: error.message });
-        }
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
-            method: 'POST',
-            body: { eventName, flowId: context.flowId, componentId: context.componentId }
-        });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
+++ b/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
@@ -7,20 +7,18 @@ module.exports = {
 
     start: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Create:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = `${ENTITY_NAME}.Create`;
+        await context.log({ step: 'Registering listener', eventName });
+        // Register a listener so webhook events received via ../../routes.js can be routed
+        // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Create:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Unregistering webhook', webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = `${ENTITY_NAME}.Create`;
+        await context.log({ step: 'Unregistering listener', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
+++ b/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
@@ -8,17 +8,43 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
-        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
+        const realmId = context.profileInfo.companyId;
+        await context.log({ step: 'Registering listener', eventName, realmId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
+        try {
+            await context.addListener(eventName, { realmId });
+        } catch (error) {
+            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
+            await context.log({ step: 'addListener failed', eventName, error: error.message });
+        }
+        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
+        // listener, so register through the plugin route which writes the registration
+        // itself. Remove once the engine persists listeners. See routes.js.
+        // The public API origin must come from the component (getWebhookUrl) — the plugin
+        // route sees only the internal hostname when called through callAppmixer.
+        const apiOrigin = new URL(context.getWebhookUrl()).origin;
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners',
+            method: 'POST',
+            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
+        });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
         await context.log({ step: 'Unregistering listener', eventName });
-        return context.removeListener(eventName);
+        try {
+            await context.removeListener(eventName);
+        } catch (error) {
+            await context.log({ step: 'removeListener failed', eventName, error: error.message });
+        }
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
+            method: 'POST',
+            body: { eventName, flowId: context.flowId, componentId: context.componentId }
+        });
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
+++ b/src/appmixer/quickbooks/accounting/NewCustomer/NewCustomer.js
@@ -8,7 +8,7 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
-        await context.log({ step: 'Registering listener', eventName });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
         return context.addListener(eventName, { realmId: context.profileInfo.companyId });

--- a/src/appmixer/quickbooks/accounting/NewCustomer/component.json
+++ b/src/appmixer/quickbooks/accounting/NewCustomer/component.json
@@ -11,14 +11,284 @@
     "outPorts": [
         {
             "name": "out",
-            "source": {
-                "url": "/component/appmixer/quickbooks/accounting/ListCustomers?outPort=out",
-                "data": {
-                    "properties": {
-                        "generateOutputPortOptions": true
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "Id": {
+                        "type": "string",
+                        "title": "Id",
+                        "example": "80"
                     },
-                    "messages": {
-                        "in/outputType": "item"
+                    "SyncToken": {
+                        "type": "string",
+                        "title": "SyncToken",
+                        "example": "0"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "title": "domain",
+                        "example": "QBO"
+                    },
+                    "sparse": {
+                        "type": "boolean",
+                        "title": "sparse",
+                        "example": false
+                    },
+                    "DisplayName": {
+                        "type": "string",
+                        "title": "DisplayName",
+                        "example": "E2E QB Customer 1786347955"
+                    },
+                    "GivenName": {
+                        "type": "string",
+                        "title": "GivenName",
+                        "example": "E2E"
+                    },
+                    "MiddleName": {
+                        "type": "string",
+                        "title": "MiddleName",
+                        "example": "B."
+                    },
+                    "FamilyName": {
+                        "type": "string",
+                        "title": "FamilyName",
+                        "example": "Tester"
+                    },
+                    "FullyQualifiedName": {
+                        "type": "string",
+                        "title": "FullyQualifiedName",
+                        "example": "E2E QB Customer 1786347955"
+                    },
+                    "CompanyName": {
+                        "type": "string",
+                        "title": "CompanyName",
+                        "example": "E2E Test Co"
+                    },
+                    "PrintOnCheckName": {
+                        "type": "string",
+                        "title": "PrintOnCheckName",
+                        "example": "E2E Test Co"
+                    },
+                    "Active": {
+                        "type": "boolean",
+                        "title": "Active",
+                        "example": true
+                    },
+                    "Taxable": {
+                        "type": "boolean",
+                        "title": "Taxable",
+                        "example": true
+                    },
+                    "Job": {
+                        "type": "boolean",
+                        "title": "Job",
+                        "example": false
+                    },
+                    "BillWithParent": {
+                        "type": "boolean",
+                        "title": "BillWithParent",
+                        "example": false
+                    },
+                    "Balance": {
+                        "type": "number",
+                        "title": "Balance",
+                        "example": 0
+                    },
+                    "BalanceWithJobs": {
+                        "type": "number",
+                        "title": "BalanceWithJobs",
+                        "example": 0
+                    },
+                    "Notes": {
+                        "type": "string",
+                        "title": "Notes",
+                        "example": "Preferred customer"
+                    },
+                    "PreferredDeliveryMethod": {
+                        "type": "string",
+                        "title": "PreferredDeliveryMethod",
+                        "example": "Print"
+                    },
+                    "DefaultTaxCodeRef": {
+                        "type": "object",
+                        "title": "DefaultTaxCodeRef",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "2"
+                            }
+                        }
+                    },
+                    "PrimaryEmailAddr": {
+                        "type": "object",
+                        "title": "PrimaryEmailAddr",
+                        "properties": {
+                            "Address": {
+                                "type": "string",
+                                "title": "Address",
+                                "example": "e2e-customer@appmixer-test.com"
+                            }
+                        }
+                    },
+                    "PrimaryPhone": {
+                        "type": "object",
+                        "title": "PrimaryPhone",
+                        "properties": {
+                            "FreeFormNumber": {
+                                "type": "string",
+                                "title": "FreeFormNumber",
+                                "example": "(555) 555-5555"
+                            }
+                        }
+                    },
+                    "MetaData": {
+                        "type": "object",
+                        "title": "MetaData",
+                        "properties": {
+                            "CreateTime": {
+                                "type": "string",
+                                "title": "CreateTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            },
+                            "LastUpdatedTime": {
+                                "type": "string",
+                                "title": "LastUpdatedTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            }
+                        }
+                    },
+                    "BillAddr": {
+                        "type": "object",
+                        "title": "BillAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
+                    },
+                    "ShipAddr": {
+                        "type": "object",
+                        "title": "ShipAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
                     }
                 }
             }

--- a/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
@@ -8,43 +8,17 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
-        const realmId = context.profileInfo.companyId;
-        await context.log({ step: 'Registering listener', eventName, realmId });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        try {
-            await context.addListener(eventName, { realmId });
-        } catch (error) {
-            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
-            await context.log({ step: 'addListener failed', eventName, error: error.message });
-        }
-        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
-        // listener, so register through the plugin route which writes the registration
-        // itself. Remove once the engine persists listeners. See routes.js.
-        // The public API origin must come from the component (getWebhookUrl) — the plugin
-        // route sees only the internal hostname when called through callAppmixer.
-        const apiOrigin = new URL(context.getWebhookUrl()).origin;
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners',
-            method: 'POST',
-            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
-        });
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
         await context.log({ step: 'Unregistering listener', eventName });
-        try {
-            await context.removeListener(eventName);
-        } catch (error) {
-            await context.log({ step: 'removeListener failed', eventName, error: error.message });
-        }
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
-            method: 'POST',
-            body: { eventName, flowId: context.flowId, componentId: context.componentId }
-        });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
@@ -7,20 +7,18 @@ module.exports = {
 
     start: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Create:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = `${ENTITY_NAME}.Create`;
+        await context.log({ step: 'Registering listener', eventName });
+        // Register a listener so webhook events received via ../../routes.js can be routed
+        // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Create:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Unregistering webhook', webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = `${ENTITY_NAME}.Create`;
+        await context.log({ step: 'Unregistering listener', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
@@ -8,17 +8,43 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
-        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
+        const realmId = context.profileInfo.companyId;
+        await context.log({ step: 'Registering listener', eventName, realmId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
+        try {
+            await context.addListener(eventName, { realmId });
+        } catch (error) {
+            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
+            await context.log({ step: 'addListener failed', eventName, error: error.message });
+        }
+        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
+        // listener, so register through the plugin route which writes the registration
+        // itself. Remove once the engine persists listeners. See routes.js.
+        // The public API origin must come from the component (getWebhookUrl) — the plugin
+        // route sees only the internal hostname when called through callAppmixer.
+        const apiOrigin = new URL(context.getWebhookUrl()).origin;
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners',
+            method: 'POST',
+            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
+        });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
         await context.log({ step: 'Unregistering listener', eventName });
-        return context.removeListener(eventName);
+        try {
+            await context.removeListener(eventName);
+        } catch (error) {
+            await context.log({ step: 'removeListener failed', eventName, error: error.message });
+        }
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
+            method: 'POST',
+            body: { eventName, flowId: context.flowId, componentId: context.componentId }
+        });
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
+++ b/src/appmixer/quickbooks/accounting/NewInvoice/NewInvoice.js
@@ -8,7 +8,7 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Create`;
-        await context.log({ step: 'Registering listener', eventName });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
         return context.addListener(eventName, { realmId: context.profileInfo.companyId });

--- a/src/appmixer/quickbooks/accounting/NewInvoice/component.json
+++ b/src/appmixer/quickbooks/accounting/NewInvoice/component.json
@@ -12,216 +12,367 @@
     "outPorts": [
         {
             "name": "out",
-            "options": [
-                {
-                    "label": "Txn Date",
-                    "value": "TxnDate"
-                },
-                {
-                    "label": "Domain",
-                    "value": "domain"
-                },
-                {
-                    "label": "Print Status",
-                    "value": "PrintStatus"
-                },
-                {
-                    "label": "Sales Term Ref Value",
-                    "value": "SalesTermRef.value"
-                },
-                {
-                    "label": "Total Amt",
-                    "value": "TotalAmt"
-                },
-                {
-                    "label": "Line",
-                    "value": "Line"
-                },
-                {
-                    "label": "Due Date",
-                    "value": "DueDate"
-                },
-                {
-                    "label": "Apply Tax After Discount",
-                    "value": "ApplyTaxAfterDiscount"
-                },
-                {
-                    "label": "Doc Number",
-                    "value": "DocNumber"
-                },
-                {
-                    "label": "Sparse",
-                    "value": "sparse"
-                },
-                {
-                    "label": "Customer Memo Value",
-                    "value": "CustomerMemo.value"
-                },
-                {
-                    "label": "Deposit",
-                    "value": "Deposit"
-                },
-                {
-                    "label": "Balance",
-                    "value": "Balance"
-                },
-                {
-                    "label": "Customer Ref Name",
-                    "value": "CustomerRef.name"
-                },
-                {
-                    "label": "Customer Ref Value",
-                    "value": "CustomerRef.value"
-                },
-                {
-                    "label": "Txn Tax Detail Txn Tax Code Ref Value",
-                    "value": "TxnTaxDetail.TxnTaxCodeRef.value"
-                },
-                {
-                    "label": "Txn Tax Detail Total Tax",
-                    "value": "TxnTaxDetail.TotalTax"
-                },
-                {
-                    "label": "Txn Tax Detail Tax Line",
-                    "value": "TxnTaxDetail.TaxLine"
-                },
-                {
-                    "label": "Sync Token",
-                    "value": "SyncToken"
-                },
-                {
-                    "label": "Linked Txn",
-                    "value": "LinkedTxn"
-                },
-                {
-                    "label": "Bill Email Address",
-                    "value": "BillEmail.Address"
-                },
-                {
-                    "label": "Ship Addr City",
-                    "value": "ShipAddr.City"
-                },
-                {
-                    "label": "Ship Addr Line 5",
-                    "value": "ShipAddr.Line5"
-                },
-                {
-                    "label": "Ship Addr Line 4",
-                    "value": "ShipAddr.Line4"
-                },
-                {
-                    "label": "Ship Addr Line 3",
-                    "value": "ShipAddr.Line3"
-                },
-                {
-                    "label": "Ship Addr Line 2",
-                    "value": "ShipAddr.Line2"
-                },
-                {
-                    "label": "Ship Addr Line 1",
-                    "value": "ShipAddr.Line1"
-                },
-                {
-                    "label": "Ship Addr Postal Code",
-                    "value": "ShipAddr.PostalCode"
-                },
-                {
-                    "label": "Ship Addr Lat",
-                    "value": "ShipAddr.Lat"
-                },
-                {
-                    "label": "Ship Addr Long",
-                    "value": "ShipAddr.Long"
-                },
-                {
-                    "label": "Ship Addr Country Sub Division Code",
-                    "value": "ShipAddr.CountrySubDivisionCode"
-                },
-                {
-                    "label": "Ship Addr Country",
-                    "value": "ShipAddr.Country"
-                },
-                {
-                    "label": "Ship Addr Id",
-                    "value": "ShipAddr.Id"
-                },
-                {
-                    "label": "Email Status",
-                    "value": "EmailStatus"
-                },
-                {
-                    "label": "Bill Addr Line 5",
-                    "value": "BillAddr.Line5"
-                },
-                {
-                    "label": "Bill Addr Line 4",
-                    "value": "BillAddr.Line4"
-                },
-                {
-                    "label": "Bill Addr Line 3",
-                    "value": "BillAddr.Line3"
-                },
-                {
-                    "label": "Bill Addr Line 2",
-                    "value": "BillAddr.Line2"
-                },
-                {
-                    "label": "Bill Addr Line 1",
-                    "value": "BillAddr.Line1"
-                },
-                {
-                    "label": "Bill Addr Long",
-                    "value": "BillAddr.Long"
-                },
-                {
-                    "label": "Bill Addr Lat",
-                    "value": "BillAddr.Lat"
-                },
-                {
-                    "label": "Bill Addr Id",
-                    "value": "BillAddr.Id"
-                },
-                {
-                    "label": "Bill Addr City",
-                    "value": "BillAddr.City"
-                },
-                {
-                    "label": "Bill Addr Postal Code",
-                    "value": "BillAddr.PostalCode"
-                },
-                {
-                    "label": "Bill Addr Lat",
-                    "value": "BillAddr.Lat"
-                },
-                {
-                    "label": "Bill Addr Long",
-                    "value": "BillAddr.Long"
-                },
-                {
-                    "label": "Bill Addr Country Sub Division Code",
-                    "value": "BillAddr.CountrySubDivisionCode"
-                },
-                {
-                    "label": "Bill Addr Country",
-                    "value": "BillAddr.Country"
-                },
-                {
-                    "label": "Meta Data Create Time",
-                    "value": "MetaData.CreateTime"
-                },
-                {
-                    "label": "Meta Data Last Updated Time",
-                    "value": "MetaData.LastUpdatedTime"
-                },
-                {
-                    "label": "Custom Field",
-                    "value": "CustomField"
-                },
-                {
-                    "label": "Id",
-                    "value": "Id"
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "Id": {
+                        "type": "string",
+                        "title": "Id",
+                        "example": "199"
+                    },
+                    "SyncToken": {
+                        "type": "string",
+                        "title": "SyncToken",
+                        "example": "0"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "title": "domain",
+                        "example": "QBO"
+                    },
+                    "sparse": {
+                        "type": "boolean",
+                        "title": "sparse",
+                        "example": false
+                    },
+                    "DocNumber": {
+                        "type": "string",
+                        "title": "DocNumber",
+                        "example": "1045"
+                    },
+                    "TxnDate": {
+                        "type": "string",
+                        "title": "TxnDate",
+                        "example": "2026-08-10"
+                    },
+                    "DueDate": {
+                        "type": "string",
+                        "title": "DueDate",
+                        "example": "2026-09-09"
+                    },
+                    "TotalAmt": {
+                        "type": "number",
+                        "title": "TotalAmt",
+                        "example": 50
+                    },
+                    "Balance": {
+                        "type": "number",
+                        "title": "Balance",
+                        "example": 50
+                    },
+                    "Deposit": {
+                        "type": "number",
+                        "title": "Deposit",
+                        "example": 0
+                    },
+                    "ApplyTaxAfterDiscount": {
+                        "type": "boolean",
+                        "title": "ApplyTaxAfterDiscount",
+                        "example": false
+                    },
+                    "PrintStatus": {
+                        "type": "string",
+                        "title": "PrintStatus",
+                        "example": "NeedToPrint"
+                    },
+                    "EmailStatus": {
+                        "type": "string",
+                        "title": "EmailStatus",
+                        "example": "NotSet"
+                    },
+                    "CustomerRef": {
+                        "type": "object",
+                        "title": "CustomerRef",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "82"
+                            },
+                            "name": {
+                                "type": "string",
+                                "title": "name",
+                                "example": "E2E QB Customer 1786348300"
+                            }
+                        }
+                    },
+                    "CustomerMemo": {
+                        "type": "object",
+                        "title": "CustomerMemo",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "Thank you for your business!"
+                            }
+                        }
+                    },
+                    "SalesTermRef": {
+                        "type": "object",
+                        "title": "SalesTermRef",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "3"
+                            }
+                        }
+                    },
+                    "BillEmail": {
+                        "type": "object",
+                        "title": "BillEmail",
+                        "properties": {
+                            "Address": {
+                                "type": "string",
+                                "title": "Address",
+                                "example": "e2e-customer@appmixer-test.com"
+                            }
+                        }
+                    },
+                    "TxnTaxDetail": {
+                        "type": "object",
+                        "title": "TxnTaxDetail",
+                        "properties": {
+                            "TotalTax": {
+                                "type": "number",
+                                "title": "TotalTax",
+                                "example": 0
+                            },
+                            "TxnTaxCodeRef": {
+                                "type": "object",
+                                "title": "TxnTaxCodeRef",
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "title": "value",
+                                        "example": "2"
+                                    }
+                                }
+                            },
+                            "TaxLine": {
+                                "type": "array",
+                                "title": "TaxLine",
+                                "items": {
+                                    "type": "object"
+                                },
+                                "example": [
+                                    {
+                                        "Amount": 0,
+                                        "DetailType": "TaxLineDetail",
+                                        "TaxLineDetail": {
+                                            "TaxRateRef": {
+                                                "value": "1"
+                                            },
+                                            "PercentBased": true,
+                                            "TaxPercent": 0,
+                                            "NetAmountTaxable": 50
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Line": {
+                        "type": "array",
+                        "title": "Line",
+                        "items": {
+                            "type": "object"
+                        },
+                        "example": [
+                            {
+                                "Id": "1",
+                                "LineNum": 1,
+                                "Description": "E2E service",
+                                "Amount": 50,
+                                "DetailType": "SalesItemLineDetail",
+                                "SalesItemLineDetail": {
+                                    "Qty": 1,
+                                    "ItemRef": {
+                                        "value": "1",
+                                        "name": "Services"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "LinkedTxn": {
+                        "type": "array",
+                        "title": "LinkedTxn",
+                        "items": {
+                            "type": "object"
+                        },
+                        "example": [
+                            {
+                                "TxnId": "145",
+                                "TxnType": "Payment"
+                            }
+                        ]
+                    },
+                    "CustomField": {
+                        "type": "array",
+                        "title": "CustomField",
+                        "items": {
+                            "type": "object"
+                        },
+                        "example": [
+                            {
+                                "DefinitionId": "1",
+                                "Name": "Crew #",
+                                "Type": "StringType",
+                                "StringValue": "102"
+                            }
+                        ]
+                    },
+                    "MetaData": {
+                        "type": "object",
+                        "title": "MetaData",
+                        "properties": {
+                            "CreateTime": {
+                                "type": "string",
+                                "title": "CreateTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            },
+                            "LastUpdatedTime": {
+                                "type": "string",
+                                "title": "LastUpdatedTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            }
+                        }
+                    },
+                    "BillAddr": {
+                        "type": "object",
+                        "title": "BillAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
+                    },
+                    "ShipAddr": {
+                        "type": "object",
+                        "title": "ShipAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
+                    }
                 }
-            ]
+            }
         }
     ]
 }

--- a/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
@@ -7,20 +7,18 @@ module.exports = {
 
     start: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Update:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = `${ENTITY_NAME}.Update`;
+        await context.log({ step: 'Registering listener', eventName });
+        // Register a listener so webhook events received via ../../routes.js can be routed
+        // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Update:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Unregistering webhook', webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = `${ENTITY_NAME}.Update`;
+        await context.log({ step: 'Unregistering listener', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
@@ -8,7 +8,7 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
-        await context.log({ step: 'Registering listener', eventName });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
         return context.addListener(eventName, { realmId: context.profileInfo.companyId });

--- a/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
@@ -8,43 +8,17 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
-        const realmId = context.profileInfo.companyId;
-        await context.log({ step: 'Registering listener', eventName, realmId });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        try {
-            await context.addListener(eventName, { realmId });
-        } catch (error) {
-            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
-            await context.log({ step: 'addListener failed', eventName, error: error.message });
-        }
-        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
-        // listener, so register through the plugin route which writes the registration
-        // itself. Remove once the engine persists listeners. See routes.js.
-        // The public API origin must come from the component (getWebhookUrl) — the plugin
-        // route sees only the internal hostname when called through callAppmixer.
-        const apiOrigin = new URL(context.getWebhookUrl()).origin;
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners',
-            method: 'POST',
-            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
-        });
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
         await context.log({ step: 'Unregistering listener', eventName });
-        try {
-            await context.removeListener(eventName);
-        } catch (error) {
-            await context.log({ step: 'removeListener failed', eventName, error: error.message });
-        }
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
-            method: 'POST',
-            body: { eventName, flowId: context.flowId, componentId: context.componentId }
-        });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedCustomer/UpdatedCustomer.js
@@ -8,17 +8,43 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
-        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
+        const realmId = context.profileInfo.companyId;
+        await context.log({ step: 'Registering listener', eventName, realmId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
+        try {
+            await context.addListener(eventName, { realmId });
+        } catch (error) {
+            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
+            await context.log({ step: 'addListener failed', eventName, error: error.message });
+        }
+        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
+        // listener, so register through the plugin route which writes the registration
+        // itself. Remove once the engine persists listeners. See routes.js.
+        // The public API origin must come from the component (getWebhookUrl) — the plugin
+        // route sees only the internal hostname when called through callAppmixer.
+        const apiOrigin = new URL(context.getWebhookUrl()).origin;
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners',
+            method: 'POST',
+            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
+        });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
         await context.log({ step: 'Unregistering listener', eventName });
-        return context.removeListener(eventName);
+        try {
+            await context.removeListener(eventName);
+        } catch (error) {
+            await context.log({ step: 'removeListener failed', eventName, error: error.message });
+        }
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
+            method: 'POST',
+            body: { eventName, flowId: context.flowId, componentId: context.componentId }
+        });
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/UpdatedCustomer/component.json
+++ b/src/appmixer/quickbooks/accounting/UpdatedCustomer/component.json
@@ -11,14 +11,284 @@
     "outPorts": [
         {
             "name": "out",
-            "source": {
-                "url": "/component/appmixer/quickbooks/accounting/ListCustomers?outPort=out",
-                "data": {
-                    "properties": {
-                        "generateOutputPortOptions": true
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "Id": {
+                        "type": "string",
+                        "title": "Id",
+                        "example": "80"
                     },
-                    "messages": {
-                        "in/outputType": "item"
+                    "SyncToken": {
+                        "type": "string",
+                        "title": "SyncToken",
+                        "example": "0"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "title": "domain",
+                        "example": "QBO"
+                    },
+                    "sparse": {
+                        "type": "boolean",
+                        "title": "sparse",
+                        "example": false
+                    },
+                    "DisplayName": {
+                        "type": "string",
+                        "title": "DisplayName",
+                        "example": "E2E QB Customer 1786347955"
+                    },
+                    "GivenName": {
+                        "type": "string",
+                        "title": "GivenName",
+                        "example": "E2E"
+                    },
+                    "MiddleName": {
+                        "type": "string",
+                        "title": "MiddleName",
+                        "example": "B."
+                    },
+                    "FamilyName": {
+                        "type": "string",
+                        "title": "FamilyName",
+                        "example": "Tester"
+                    },
+                    "FullyQualifiedName": {
+                        "type": "string",
+                        "title": "FullyQualifiedName",
+                        "example": "E2E QB Customer 1786347955"
+                    },
+                    "CompanyName": {
+                        "type": "string",
+                        "title": "CompanyName",
+                        "example": "E2E Test Co"
+                    },
+                    "PrintOnCheckName": {
+                        "type": "string",
+                        "title": "PrintOnCheckName",
+                        "example": "E2E Test Co"
+                    },
+                    "Active": {
+                        "type": "boolean",
+                        "title": "Active",
+                        "example": true
+                    },
+                    "Taxable": {
+                        "type": "boolean",
+                        "title": "Taxable",
+                        "example": true
+                    },
+                    "Job": {
+                        "type": "boolean",
+                        "title": "Job",
+                        "example": false
+                    },
+                    "BillWithParent": {
+                        "type": "boolean",
+                        "title": "BillWithParent",
+                        "example": false
+                    },
+                    "Balance": {
+                        "type": "number",
+                        "title": "Balance",
+                        "example": 0
+                    },
+                    "BalanceWithJobs": {
+                        "type": "number",
+                        "title": "BalanceWithJobs",
+                        "example": 0
+                    },
+                    "Notes": {
+                        "type": "string",
+                        "title": "Notes",
+                        "example": "Preferred customer"
+                    },
+                    "PreferredDeliveryMethod": {
+                        "type": "string",
+                        "title": "PreferredDeliveryMethod",
+                        "example": "Print"
+                    },
+                    "DefaultTaxCodeRef": {
+                        "type": "object",
+                        "title": "DefaultTaxCodeRef",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "2"
+                            }
+                        }
+                    },
+                    "PrimaryEmailAddr": {
+                        "type": "object",
+                        "title": "PrimaryEmailAddr",
+                        "properties": {
+                            "Address": {
+                                "type": "string",
+                                "title": "Address",
+                                "example": "e2e-customer@appmixer-test.com"
+                            }
+                        }
+                    },
+                    "PrimaryPhone": {
+                        "type": "object",
+                        "title": "PrimaryPhone",
+                        "properties": {
+                            "FreeFormNumber": {
+                                "type": "string",
+                                "title": "FreeFormNumber",
+                                "example": "(555) 555-5555"
+                            }
+                        }
+                    },
+                    "MetaData": {
+                        "type": "object",
+                        "title": "MetaData",
+                        "properties": {
+                            "CreateTime": {
+                                "type": "string",
+                                "title": "CreateTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            },
+                            "LastUpdatedTime": {
+                                "type": "string",
+                                "title": "LastUpdatedTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            }
+                        }
+                    },
+                    "BillAddr": {
+                        "type": "object",
+                        "title": "BillAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
+                    },
+                    "ShipAddr": {
+                        "type": "object",
+                        "title": "ShipAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
                     }
                 }
             }

--- a/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -7,20 +7,18 @@ module.exports = {
 
     start: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Update:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Registering webhook', webhook });
-        // Subscribe to a static webhook events received via ../../plugin.js.
-        return context.service.stateAddToSet(webhook, { flowId, componentId, webhook });
+        const eventName = `${ENTITY_NAME}.Update`;
+        await context.log({ step: 'Registering listener', eventName });
+        // Register a listener so webhook events received via ../../routes.js can be routed
+        // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
-        const { componentId, flowId } = context;
-        const webhook = `${ENTITY_NAME}.Update:${context.profileInfo.companyId}`;
-        await context.log({ step: 'Unregistering webhook', webhook });
-        // Unsubscribe from a static webhook events received via ../../plugin.js.
-        return context.service.stateRemoveFromSet(webhook, { componentId, flowId });
+        const eventName = `${ENTITY_NAME}.Update`;
+        await context.log({ step: 'Unregistering listener', eventName });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -8,7 +8,7 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
-        await context.log({ step: 'Registering listener', eventName });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
         return context.addListener(eventName, { realmId: context.profileInfo.companyId });

--- a/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -8,43 +8,17 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
-        const realmId = context.profileInfo.companyId;
-        await context.log({ step: 'Registering listener', eventName, realmId });
+        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        try {
-            await context.addListener(eventName, { realmId });
-        } catch (error) {
-            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
-            await context.log({ step: 'addListener failed', eventName, error: error.message });
-        }
-        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
-        // listener, so register through the plugin route which writes the registration
-        // itself. Remove once the engine persists listeners. See routes.js.
-        // The public API origin must come from the component (getWebhookUrl) — the plugin
-        // route sees only the internal hostname when called through callAppmixer.
-        const apiOrigin = new URL(context.getWebhookUrl()).origin;
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners',
-            method: 'POST',
-            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
-        });
+        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
         await context.log({ step: 'Unregistering listener', eventName });
-        try {
-            await context.removeListener(eventName);
-        } catch (error) {
-            await context.log({ step: 'removeListener failed', eventName, error: error.message });
-        }
-        return context.callAppmixer({
-            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
-            method: 'POST',
-            body: { eventName, flowId: context.flowId, componentId: context.componentId }
-        });
+        return context.removeListener(eventName);
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
+++ b/src/appmixer/quickbooks/accounting/UpdatedInvoice/UpdatedInvoice.js
@@ -8,17 +8,43 @@ module.exports = {
     start: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
-        await context.log({ step: 'Registering listener', eventName, realmId: context.profileInfo && context.profileInfo.companyId });
+        const realmId = context.profileInfo.companyId;
+        await context.log({ step: 'Registering listener', eventName, realmId });
         // Register a listener so webhook events received via ../../routes.js can be routed
         // to this component by realmId. This is AuthHub-compatible (shared webhook endpoint).
-        return context.addListener(eventName, { realmId: context.profileInfo.companyId });
+        try {
+            await context.addListener(eventName, { realmId });
+        } catch (error) {
+            // Tolerated: the plugin-route registration below is the effective one (see routes.js).
+            await context.log({ step: 'addListener failed', eventName, error: error.message });
+        }
+        // WORKAROUND (engine 6.6.0): addListener acknowledges but does not persist the
+        // listener, so register through the plugin route which writes the registration
+        // itself. Remove once the engine persists listeners. See routes.js.
+        // The public API origin must come from the component (getWebhookUrl) — the plugin
+        // route sees only the internal hostname when called through callAppmixer.
+        const apiOrigin = new URL(context.getWebhookUrl()).origin;
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners',
+            method: 'POST',
+            body: { eventName, realmId, flowId: context.flowId, componentId: context.componentId, apiOrigin }
+        });
     },
 
     stop: async function(context) {
 
         const eventName = `${ENTITY_NAME}.Update`;
         await context.log({ step: 'Unregistering listener', eventName });
-        return context.removeListener(eventName);
+        try {
+            await context.removeListener(eventName);
+        } catch (error) {
+            await context.log({ step: 'removeListener failed', eventName, error: error.message });
+        }
+        return context.callAppmixer({
+            endPoint: '/plugins/appmixer/quickbooks/listeners/remove',
+            method: 'POST',
+            body: { eventName, flowId: context.flowId, componentId: context.componentId }
+        });
     },
 
     receive: function(context) {

--- a/src/appmixer/quickbooks/accounting/UpdatedInvoice/component.json
+++ b/src/appmixer/quickbooks/accounting/UpdatedInvoice/component.json
@@ -12,216 +12,367 @@
     "outPorts": [
         {
             "name": "out",
-            "options": [
-                {
-                    "label": "Txn Date",
-                    "value": "TxnDate"
-                },
-                {
-                    "label": "Domain",
-                    "value": "domain"
-                },
-                {
-                    "label": "Print Status",
-                    "value": "PrintStatus"
-                },
-                {
-                    "label": "Sales Term Ref Value",
-                    "value": "SalesTermRef.value"
-                },
-                {
-                    "label": "Total Amt",
-                    "value": "TotalAmt"
-                },
-                {
-                    "label": "Line",
-                    "value": "Line"
-                },
-                {
-                    "label": "Due Date",
-                    "value": "DueDate"
-                },
-                {
-                    "label": "Apply Tax After Discount",
-                    "value": "ApplyTaxAfterDiscount"
-                },
-                {
-                    "label": "Doc Number",
-                    "value": "DocNumber"
-                },
-                {
-                    "label": "Sparse",
-                    "value": "sparse"
-                },
-                {
-                    "label": "Customer Memo Value",
-                    "value": "CustomerMemo.value"
-                },
-                {
-                    "label": "Deposit",
-                    "value": "Deposit"
-                },
-                {
-                    "label": "Balance",
-                    "value": "Balance"
-                },
-                {
-                    "label": "Customer Ref Name",
-                    "value": "CustomerRef.name"
-                },
-                {
-                    "label": "Customer Ref Value",
-                    "value": "CustomerRef.value"
-                },
-                {
-                    "label": "Txn Tax Detail Txn Tax Code Ref Value",
-                    "value": "TxnTaxDetail.TxnTaxCodeRef.value"
-                },
-                {
-                    "label": "Txn Tax Detail Total Tax",
-                    "value": "TxnTaxDetail.TotalTax"
-                },
-                {
-                    "label": "Txn Tax Detail Tax Line",
-                    "value": "TxnTaxDetail.TaxLine"
-                },
-                {
-                    "label": "Sync Token",
-                    "value": "SyncToken"
-                },
-                {
-                    "label": "Linked Txn",
-                    "value": "LinkedTxn"
-                },
-                {
-                    "label": "Bill Email Address",
-                    "value": "BillEmail.Address"
-                },
-                {
-                    "label": "Ship Addr City",
-                    "value": "ShipAddr.City"
-                },
-                {
-                    "label": "Ship Addr Line 5",
-                    "value": "ShipAddr.Line5"
-                },
-                {
-                    "label": "Ship Addr Line 4",
-                    "value": "ShipAddr.Line4"
-                },
-                {
-                    "label": "Ship Addr Line 3",
-                    "value": "ShipAddr.Line3"
-                },
-                {
-                    "label": "Ship Addr Line 2",
-                    "value": "ShipAddr.Line2"
-                },
-                {
-                    "label": "Ship Addr Line 1",
-                    "value": "ShipAddr.Line1"
-                },
-                {
-                    "label": "Ship Addr Postal Code",
-                    "value": "ShipAddr.PostalCode"
-                },
-                {
-                    "label": "Ship Addr Lat",
-                    "value": "ShipAddr.Lat"
-                },
-                {
-                    "label": "Ship Addr Long",
-                    "value": "ShipAddr.Long"
-                },
-                {
-                    "label": "Ship Addr Country Sub Division Code",
-                    "value": "ShipAddr.CountrySubDivisionCode"
-                },
-                {
-                    "label": "Ship Addr Country",
-                    "value": "ShipAddr.Country"
-                },
-                {
-                    "label": "Ship Addr Id",
-                    "value": "ShipAddr.Id"
-                },
-                {
-                    "label": "Email Status",
-                    "value": "EmailStatus"
-                },
-                {
-                    "label": "Bill Addr Line 5",
-                    "value": "BillAddr.Line5"
-                },
-                {
-                    "label": "Bill Addr Line 4",
-                    "value": "BillAddr.Line4"
-                },
-                {
-                    "label": "Bill Addr Line 3",
-                    "value": "BillAddr.Line3"
-                },
-                {
-                    "label": "Bill Addr Line 2",
-                    "value": "BillAddr.Line2"
-                },
-                {
-                    "label": "Bill Addr Line 1",
-                    "value": "BillAddr.Line1"
-                },
-                {
-                    "label": "Bill Addr Long",
-                    "value": "BillAddr.Long"
-                },
-                {
-                    "label": "Bill Addr Lat",
-                    "value": "BillAddr.Lat"
-                },
-                {
-                    "label": "Bill Addr Id",
-                    "value": "BillAddr.Id"
-                },
-                {
-                    "label": "Bill Addr City",
-                    "value": "BillAddr.City"
-                },
-                {
-                    "label": "Bill Addr Postal Code",
-                    "value": "BillAddr.PostalCode"
-                },
-                {
-                    "label": "Bill Addr Lat",
-                    "value": "BillAddr.Lat"
-                },
-                {
-                    "label": "Bill Addr Long",
-                    "value": "BillAddr.Long"
-                },
-                {
-                    "label": "Bill Addr Country Sub Division Code",
-                    "value": "BillAddr.CountrySubDivisionCode"
-                },
-                {
-                    "label": "Bill Addr Country",
-                    "value": "BillAddr.Country"
-                },
-                {
-                    "label": "Meta Data Create Time",
-                    "value": "MetaData.CreateTime"
-                },
-                {
-                    "label": "Meta Data Last Updated Time",
-                    "value": "MetaData.LastUpdatedTime"
-                },
-                {
-                    "label": "Custom Field",
-                    "value": "CustomField"
-                },
-                {
-                    "label": "Id",
-                    "value": "Id"
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "Id": {
+                        "type": "string",
+                        "title": "Id",
+                        "example": "199"
+                    },
+                    "SyncToken": {
+                        "type": "string",
+                        "title": "SyncToken",
+                        "example": "0"
+                    },
+                    "domain": {
+                        "type": "string",
+                        "title": "domain",
+                        "example": "QBO"
+                    },
+                    "sparse": {
+                        "type": "boolean",
+                        "title": "sparse",
+                        "example": false
+                    },
+                    "DocNumber": {
+                        "type": "string",
+                        "title": "DocNumber",
+                        "example": "1045"
+                    },
+                    "TxnDate": {
+                        "type": "string",
+                        "title": "TxnDate",
+                        "example": "2026-08-10"
+                    },
+                    "DueDate": {
+                        "type": "string",
+                        "title": "DueDate",
+                        "example": "2026-09-09"
+                    },
+                    "TotalAmt": {
+                        "type": "number",
+                        "title": "TotalAmt",
+                        "example": 50
+                    },
+                    "Balance": {
+                        "type": "number",
+                        "title": "Balance",
+                        "example": 50
+                    },
+                    "Deposit": {
+                        "type": "number",
+                        "title": "Deposit",
+                        "example": 0
+                    },
+                    "ApplyTaxAfterDiscount": {
+                        "type": "boolean",
+                        "title": "ApplyTaxAfterDiscount",
+                        "example": false
+                    },
+                    "PrintStatus": {
+                        "type": "string",
+                        "title": "PrintStatus",
+                        "example": "NeedToPrint"
+                    },
+                    "EmailStatus": {
+                        "type": "string",
+                        "title": "EmailStatus",
+                        "example": "NotSet"
+                    },
+                    "CustomerRef": {
+                        "type": "object",
+                        "title": "CustomerRef",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "82"
+                            },
+                            "name": {
+                                "type": "string",
+                                "title": "name",
+                                "example": "E2E QB Customer 1786348300"
+                            }
+                        }
+                    },
+                    "CustomerMemo": {
+                        "type": "object",
+                        "title": "CustomerMemo",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "Thank you for your business!"
+                            }
+                        }
+                    },
+                    "SalesTermRef": {
+                        "type": "object",
+                        "title": "SalesTermRef",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "title": "value",
+                                "example": "3"
+                            }
+                        }
+                    },
+                    "BillEmail": {
+                        "type": "object",
+                        "title": "BillEmail",
+                        "properties": {
+                            "Address": {
+                                "type": "string",
+                                "title": "Address",
+                                "example": "e2e-customer@appmixer-test.com"
+                            }
+                        }
+                    },
+                    "TxnTaxDetail": {
+                        "type": "object",
+                        "title": "TxnTaxDetail",
+                        "properties": {
+                            "TotalTax": {
+                                "type": "number",
+                                "title": "TotalTax",
+                                "example": 0
+                            },
+                            "TxnTaxCodeRef": {
+                                "type": "object",
+                                "title": "TxnTaxCodeRef",
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "title": "value",
+                                        "example": "2"
+                                    }
+                                }
+                            },
+                            "TaxLine": {
+                                "type": "array",
+                                "title": "TaxLine",
+                                "items": {
+                                    "type": "object"
+                                },
+                                "example": [
+                                    {
+                                        "Amount": 0,
+                                        "DetailType": "TaxLineDetail",
+                                        "TaxLineDetail": {
+                                            "TaxRateRef": {
+                                                "value": "1"
+                                            },
+                                            "PercentBased": true,
+                                            "TaxPercent": 0,
+                                            "NetAmountTaxable": 50
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "Line": {
+                        "type": "array",
+                        "title": "Line",
+                        "items": {
+                            "type": "object"
+                        },
+                        "example": [
+                            {
+                                "Id": "1",
+                                "LineNum": 1,
+                                "Description": "E2E service",
+                                "Amount": 50,
+                                "DetailType": "SalesItemLineDetail",
+                                "SalesItemLineDetail": {
+                                    "Qty": 1,
+                                    "ItemRef": {
+                                        "value": "1",
+                                        "name": "Services"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "LinkedTxn": {
+                        "type": "array",
+                        "title": "LinkedTxn",
+                        "items": {
+                            "type": "object"
+                        },
+                        "example": [
+                            {
+                                "TxnId": "145",
+                                "TxnType": "Payment"
+                            }
+                        ]
+                    },
+                    "CustomField": {
+                        "type": "array",
+                        "title": "CustomField",
+                        "items": {
+                            "type": "object"
+                        },
+                        "example": [
+                            {
+                                "DefinitionId": "1",
+                                "Name": "Crew #",
+                                "Type": "StringType",
+                                "StringValue": "102"
+                            }
+                        ]
+                    },
+                    "MetaData": {
+                        "type": "object",
+                        "title": "MetaData",
+                        "properties": {
+                            "CreateTime": {
+                                "type": "string",
+                                "title": "CreateTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            },
+                            "LastUpdatedTime": {
+                                "type": "string",
+                                "title": "LastUpdatedTime",
+                                "example": "2026-08-10T00:51:40-07:00"
+                            }
+                        }
+                    },
+                    "BillAddr": {
+                        "type": "object",
+                        "title": "BillAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
+                    },
+                    "ShipAddr": {
+                        "type": "object",
+                        "title": "ShipAddr",
+                        "properties": {
+                            "Id": {
+                                "type": "string",
+                                "title": "Id",
+                                "example": "2"
+                            },
+                            "Line1": {
+                                "type": "string",
+                                "title": "Line1",
+                                "example": "123 Main Street"
+                            },
+                            "Line2": {
+                                "type": "string",
+                                "title": "Line2",
+                                "example": "Suite 200"
+                            },
+                            "Line3": {
+                                "type": "string",
+                                "title": "Line3",
+                                "example": ""
+                            },
+                            "Line4": {
+                                "type": "string",
+                                "title": "Line4",
+                                "example": ""
+                            },
+                            "Line5": {
+                                "type": "string",
+                                "title": "Line5",
+                                "example": ""
+                            },
+                            "City": {
+                                "type": "string",
+                                "title": "City",
+                                "example": "Mountain View"
+                            },
+                            "Country": {
+                                "type": "string",
+                                "title": "Country",
+                                "example": "USA"
+                            },
+                            "CountrySubDivisionCode": {
+                                "type": "string",
+                                "title": "CountrySubDivisionCode",
+                                "example": "CA"
+                            },
+                            "PostalCode": {
+                                "type": "string",
+                                "title": "PostalCode",
+                                "example": "94042"
+                            },
+                            "Lat": {
+                                "type": "string",
+                                "title": "Lat",
+                                "example": "37.4442407"
+                            },
+                            "Long": {
+                                "type": "string",
+                                "title": "Long",
+                                "example": "-122.1625017"
+                            }
+                        }
+                    }
                 }
-            ]
+            }
         }
     ]
 }

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newcustomer.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newcustomer.json
@@ -1,0 +1,269 @@
+{
+    "name": "E2E QuickBooks NewCustomer trigger",
+    "type": "automation",
+    "notes": {},
+    "flow": {
+        "4caf9385-d5f5-4204-8a5c-be256e932345": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "config": {}
+        },
+        "f841ef20-a6aa-4c77-a1c9-349133c4dcbf": {
+            "type": "appmixer.quickbooks.accounting.CreateCustomer",
+            "x": 320,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "4caf9385-d5f5-4204-8a5c-be256e932345": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4caf9385-d5f5-4204-8a5c-be256e932345": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "displayName": {
+                                        "v-cust-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_now"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "givenName": {},
+                                    "familyName": {},
+                                    "companyName": {},
+                                    "primaryEmailAddrAddress": {},
+                                    "printOnCheckName": {}
+                                },
+                                "lambda": {
+                                    "displayName": "E2E QB Customer {{{v-cust-ts}}}",
+                                    "givenName": "E2E",
+                                    "familyName": "Tester",
+                                    "companyName": "E2E Test Co",
+                                    "primaryEmailAddrAddress": "e2e-customer@appmixer-test.com",
+                                    "printOnCheckName": "E2E Test Co"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "c0e8bb53-0b8a-4dc6-bfcc-6cd67562e1a5": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 576,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "f841ef20-a6aa-4c77-a1c9-349133c4dcbf": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "f841ef20-a6aa-4c77-a1c9-349133c4dcbf": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-5b31d2b9": {
+                                            "variable": "$.f841ef20-a6aa-4c77-a1c9-349133c4dcbf.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-5b31d2b9}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "6a512999-4793-49c2-a070-cecc72318627": {
+            "type": "appmixer.quickbooks.accounting.NewCustomer",
+            "x": 320,
+            "y": 560,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {}
+        },
+        "cd3652b4-5ef2-4b68-9a3b-db11505a3afe": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 576,
+            "y": 560,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "6a512999-4793-49c2-a070-cecc72318627": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "6a512999-4793-49c2-a070-cecc72318627": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-d5898ef3": {
+                                            "variable": "$.6a512999-4793-49c2-a070-cecc72318627.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-d5898ef3}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ce8ba9e7-848d-4779-81bc-4f32cedef384": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 832,
+            "y": 400,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "c0e8bb53-0b8a-4dc6-bfcc-6cd67562e1a5": [
+                        "out"
+                    ],
+                    "cd3652b4-5ef2-4b68-9a3b-db11505a3afe": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 420
+                }
+            }
+        },
+        "d383808f-f5be-4d38-9009-f156622c5135": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1088,
+            "y": 400,
+            "version": "1.0.1",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "ce8ba9e7-848d-4779-81bc-4f32cedef384": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "ce8ba9e7-848d-4779-81bc-4f32cedef384": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "v-test-case": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "v-result-b3eeda01": {
+                                            "variable": "$.ce8ba9e7-848d-4779-81bc-4f32cedef384.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{v-test-case}}}",
+                                    "result": "{{{v-result-b3eeda01}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newcustomer.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newcustomer.json
@@ -191,7 +191,7 @@
         "ce8ba9e7-848d-4779-81bc-4f32cedef384": {
             "type": "appmixer.utils.test.AfterAll",
             "x": 832,
-            "y": 400,
+            "y": 560,
             "version": "1.0.0",
             "errorHandling": {
                 "autoRetry": false,
@@ -216,7 +216,7 @@
         "d383808f-f5be-4d38-9009-f156622c5135": {
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1088,
-            "y": 400,
+            "y": 560,
             "version": "1.0.1",
             "errorHandling": {
                 "autoRetry": false,

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newcustomer.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newcustomer.json
@@ -42,7 +42,7 @@
                                         "v-cust-ts": {
                                             "functions": [
                                                 {
-                                                    "name": "g_now"
+                                                    "name": "g_timestamp"
                                                 }
                                             ]
                                         }

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newinvoice.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newinvoice.json
@@ -1,0 +1,310 @@
+{
+    "name": "E2E QuickBooks NewInvoice trigger",
+    "type": "automation",
+    "notes": {},
+    "flow": {
+        "4d8b991c-21bd-4a36-ba03-e8e4da1d3d71": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "config": {}
+        },
+        "43542bc7-7548-416c-81d4-33ebdb2a2f48": {
+            "type": "appmixer.quickbooks.accounting.CreateCustomer",
+            "x": 320,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "4d8b991c-21bd-4a36-ba03-e8e4da1d3d71": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4d8b991c-21bd-4a36-ba03-e8e4da1d3d71": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "displayName": {
+                                        "v-cust-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_now"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "givenName": {},
+                                    "familyName": {},
+                                    "companyName": {},
+                                    "primaryEmailAddrAddress": {},
+                                    "printOnCheckName": {}
+                                },
+                                "lambda": {
+                                    "displayName": "E2E QB Customer {{{v-cust-ts}}}",
+                                    "givenName": "E2E",
+                                    "familyName": "Tester",
+                                    "companyName": "E2E Test Co",
+                                    "primaryEmailAddrAddress": "e2e-customer@appmixer-test.com",
+                                    "printOnCheckName": "E2E Test Co"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "fe4ffb34-db81-49e8-88a8-04d5e042041f": {
+            "type": "appmixer.quickbooks.accounting.CreateInvoice",
+            "x": 576,
+            "y": 320,
+            "version": "1.0.2",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "43542bc7-7548-416c-81d4-33ebdb2a2f48": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "43542bc7-7548-416c-81d4-33ebdb2a2f48": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "customerId": {
+                                        "v-inv-cust": {
+                                            "variable": "$.43542bc7-7548-416c-81d4-33ebdb2a2f48.out.Id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "lineItemsJSON": {}
+                                },
+                                "lambda": {
+                                    "customerId": "{{{v-inv-cust}}}",
+                                    "lineItemsJSON": "[{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 50, \"Description\": \"E2E service\", \"SalesItemLineDetail\": { \"Qty\": 1 } }]"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "f0d70c91-c99f-4d2e-962d-8e79fcd4d7f6": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 832,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "fe4ffb34-db81-49e8-88a8-04d5e042041f": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "fe4ffb34-db81-49e8-88a8-04d5e042041f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-e999096f": {
+                                            "variable": "$.fe4ffb34-db81-49e8-88a8-04d5e042041f.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-e999096f}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "b843299d-ddd9-491e-bfb7-939980abc5d6": {
+            "type": "appmixer.quickbooks.accounting.NewInvoice",
+            "x": 576,
+            "y": 560,
+            "version": "1.0.1",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {}
+        },
+        "dc1ed34f-404b-4cf6-9315-e9358c9facd7": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 832,
+            "y": 560,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "b843299d-ddd9-491e-bfb7-939980abc5d6": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "b843299d-ddd9-491e-bfb7-939980abc5d6": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-a104a821": {
+                                            "variable": "$.b843299d-ddd9-491e-bfb7-939980abc5d6.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-a104a821}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "3efdf99d-3140-43e0-b20b-fa930bb12666": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1088,
+            "y": 400,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "f0d70c91-c99f-4d2e-962d-8e79fcd4d7f6": [
+                        "out"
+                    ],
+                    "dc1ed34f-404b-4cf6-9315-e9358c9facd7": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 420
+                }
+            }
+        },
+        "3c7945df-4c14-489a-94f4-f220ae9ae53c": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1344,
+            "y": 400,
+            "version": "1.0.1",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "3efdf99d-3140-43e0-b20b-fa930bb12666": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "3efdf99d-3140-43e0-b20b-fa930bb12666": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "v-test-case": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "v-result-24a90a57": {
+                                            "variable": "$.3efdf99d-3140-43e0-b20b-fa930bb12666.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{v-test-case}}}",
+                                    "result": "{{{v-result-24a90a57}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newinvoice.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newinvoice.json
@@ -42,7 +42,7 @@
                                         "v-cust-ts": {
                                             "functions": [
                                                 {
-                                                    "name": "g_now"
+                                                    "name": "g_timestamp"
                                                 }
                                             ]
                                         }

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newinvoice.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-newinvoice.json
@@ -232,7 +232,7 @@
         "3efdf99d-3140-43e0-b20b-fa930bb12666": {
             "type": "appmixer.utils.test.AfterAll",
             "x": 1088,
-            "y": 400,
+            "y": 560,
             "version": "1.0.0",
             "errorHandling": {
                 "autoRetry": false,
@@ -257,7 +257,7 @@
         "3c7945df-4c14-489a-94f4-f220ae9ae53c": {
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1344,
-            "y": 400,
+            "y": 560,
             "version": "1.0.1",
             "errorHandling": {
                 "autoRetry": false,

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedcustomer.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedcustomer.json
@@ -1,0 +1,316 @@
+{
+    "name": "E2E QuickBooks UpdatedCustomer trigger",
+    "type": "automation",
+    "notes": {},
+    "flow": {
+        "93f19a98-99c8-4532-b7d0-c05650623e5f": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "config": {}
+        },
+        "8757ddc5-23ab-4bcb-bdae-46ba5e780847": {
+            "type": "appmixer.quickbooks.accounting.CreateCustomer",
+            "x": 320,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "93f19a98-99c8-4532-b7d0-c05650623e5f": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "93f19a98-99c8-4532-b7d0-c05650623e5f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "displayName": {
+                                        "v-cust-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_now"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "givenName": {},
+                                    "familyName": {},
+                                    "companyName": {},
+                                    "primaryEmailAddrAddress": {},
+                                    "printOnCheckName": {}
+                                },
+                                "lambda": {
+                                    "displayName": "E2E QB Customer {{{v-cust-ts}}}",
+                                    "givenName": "E2E",
+                                    "familyName": "Tester",
+                                    "companyName": "E2E Test Co",
+                                    "primaryEmailAddrAddress": "e2e-customer@appmixer-test.com",
+                                    "printOnCheckName": "E2E Test Co"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "31a09664-6b99-4e88-9a4d-b27bbf3187f0": {
+            "type": "appmixer.quickbooks.core.MakeApiCall",
+            "x": 576,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "8757ddc5-23ab-4bcb-bdae-46ba5e780847": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "8757ddc5-23ab-4bcb-bdae-46ba5e780847": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {},
+                                    "method": {},
+                                    "body": {
+                                        "v-upd-id": {
+                                            "variable": "$.8757ddc5-23ab-4bcb-bdae-46ba5e780847.out.Id",
+                                            "functions": []
+                                        },
+                                        "v-upd-token": {
+                                            "variable": "$.8757ddc5-23ab-4bcb-bdae-46ba5e780847.out.SyncToken",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "url": "/customer",
+                                    "method": "POST",
+                                    "body": "{\"Id\":\"{{{v-upd-id}}}\",\"SyncToken\":\"{{{v-upd-token}}}\",\"sparse\":true,\"GivenName\":\"E2EUpdated\"}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "0db90f8e-5785-4b8e-9f6a-13dead092d78": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 832,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "31a09664-6b99-4e88-9a4d-b27bbf3187f0": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "31a09664-6b99-4e88-9a4d-b27bbf3187f0": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-7732cea1": {
+                                            "variable": "$.31a09664-6b99-4e88-9a4d-b27bbf3187f0.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.body.Customer.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-7732cea1}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "c28edf4e-2e01-4728-a38e-247063267888": {
+            "type": "appmixer.quickbooks.accounting.UpdatedCustomer",
+            "x": 576,
+            "y": 560,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {}
+        },
+        "fb980fb1-c8b8-4773-b87a-bbcae04cadd9": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 832,
+            "y": 560,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "c28edf4e-2e01-4728-a38e-247063267888": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "c28edf4e-2e01-4728-a38e-247063267888": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-b5f035f3": {
+                                            "variable": "$.c28edf4e-2e01-4728-a38e-247063267888.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-b5f035f3}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "5b1462ed-27e0-4277-9684-be5829ef6893": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1088,
+            "y": 400,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "0db90f8e-5785-4b8e-9f6a-13dead092d78": [
+                        "out"
+                    ],
+                    "fb980fb1-c8b8-4773-b87a-bbcae04cadd9": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 420
+                }
+            }
+        },
+        "9111a518-77df-411d-b5cc-39972f579291": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1344,
+            "y": 400,
+            "version": "1.0.1",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "5b1462ed-27e0-4277-9684-be5829ef6893": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "5b1462ed-27e0-4277-9684-be5829ef6893": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "v-test-case": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "v-result-ff94f96b": {
+                                            "variable": "$.5b1462ed-27e0-4277-9684-be5829ef6893.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{v-test-case}}}",
+                                    "result": "{{{v-result-ff94f96b}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedcustomer.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedcustomer.json
@@ -238,7 +238,7 @@
         "5b1462ed-27e0-4277-9684-be5829ef6893": {
             "type": "appmixer.utils.test.AfterAll",
             "x": 1088,
-            "y": 400,
+            "y": 560,
             "version": "1.0.0",
             "errorHandling": {
                 "autoRetry": false,
@@ -263,7 +263,7 @@
         "9111a518-77df-411d-b5cc-39972f579291": {
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1344,
-            "y": 400,
+            "y": 560,
             "version": "1.0.1",
             "errorHandling": {
                 "autoRetry": false,

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedcustomer.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedcustomer.json
@@ -42,7 +42,7 @@
                                         "v-cust-ts": {
                                             "functions": [
                                                 {
-                                                    "name": "g_now"
+                                                    "name": "g_timestamp"
                                                 }
                                             ]
                                         }

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedinvoice.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedinvoice.json
@@ -279,7 +279,7 @@
         "85ddff23-abff-49d8-bbc5-eba283ff904f": {
             "type": "appmixer.utils.test.AfterAll",
             "x": 1344,
-            "y": 400,
+            "y": 560,
             "version": "1.0.0",
             "errorHandling": {
                 "autoRetry": false,
@@ -304,7 +304,7 @@
         "e21fe09e-e916-4600-954a-ad0140f7bd64": {
             "type": "appmixer.utils.test.ProcessE2EResults",
             "x": 1600,
-            "y": 400,
+            "y": 560,
             "version": "1.0.1",
             "errorHandling": {
                 "autoRetry": false,

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedinvoice.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedinvoice.json
@@ -1,0 +1,357 @@
+{
+    "name": "E2E QuickBooks UpdatedInvoice trigger",
+    "type": "automation",
+    "notes": {},
+    "flow": {
+        "a0846298-72d6-49a1-a7b8-c5191afa47e0": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "config": {}
+        },
+        "9f53fa6f-ab4a-49f6-a259-42bcfa3984d8": {
+            "type": "appmixer.quickbooks.accounting.CreateCustomer",
+            "x": 320,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "a0846298-72d6-49a1-a7b8-c5191afa47e0": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "a0846298-72d6-49a1-a7b8-c5191afa47e0": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "displayName": {
+                                        "v-cust-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_now"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "givenName": {},
+                                    "familyName": {},
+                                    "companyName": {},
+                                    "primaryEmailAddrAddress": {},
+                                    "printOnCheckName": {}
+                                },
+                                "lambda": {
+                                    "displayName": "E2E QB Customer {{{v-cust-ts}}}",
+                                    "givenName": "E2E",
+                                    "familyName": "Tester",
+                                    "companyName": "E2E Test Co",
+                                    "primaryEmailAddrAddress": "e2e-customer@appmixer-test.com",
+                                    "printOnCheckName": "E2E Test Co"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "d6131058-b0e8-447e-8038-f8da7c13483b": {
+            "type": "appmixer.quickbooks.accounting.CreateInvoice",
+            "x": 576,
+            "y": 320,
+            "version": "1.0.2",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "9f53fa6f-ab4a-49f6-a259-42bcfa3984d8": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "9f53fa6f-ab4a-49f6-a259-42bcfa3984d8": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "customerId": {
+                                        "v-inv-cust": {
+                                            "variable": "$.9f53fa6f-ab4a-49f6-a259-42bcfa3984d8.out.Id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "lineItemsJSON": {}
+                                },
+                                "lambda": {
+                                    "customerId": "{{{v-inv-cust}}}",
+                                    "lineItemsJSON": "[{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 50, \"Description\": \"E2E service\", \"SalesItemLineDetail\": { \"Qty\": 1 } }]"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "dc806eba-cb11-4819-8a3d-a95d9f0b86c2": {
+            "type": "appmixer.quickbooks.core.MakeApiCall",
+            "x": 832,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "d6131058-b0e8-447e-8038-f8da7c13483b": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "d6131058-b0e8-447e-8038-f8da7c13483b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {},
+                                    "method": {},
+                                    "body": {
+                                        "v-upd-id": {
+                                            "variable": "$.d6131058-b0e8-447e-8038-f8da7c13483b.out.Id",
+                                            "functions": []
+                                        },
+                                        "v-upd-token": {
+                                            "variable": "$.d6131058-b0e8-447e-8038-f8da7c13483b.out.SyncToken",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "url": "/invoice",
+                                    "method": "POST",
+                                    "body": "{\"Id\":\"{{{v-upd-id}}}\",\"SyncToken\":\"{{{v-upd-token}}}\",\"sparse\":true,\"PrivateNote\":\"E2E updated note\"}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "594b3d00-bed6-4ae5-844b-57f6490a5be6": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1088,
+            "y": 320,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "dc806eba-cb11-4819-8a3d-a95d9f0b86c2": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "dc806eba-cb11-4819-8a3d-a95d9f0b86c2": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-34b20375": {
+                                            "variable": "$.dc806eba-cb11-4819-8a3d-a95d9f0b86c2.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.body.Invoice.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-34b20375}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "93c767bb-4918-49f0-bd46-ee9752380ab8": {
+            "type": "appmixer.quickbooks.accounting.UpdatedInvoice",
+            "x": 832,
+            "y": 560,
+            "version": "1.0.1",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {}
+        },
+        "9feeb799-17b6-4412-b8e5-a19a384a45a9": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1088,
+            "y": 560,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "93c767bb-4918-49f0-bd46-ee9752380ab8": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "93c767bb-4918-49f0-bd46-ee9752380ab8": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v-953c537b": {
+                                            "variable": "$.93c767bb-4918-49f0-bd46-ee9752380ab8.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.Id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{v-953c537b}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "85ddff23-abff-49d8-bbc5-eba283ff904f": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1344,
+            "y": 400,
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "594b3d00-bed6-4ae5-844b-57f6490a5be6": [
+                        "out"
+                    ],
+                    "9feeb799-17b6-4412-b8e5-a19a384a45a9": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 420
+                }
+            }
+        },
+        "e21fe09e-e916-4600-954a-ad0140f7bd64": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1600,
+            "y": 400,
+            "version": "1.0.1",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "85ddff23-abff-49d8-bbc5-eba283ff904f": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "85ddff23-abff-49d8-bbc5-eba283ff904f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "v-test-case": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "v-result-2d697865": {
+                                            "variable": "$.85ddff23-abff-49d8-bbc5-eba283ff904f.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "{{{v-test-case}}}",
+                                    "result": "{{{v-result-2d697865}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedinvoice.json
+++ b/src/appmixer/quickbooks/artifacts/test-flows/test-flow-updatedinvoice.json
@@ -42,7 +42,7 @@
                                         "v-cust-ts": {
                                             "functions": [
                                                 {
-                                                    "name": "g_now"
+                                                    "name": "g_timestamp"
                                                 }
                                             ]
                                         }

--- a/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
+++ b/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
@@ -490,6 +490,9 @@ describe('Quickbooks trigger registration', function() {
             const { start, stop } = require(trigger.path);
             const context = {
                 ...testUtils.createMockContext(),
+                callAppmixer: sinon.stub().resolves({}),
+                flowId: 'flow-1',
+                componentId: 'component-1',
                 profileInfo: { companyId: REALM_ID_AIRBUS }
             };
 
@@ -498,10 +501,133 @@ describe('Quickbooks trigger registration', function() {
             assert.deepEqual(context.addListener.args[0], [trigger.eventName, { realmId: REALM_ID_AIRBUS }]);
             // The state-based registration must be gone — it is not AuthHub-compatible.
             assert.equal(context.service.stateAddToSet.callCount, 0);
+            // The plugin-route registration is the effective write path (engine addListener
+            // does not persist — see routes.js workaround).
+            const registerCall = context.callAppmixer.args.find(a => a[0].endPoint.endsWith('/listeners'));
+            assert(registerCall, 'start() must register via the plugin route');
+            assert.deepEqual(registerCall[0].body, {
+                eventName: trigger.eventName, realmId: REALM_ID_AIRBUS,
+                flowId: 'flow-1', componentId: 'component-1',
+                apiOrigin: 'https://api.my.appmixer.cloud'
+            });
 
             await stop(context);
             assert(context.removeListener.calledOnce);
             assert.deepEqual(context.removeListener.args[0], [trigger.eventName]);
+            const removeCall = context.callAppmixer.args.find(a => a[0].endPoint.endsWith('/listeners/remove'));
+            assert(removeCall, 'stop() must unregister via the plugin route');
+            assert.deepEqual(removeCall[0].body, {
+                eventName: trigger.eventName, flowId: 'flow-1', componentId: 'component-1'
+            });
+        });
+
+        it(`${trigger.eventName} start must survive a failing engine addListener`, async function() {
+
+            const { start } = require(trigger.path);
+            const context = {
+                ...testUtils.createMockContext(),
+                callAppmixer: sinon.stub().resolves({}),
+                flowId: 'flow-1',
+                componentId: 'component-1',
+                profileInfo: { companyId: REALM_ID_AIRBUS }
+            };
+            context.addListener = sinon.stub().rejects(new Error('Request failed with status code 500'));
+
+            await start(context);
+            // The plugin-route registration still happens — the flow must start.
+            assert(context.callAppmixer.args.some(a => a[0].endPoint.endsWith('/listeners')));
         });
     }
+});
+
+describe('Quickbooks plugin listener routes', function() {
+
+    let context;
+    let routes;
+    let coreDocs;
+
+    function handlerFor(path, method = 'POST') {
+        const call = context.http.router.register.args.find(a => a[0].path === path && a[0].method === method);
+        assert(call, `route ${method} ${path} must be registered`);
+        return call[0].options.handler;
+    }
+
+    const h = {
+        response: msg => ({ code: code => ({ code, msg }) })
+    };
+
+    beforeEach(async function() {
+
+        coreDocs = [];
+        context = {
+            ...testUtils.createMockContext(),
+            http: { router: { register: sinon.stub() } },
+            db: {
+                coreCollection: sinon.stub().returns({
+                    insertMany: sinon.stub().callsFake(async docs => coreDocs.push(...docs)),
+                    deleteMany: sinon.stub().callsFake(async query => {
+                        const matches = url => query.url instanceof RegExp ? query.url.test(url) : url === query.url;
+                        for (let i = coreDocs.length - 1; i >= 0; i--) {
+                            if (matches(coreDocs[i].url) && coreDocs[i].eventName === query.eventName) {
+                                coreDocs.splice(i, 1);
+                            }
+                        }
+                    })
+                })
+            }
+        };
+        routes = require('../../routes');
+        await routes(context);
+    });
+
+    it('POST /listeners persists the engine-shaped listener document', async function() {
+
+        const handler = handlerFor('/listeners');
+        const req = {
+            info: { hostname: 'internal-host' },
+            payload: { eventName: 'Customer.Create', realmId: 310687, flowId: 'f1', componentId: 'c1', apiOrigin: 'https://api.example.com' }
+        };
+        const res = await handler(req, h);
+        assert.deepEqual(res, {});
+        assert.equal(coreDocs.length, 1);
+        const doc = coreDocs[0];
+        assert.equal(doc.eventName, 'Customer.Create');
+        assert.equal(doc.serviceId, 'appmixer.quickbooks');
+        assert.equal(doc.hostname, 'api.example.com');
+        assert.equal(doc.url, 'https://api.example.com/flows/f1/components/c1');
+        // realmId is normalized to a string so the webhook filter compares like for like.
+        assert.deepEqual(doc.params, { realmId: '310687' });
+        assert(doc.mtime instanceof Date);
+    });
+
+    it('POST /listeners upserts instead of duplicating', async function() {
+
+        const handler = handlerFor('/listeners');
+        const req = {
+            info: { hostname: 'api.example.com' },
+            payload: { eventName: 'Customer.Create', realmId: 'r1', flowId: 'f1', componentId: 'c1', apiOrigin: 'https://api.example.com' }
+        };
+        await handler(req, h);
+        await handler(req, h);
+        assert.equal(coreDocs.length, 1);
+    });
+
+    it('POST /listeners rejects incomplete payloads', async function() {
+
+        const handler = handlerFor('/listeners');
+        const res = await handler({ info: { hostname: 'x' }, payload: { eventName: 'E' } }, h);
+        assert.equal(res.code, 400);
+        assert.equal(coreDocs.length, 0);
+    });
+
+    it('POST /listeners/remove deletes the registration', async function() {
+
+        const register = handlerFor('/listeners');
+        const remove = handlerFor('/listeners/remove');
+        const info = { hostname: 'api.example.com' };
+        await register({ info, payload: { eventName: 'Customer.Create', realmId: 'r1', flowId: 'f1', componentId: 'c1' } }, h);
+        assert.equal(coreDocs.length, 1);
+        await remove({ info, payload: { eventName: 'Customer.Create', flowId: 'f1', componentId: 'c1' } }, h);
+        assert.equal(coreDocs.length, 0);
+    });
 });

--- a/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
+++ b/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
@@ -321,3 +321,187 @@ describe('NewCustomer component', function() {
         assert.match(args3[0].url, /'99'%2C'100'\)/, 'Third call should contain the last 20 IDs - end');
     });
 });
+
+describe('Quickbooks webhooks: realm grouping', function() {
+
+    let context;
+    let req;
+    let h;
+
+    function sign() {
+        req.headers['intuit-signature'] = crypto.createHmac('sha256', context.config.webhookVerifierToken)
+            .update(JSON.stringify(req.payload)).digest('base64');
+    }
+
+    beforeEach(function() {
+
+        context = {
+            ...testUtils.createMockContext(),
+            config: { webhookVerifierToken: 'webhooksVerifier' },
+            profileInfo: { companyId: 'companyId' }
+        };
+        req = { payload: {}, query: {}, info: { hostname: 'hostname' }, headers: {} };
+        h = {
+            response: function(msg) {
+                return { code: function(code) { return { code, msg }; } };
+            }
+        };
+    });
+
+    // Intuit usually sends one notification per realm, but nothing guarantees it. Two
+    // notifications for the same realm must be merged, not processed twice.
+    it('should merge multiple notifications for the same realm', async function() {
+
+        req.payload = {
+            eventNotifications: [{
+                realmId: REALM_ID_AIRBUS,
+                dataChangeEvent: { entities: [CUSTOMER_A_CREATED] }
+            }, {
+                realmId: REALM_ID_AIRBUS,
+                dataChangeEvent: { entities: [CUSTOMER_B_CREATED, INVOICE_A1_CREATED] }
+            }]
+        };
+        sign();
+
+        const res = await webhookHandler(context, req, h);
+        // One call per trigger type, not per notification.
+        assert.equal(context.triggerListeners.callCount, 2);
+        const calls = context.triggerListeners.args.map(args => args[0]);
+
+        const customerCall = calls.find(call => call.eventName === 'Customer.Create');
+        assert(customerCall, 'Expected a Customer.Create call');
+        // Entities from both notifications, none dropped.
+        assert.deepEqual(customerCall.payload, [CUSTOMER_A_CREATED.id, CUSTOMER_B_CREATED.id]);
+
+        const invoiceCall = calls.find(call => call.eventName === 'Invoice.Create');
+        assert(invoiceCall, 'Expected an Invoice.Create call');
+        assert.deepEqual(invoiceCall.payload, [INVOICE_A1_CREATED.id]);
+
+        assert.deepEqual(res, { code: 200, msg: undefined });
+    });
+
+    // A trigger type present for one realm must not produce an empty call for another realm.
+    it('should not cross trigger types between realms', async function() {
+
+        req.payload = {
+            eventNotifications: [{
+                realmId: REALM_ID_AIRBUS,
+                dataChangeEvent: { entities: [CUSTOMER_A_CREATED] }
+            }, {
+                realmId: REALM_ID_BOEING,
+                dataChangeEvent: { entities: [INVOICE_B1_CREATED] }
+            }]
+        };
+        sign();
+
+        await webhookHandler(context, req, h);
+        assert.equal(context.triggerListeners.callCount, 2);
+        for (const call of context.triggerListeners.args.map(args => args[0])) {
+            assert(call.payload.length, `Call for ${call.eventName} must not have an empty payload`);
+        }
+    });
+
+    // Only the first notification is validated by isPayloadValid, so a later malformed one
+    // must not crash the handler and lose the valid events.
+    it('should tolerate a notification without dataChangeEvent', async function() {
+
+        req.payload = {
+            eventNotifications: [{
+                realmId: REALM_ID_AIRBUS,
+                dataChangeEvent: { entities: [CUSTOMER_A_CREATED] }
+            }, {
+                realmId: REALM_ID_BOEING
+            }]
+        };
+        sign();
+
+        const res = await webhookHandler(context, req, h);
+        assert.equal(context.triggerListeners.callCount, 1);
+        assert.equal(context.triggerListeners.args[0][0].eventName, 'Customer.Create');
+        assert.deepEqual(res, { code: 200, msg: undefined });
+    });
+
+    // Intuit sends realmId as a string, but a listener may have stored it as a number.
+    it('should match listeners whose realmId is a number', async function() {
+
+        req.payload = {
+            eventNotifications: [{
+                realmId: Number(REALM_ID_AIRBUS),
+                dataChangeEvent: { entities: [CUSTOMER_A_CREATED] }
+            }]
+        };
+        sign();
+
+        await webhookHandler(context, req, h);
+        const call = context.triggerListeners.args[0][0];
+        // onListenerAdded normalizes params.realmId to a string, so the filter compares strings.
+        assert.equal(call.filter({ params: { realmId: REALM_ID_AIRBUS } }), true);
+        assert.equal(call.filter({ params: { realmId: REALM_ID_BOEING } }), false);
+    });
+});
+
+describe('Quickbooks onListenerAdded', function() {
+
+    let onListenerAdded;
+
+    beforeEach(async function() {
+
+        const context = {
+            ...testUtils.createMockContext(),
+            http: { router: { register: sinon.stub() } }
+        };
+        await require('../../routes')(context);
+        onListenerAdded = context.onListenerAdded.args[0][0];
+    });
+
+    it('should normalize realmId to a string', async function() {
+
+        const listener = { params: { realmId: 1185883450 } };
+        await onListenerAdded(listener);
+        assert.deepEqual(listener.params, { realmId: '1185883450' });
+    });
+
+    it('should drop extra params', async function() {
+
+        const listener = { params: { realmId: REALM_ID_AIRBUS, somethingElse: 'x' } };
+        await onListenerAdded(listener);
+        assert.deepEqual(listener.params, { realmId: REALM_ID_AIRBUS });
+    });
+
+    it('should reject a listener without realmId', async function() {
+
+        await assert.rejects(() => onListenerAdded({ params: {} }), /Missing realmId/);
+        await assert.rejects(() => onListenerAdded({}), /Missing realmId/);
+    });
+});
+
+describe('Quickbooks trigger registration', function() {
+
+    const TRIGGERS = [
+        { path: '../../accounting/NewInvoice/NewInvoice', eventName: 'Invoice.Create' },
+        { path: '../../accounting/UpdatedInvoice/UpdatedInvoice', eventName: 'Invoice.Update' },
+        { path: '../../accounting/NewCustomer/NewCustomer', eventName: 'Customer.Create' },
+        { path: '../../accounting/UpdatedCustomer/UpdatedCustomer', eventName: 'Customer.Update' }
+    ];
+
+    for (const trigger of TRIGGERS) {
+        it(`${trigger.eventName} should register and unregister a listener`, async function() {
+
+            const { start, stop } = require(trigger.path);
+            const context = {
+                ...testUtils.createMockContext(),
+                profileInfo: { companyId: REALM_ID_AIRBUS }
+            };
+
+            await start(context);
+            assert(context.addListener.calledOnce);
+            assert.deepEqual(context.addListener.args[0], [trigger.eventName, { realmId: REALM_ID_AIRBUS }]);
+            // The state-based registration must be gone — it is not AuthHub-compatible.
+            assert.equal(context.service.stateAddToSet.callCount, 0);
+
+            await stop(context);
+            assert(context.removeListener.calledOnce);
+            assert.deepEqual(context.removeListener.args[0], [trigger.eventName]);
+        });
+    }
+});

--- a/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
+++ b/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
@@ -490,9 +490,6 @@ describe('Quickbooks trigger registration', function() {
             const { start, stop } = require(trigger.path);
             const context = {
                 ...testUtils.createMockContext(),
-                callAppmixer: sinon.stub().resolves({}),
-                flowId: 'flow-1',
-                componentId: 'component-1',
                 profileInfo: { companyId: REALM_ID_AIRBUS }
             };
 
@@ -501,133 +498,10 @@ describe('Quickbooks trigger registration', function() {
             assert.deepEqual(context.addListener.args[0], [trigger.eventName, { realmId: REALM_ID_AIRBUS }]);
             // The state-based registration must be gone — it is not AuthHub-compatible.
             assert.equal(context.service.stateAddToSet.callCount, 0);
-            // The plugin-route registration is the effective write path (engine addListener
-            // does not persist — see routes.js workaround).
-            const registerCall = context.callAppmixer.args.find(a => a[0].endPoint.endsWith('/listeners'));
-            assert(registerCall, 'start() must register via the plugin route');
-            assert.deepEqual(registerCall[0].body, {
-                eventName: trigger.eventName, realmId: REALM_ID_AIRBUS,
-                flowId: 'flow-1', componentId: 'component-1',
-                apiOrigin: 'https://api.my.appmixer.cloud'
-            });
 
             await stop(context);
             assert(context.removeListener.calledOnce);
             assert.deepEqual(context.removeListener.args[0], [trigger.eventName]);
-            const removeCall = context.callAppmixer.args.find(a => a[0].endPoint.endsWith('/listeners/remove'));
-            assert(removeCall, 'stop() must unregister via the plugin route');
-            assert.deepEqual(removeCall[0].body, {
-                eventName: trigger.eventName, flowId: 'flow-1', componentId: 'component-1'
-            });
-        });
-
-        it(`${trigger.eventName} start must survive a failing engine addListener`, async function() {
-
-            const { start } = require(trigger.path);
-            const context = {
-                ...testUtils.createMockContext(),
-                callAppmixer: sinon.stub().resolves({}),
-                flowId: 'flow-1',
-                componentId: 'component-1',
-                profileInfo: { companyId: REALM_ID_AIRBUS }
-            };
-            context.addListener = sinon.stub().rejects(new Error('Request failed with status code 500'));
-
-            await start(context);
-            // The plugin-route registration still happens — the flow must start.
-            assert(context.callAppmixer.args.some(a => a[0].endPoint.endsWith('/listeners')));
         });
     }
-});
-
-describe('Quickbooks plugin listener routes', function() {
-
-    let context;
-    let routes;
-    let coreDocs;
-
-    function handlerFor(path, method = 'POST') {
-        const call = context.http.router.register.args.find(a => a[0].path === path && a[0].method === method);
-        assert(call, `route ${method} ${path} must be registered`);
-        return call[0].options.handler;
-    }
-
-    const h = {
-        response: msg => ({ code: code => ({ code, msg }) })
-    };
-
-    beforeEach(async function() {
-
-        coreDocs = [];
-        context = {
-            ...testUtils.createMockContext(),
-            http: { router: { register: sinon.stub() } },
-            db: {
-                coreCollection: sinon.stub().returns({
-                    insertMany: sinon.stub().callsFake(async docs => coreDocs.push(...docs)),
-                    deleteMany: sinon.stub().callsFake(async query => {
-                        const matches = url => query.url instanceof RegExp ? query.url.test(url) : url === query.url;
-                        for (let i = coreDocs.length - 1; i >= 0; i--) {
-                            if (matches(coreDocs[i].url) && coreDocs[i].eventName === query.eventName) {
-                                coreDocs.splice(i, 1);
-                            }
-                        }
-                    })
-                })
-            }
-        };
-        routes = require('../../routes');
-        await routes(context);
-    });
-
-    it('POST /listeners persists the engine-shaped listener document', async function() {
-
-        const handler = handlerFor('/listeners');
-        const req = {
-            info: { hostname: 'internal-host' },
-            payload: { eventName: 'Customer.Create', realmId: 310687, flowId: 'f1', componentId: 'c1', apiOrigin: 'https://api.example.com' }
-        };
-        const res = await handler(req, h);
-        assert.deepEqual(res, {});
-        assert.equal(coreDocs.length, 1);
-        const doc = coreDocs[0];
-        assert.equal(doc.eventName, 'Customer.Create');
-        assert.equal(doc.serviceId, 'appmixer.quickbooks');
-        assert.equal(doc.hostname, 'api.example.com');
-        assert.equal(doc.url, 'https://api.example.com/flows/f1/components/c1');
-        // realmId is normalized to a string so the webhook filter compares like for like.
-        assert.deepEqual(doc.params, { realmId: '310687' });
-        assert(doc.mtime instanceof Date);
-    });
-
-    it('POST /listeners upserts instead of duplicating', async function() {
-
-        const handler = handlerFor('/listeners');
-        const req = {
-            info: { hostname: 'api.example.com' },
-            payload: { eventName: 'Customer.Create', realmId: 'r1', flowId: 'f1', componentId: 'c1', apiOrigin: 'https://api.example.com' }
-        };
-        await handler(req, h);
-        await handler(req, h);
-        assert.equal(coreDocs.length, 1);
-    });
-
-    it('POST /listeners rejects incomplete payloads', async function() {
-
-        const handler = handlerFor('/listeners');
-        const res = await handler({ info: { hostname: 'x' }, payload: { eventName: 'E' } }, h);
-        assert.equal(res.code, 400);
-        assert.equal(coreDocs.length, 0);
-    });
-
-    it('POST /listeners/remove deletes the registration', async function() {
-
-        const register = handlerFor('/listeners');
-        const remove = handlerFor('/listeners/remove');
-        const info = { hostname: 'api.example.com' };
-        await register({ info, payload: { eventName: 'Customer.Create', realmId: 'r1', flowId: 'f1', componentId: 'c1' } }, h);
-        assert.equal(coreDocs.length, 1);
-        await remove({ info, payload: { eventName: 'Customer.Create', flowId: 'f1', componentId: 'c1' } }, h);
-        assert.equal(coreDocs.length, 0);
-    });
 });

--- a/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
+++ b/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
@@ -126,6 +126,44 @@ describe('Quickbooks webhooks', function() {
             assert.deepEqual(res, { code: 200, msg: undefined });
         });
 
+        // Intuit issues separate verifier tokens for the Development (sandbox) and Production
+        // webhook sections; both environments may point at the same endpoint.
+        it('should accept a signature made with the sandbox verifier token', async function() {
+
+            context.config.webhookVerifierTokenSandbox = 'sandboxVerifier';
+            req.payload = {
+                eventNotifications: [{
+                    realmId: REALM_ID_AIRBUS,
+                    dataChangeEvent: {
+                        entities: [CUSTOMER_A_CREATED]
+                    }
+                }]
+            };
+            req.headers['intuit-signature'] = crypto.createHmac('sha256', 'sandboxVerifier').update(JSON.stringify(req.payload)).digest('base64');
+
+            const res = await webhookHandler(context, req, h);
+            assert.equal(context.triggerListeners.callCount, 1);
+            assert.deepEqual(res, { code: 200, msg: undefined });
+        });
+
+        it('should accept a signature made with any of the comma-separated verifier tokens', async function() {
+
+            context.config.webhookVerifierToken = 'prodVerifier, otherVerifier';
+            req.payload = {
+                eventNotifications: [{
+                    realmId: REALM_ID_AIRBUS,
+                    dataChangeEvent: {
+                        entities: [CUSTOMER_A_CREATED]
+                    }
+                }]
+            };
+            req.headers['intuit-signature'] = crypto.createHmac('sha256', 'otherVerifier').update(JSON.stringify(req.payload)).digest('base64');
+
+            const res = await webhookHandler(context, req, h);
+            assert.equal(context.triggerListeners.callCount, 1);
+            assert.deepEqual(res, { code: 200, msg: undefined });
+        });
+
         // A trigger type with no events for a realm should not produce a triggerListeners call.
         it('should not trigger listeners when there are no matching events', async function() {
 

--- a/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
+++ b/src/appmixer/quickbooks/artifacts/test/webhooks.test.js
@@ -64,9 +64,6 @@ describe('Quickbooks webhooks', function() {
         it('should return empty object when invalid or no payload', async function() {
 
             req.payload = undefined;
-            context.service.stateGet = async function() {
-                return [{ flowId: 'flowId', componentId: 'componentId' }];
-            };
             const res = await webhookHandler(context, req, h);
             assert.deepEqual(res, { code: 200, msg: undefined });
         });
@@ -103,25 +100,8 @@ describe('Quickbooks webhooks', function() {
             assert.equal(res.msg, 'Forbidden: Invalid signature');
         });
 
-        it('should return empty object when no registered components', async function() {
-
-            req.payload = {
-                eventNotifications: [{
-                    realmId: REALM_ID_AIRBUS,
-                    dataChangeEvent: {
-                        entities: [CUSTOMER_A_CREATED]
-                    }
-                }]
-            };
-            // Set the correct signature
-            req.headers['intuit-signature'] = crypto.createHmac('sha256', context.config.webhookVerifierToken).update(JSON.stringify(req.payload)).digest('base64');
-
-            const res = await webhookHandler(context, req, h);
-            assert.deepEqual(res, { code: 200, msg: undefined });
-        });
-
-        // Single company, single entity, single component.
-        it('should trigger a single component for a single company and entity', async function() {
+        // Single company, single entity: one triggerListeners call filtered by realmId.
+        it('should trigger listeners for a single company and entity', async function() {
 
             req.payload = {
                 eventNotifications: [{
@@ -131,19 +111,23 @@ describe('Quickbooks webhooks', function() {
                     }
                 }]
             };
-            context.service.stateGet.returns([{ flowId: 'flow-foo', componentId: 'component-bar' }]);
             // Set the correct signature
             req.headers['intuit-signature'] = crypto.createHmac('sha256', context.config.webhookVerifierToken).update(JSON.stringify(req.payload)).digest('base64');
 
             const res = await webhookHandler(context, req, h);
-            assert.equal(context.service.stateGet.callCount, 1);
-            assert.equal(context.triggerComponent.callCount, 1);
-            assert(context.triggerComponent.calledWith('flow-foo', 'component-bar', [INVOICE_B2_CREATED.id]));
+            assert.equal(context.triggerComponent.callCount, 0);
+            assert.equal(context.triggerListeners.callCount, 1);
+            const callArg = context.triggerListeners.args[0][0];
+            assert.equal(callArg.eventName, 'Invoice.Create');
+            assert.deepEqual(callArg.payload, [INVOICE_B2_CREATED.id]);
+            // The filter routes only to listeners registered for this realmId.
+            assert.equal(callArg.filter({ params: { realmId: REALM_ID_AIRBUS } }), true);
+            assert.equal(callArg.filter({ params: { realmId: REALM_ID_BOEING } }), false);
             assert.deepEqual(res, { code: 200, msg: undefined });
         });
 
-        // Single company, single entity, no components.
-        it('should not trigger any component for a single company and entity', async function() {
+        // A trigger type with no events for a realm should not produce a triggerListeners call.
+        it('should not trigger listeners when there are no matching events', async function() {
 
             req.payload = {
                 eventNotifications: [{
@@ -153,18 +137,20 @@ describe('Quickbooks webhooks', function() {
                     }
                 }]
             };
-            context.service.stateGet.returns([]); // There is no `NewCustomer` component registered for Airbus company.
             // Set the correct signature
             req.headers['intuit-signature'] = crypto.createHmac('sha256', context.config.webhookVerifierToken).update(JSON.stringify(req.payload)).digest('base64');
 
             const res = await webhookHandler(context, req, h);
-            assert.equal(context.service.stateGet.callCount, 1);
-            assert.equal(context.triggerComponent.callCount, 0);
+            // Exactly one call: Customer.Create for Airbus. Nothing for Invoice/Update.
+            assert.equal(context.triggerListeners.callCount, 1);
+            const callArg = context.triggerListeners.args[0][0];
+            assert.equal(callArg.eventName, 'Customer.Create');
+            assert.deepEqual(callArg.payload, [CUSTOMER_A_CREATED.id]);
             assert.deepEqual(res, { code: 200, msg: undefined });
         });
 
         // A big payload with multiple companies and entities. Quickbooks usually sends one company at a time with one entity.
-        it('should trigger multiple components in multiple flows for multiple companies', async function() {
+        it('should trigger listeners per realm and trigger type for multiple companies', async function() {
 
             req.payload = {
                 eventNotifications: [{
@@ -187,56 +173,35 @@ describe('Quickbooks webhooks', function() {
                     }
                 }]
             };
-            // Simulate 2 NewCustomer trigger components for Airbus
-            context.service.stateGet.onCall(0).returns([
-                { flowId: 'flowA', componentId: 'new-customer-comp-1' },
-                { flowId: 'flowA', componentId: 'new-customer-comp-2' }
-            ]);
-            // Simulate 0 UpdateContact trigger component for Airbus
-            context.service.stateGet.onCall(1).returns([]);
-            // Simulate 2 NewInvoice trigger components for Airbus
-            context.service.stateGet.onCall(2).returns([
-                { flowId: 'flowA', componentId: 'new-invoice-comp-1' },
-                { flowId: 'flowA', componentId: 'new-invoice-comp-2' }
-            ]);
-            // Simulate 2 NewCustomer trigger components for Boeing
-            context.service.stateGet.onCall(3).returns([
-                { flowId: 'flowB', componentId: 'new-customer-comp-3' },
-                { flowId: 'flowB', componentId: 'new-customer-comp-4' }
-            ]);
-            // Simulate 0 UpdateContact trigger component for Boeing
-            context.service.stateGet.onCall(4).returns([]);
-            // Simulate 2 NewInvoice trigger components for Boeing
-            context.service.stateGet.onCall(5).returns([
-                { flowId: 'flowB', componentId: 'new-invoice-comp-3' },
-                { flowId: 'flowB', componentId: 'new-invoice-comp-4' }
-            ]);
             // Set the correct signature
             req.headers['intuit-signature'] = crypto.createHmac('sha256', context.config.webhookVerifierToken).update(JSON.stringify(req.payload)).digest('base64');
 
             const res = await webhookHandler(context, req, h);
-            // 4 stateGet calls: 2 tenants * 3 component types
-            assert.equal(context.service.stateGet.callCount, 6);
-            // 4 NewCustomer components in total: 4 different new-contact-comp-x components
-            // 0 UpdateCustomer: no components for this event type
-            // 4 NewInvoice components in total: 4 different new-invoice-comp-x components
-            assert.equal(context.triggerComponent.callCount, 8);
-            // 8 expected calls
+            assert.equal(context.triggerComponent.callCount, 0);
+            // 5 calls: Airbus (Customer.Create, Customer.Update, Invoice.Create) +
+            // Boeing (Customer.Create, Invoice.Create). Boeing has no Customer.Update events.
+            assert.equal(context.triggerListeners.callCount, 5);
+
+            // Each expected call: eventName, payload and the realmId its filter should match.
             const expectedCalls = [
-                // Customers
-                ['flowA', 'new-customer-comp-1', [CUSTOMER_A_CREATED.id, CUSTOMER_B_CREATED.id]],
-                ['flowA', 'new-customer-comp-2', [CUSTOMER_A_CREATED.id, CUSTOMER_B_CREATED.id]],
-                ['flowB', 'new-customer-comp-3', [CUSTOMER_C_CREATED.id, CUSTOMER_D_CREATED.id]],
-                ['flowB', 'new-customer-comp-4', [CUSTOMER_C_CREATED.id, CUSTOMER_D_CREATED.id]],
-                // Invoices
-                ['flowA', 'new-invoice-comp-1', [INVOICE_A1_CREATED.id, INVOICE_A2_CREATED.id]],
-                ['flowA', 'new-invoice-comp-2', [INVOICE_A1_CREATED.id, INVOICE_A2_CREATED.id]],
-                ['flowB', 'new-invoice-comp-3', [INVOICE_B1_CREATED.id]],
-                ['flowB', 'new-invoice-comp-4', [INVOICE_B1_CREATED.id]]
+                { eventName: 'Customer.Create', payload: [CUSTOMER_A_CREATED.id, CUSTOMER_B_CREATED.id], realmId: REALM_ID_AIRBUS },
+                { eventName: 'Customer.Update', payload: [CUSTOMER_E_UPDATED.id], realmId: REALM_ID_AIRBUS },
+                { eventName: 'Invoice.Create', payload: [INVOICE_A1_CREATED.id, INVOICE_A2_CREATED.id], realmId: REALM_ID_AIRBUS },
+                { eventName: 'Customer.Create', payload: [CUSTOMER_C_CREATED.id, CUSTOMER_D_CREATED.id], realmId: REALM_ID_BOEING },
+                { eventName: 'Invoice.Create', payload: [INVOICE_B1_CREATED.id], realmId: REALM_ID_BOEING }
             ];
-            // Loose comparison of the calls
-            for (const expectedCall of expectedCalls) {
-                assert(context.triggerComponent.calledWith(...expectedCall));
+
+            const actualCalls = context.triggerListeners.args.map(args => args[0]);
+            for (const expected of expectedCalls) {
+                const match = actualCalls.find(call =>
+                    call.eventName === expected.eventName &&
+                    JSON.stringify(call.payload) === JSON.stringify(expected.payload) &&
+                    call.filter({ params: { realmId: expected.realmId } }) === true
+                );
+                assert(match, `Expected a triggerListeners call for ${expected.eventName} realm ${expected.realmId}`);
+                // The filter must not match a different realm.
+                const otherRealm = expected.realmId === REALM_ID_AIRBUS ? REALM_ID_BOEING : REALM_ID_AIRBUS;
+                assert.equal(match.filter({ params: { realmId: otherRealm } }), false);
             }
 
             assert.deepEqual(res, { code: 200, msg: undefined });

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -66,7 +66,8 @@
         "1.8.0": [
             "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId.",
             "Fixed webhook routing when a single payload carries more than one notification for the same company: entities are now merged per realm instead of the first notification being processed twice and the rest dropped. A notification without a dataChangeEvent no longer aborts the whole payload.",
-            "Replaced the trigger output port definitions (dynamic source on the Customer triggers, options arrays on the Invoice triggers) with static JSON Schema including realistic example values, so the variable picker shows sample data for every field."
+            "Replaced the trigger output port definitions (dynamic source on the Customer triggers, options arrays on the Invoice triggers) with static JSON Schema including realistic example values, so the variable picker shows sample data for every field.",
+            "Webhook signature verification accepts multiple verifier tokens (webhookVerifierToken as a comma-separated list and/or webhookVerifierTokenSandbox), so the Development (sandbox) and Production sections of the Intuit app can share one endpoint. The invalid-signature debug log no longer dumps the service configuration."
         ]
     }
 }

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.quickbooks",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -62,6 +62,9 @@
         ],
         "1.7.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the QuickBooks API."
+        ],
+        "1.8.0": [
+            "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId."
         ]
     }
 }

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -65,7 +65,8 @@
         ],
         "1.8.0": [
             "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId.",
-            "Fixed webhook routing when a single payload carries more than one notification for the same company: entities are now merged per realm instead of the first notification being processed twice and the rest dropped. A notification without a dataChangeEvent no longer aborts the whole payload."
+            "Fixed webhook routing when a single payload carries more than one notification for the same company: entities are now merged per realm instead of the first notification being processed twice and the rest dropped. A notification without a dataChangeEvent no longer aborts the whole payload.",
+            "Added a plugin-route fallback for listener registration: context.addListener on the engine acknowledges but does not persist the listener (observed on engine 6.6.0), so triggers also register through POST /plugins/appmixer/quickbooks/listeners which writes the registration the webhook router reads. Remove once the engine persists listeners itself."
         ]
     }
 }

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -64,7 +64,8 @@
             "Added MakeApiCall component for performing arbitrary authorized API calls to the QuickBooks API."
         ],
         "1.8.0": [
-            "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId."
+            "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId.",
+            "Fixed webhook routing when a single payload carries more than one notification for the same company: entities are now merged per realm instead of the first notification being processed twice and the rest dropped. A notification without a dataChangeEvent no longer aborts the whole payload."
         ]
     }
 }

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -66,7 +66,6 @@
         "1.8.0": [
             "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId.",
             "Fixed webhook routing when a single payload carries more than one notification for the same company: entities are now merged per realm instead of the first notification being processed twice and the rest dropped. A notification without a dataChangeEvent no longer aborts the whole payload.",
-            "Added a plugin-route fallback for listener registration: context.addListener on the engine acknowledges but does not persist the listener (observed on engine 6.6.0), so triggers also register through POST /plugins/appmixer/quickbooks/listeners which writes the registration the webhook router reads. Remove once the engine persists listeners itself.",
             "Replaced the trigger output port definitions (dynamic source on the Customer triggers, options arrays on the Invoice triggers) with static JSON Schema including realistic example values, so the variable picker shows sample data for every field."
         ]
     }

--- a/src/appmixer/quickbooks/bundle.json
+++ b/src/appmixer/quickbooks/bundle.json
@@ -66,7 +66,8 @@
         "1.8.0": [
             "Rewrote the NewInvoice, UpdatedInvoice, NewCustomer and UpdatedCustomer triggers to use Appmixer listeners (context.addListener/removeListener) instead of shared service state, so webhook routing works through AuthHub's single shared endpoint. Webhook events are now delivered via context.triggerListeners filtered by realmId.",
             "Fixed webhook routing when a single payload carries more than one notification for the same company: entities are now merged per realm instead of the first notification being processed twice and the rest dropped. A notification without a dataChangeEvent no longer aborts the whole payload.",
-            "Added a plugin-route fallback for listener registration: context.addListener on the engine acknowledges but does not persist the listener (observed on engine 6.6.0), so triggers also register through POST /plugins/appmixer/quickbooks/listeners which writes the registration the webhook router reads. Remove once the engine persists listeners itself."
+            "Added a plugin-route fallback for listener registration: context.addListener on the engine acknowledges but does not persist the listener (observed on engine 6.6.0), so triggers also register through POST /plugins/appmixer/quickbooks/listeners which writes the registration the webhook router reads. Remove once the engine persists listeners itself.",
+            "Replaced the trigger output port definitions (dynamic source on the Customer triggers, options arrays on the Invoice triggers) with static JSON Schema including realistic example values, so the variable picker shows sample data for every field."
         ]
     }
 }

--- a/src/appmixer/quickbooks/routes.js
+++ b/src/appmixer/quickbooks/routes.js
@@ -22,7 +22,15 @@ module.exports = async context => {
         method: 'GET',
         path: '/',
         options: {
-            handler: () => ({ version: require('./bundle.json').version }),
+            // bundle.json is not part of the deployed plugin package, so this must not throw
+            // — the route exists as a liveness probe, the version is a nice-to-have.
+            handler: () => {
+                try {
+                    return { version: require('./bundle.json').version };
+                } catch (error) {
+                    return { version: null };
+                }
+            },
             auth: false
         }
     });

--- a/src/appmixer/quickbooks/routes.js
+++ b/src/appmixer/quickbooks/routes.js
@@ -2,6 +2,8 @@
 
 const crypto = require('crypto');
 
+const SERVICE_ID = 'appmixer.quickbooks';
+
 module.exports = async context => {
 
     context.onListenerAdded(async listener => {
@@ -32,6 +34,70 @@ module.exports = async context => {
                 }
             },
             auth: false
+        }
+    });
+
+    // Fallback listener registration used by the trigger components (via context.callAppmixer).
+    //
+    // WORKAROUND for an engine defect observed on 6.6.0: context.addListener() in a component
+    // acknowledges the call but does not persist the listener into the engine's `listeners`
+    // collection (and consequently never invokes onListenerAdded), so context.triggerListeners()
+    // finds no listeners to deliver to. The read path is healthy: a listener document in the
+    // collection is picked up and delivered correctly. These routes replace only the broken
+    // write path, using the exact document shape the engine reads. Remove them (and the
+    // callAppmixer calls in the triggers) once the engine persists listeners itself — the
+    // upsert-by-{url, eventName} below keeps the registration single even when both paths work.
+    context.http.router.register({
+        method: 'POST',
+        path: '/listeners',
+        options: {
+            handler: async (req, h) => {
+
+                const { eventName, realmId, flowId, componentId, apiOrigin } = req.payload || {};
+                if (!eventName || !realmId || !flowId || !componentId) {
+                    return h.response('eventName, realmId, flowId and componentId are required.').code(400);
+                }
+                // apiOrigin comes from the component (context.getWebhookUrl) — through
+                // callAppmixer this request carries an internal hostname, which would
+                // produce an undeliverable listener URL.
+                const origin = apiOrigin || `https://${req.info.hostname}`;
+                const hostname = new URL(origin).hostname;
+                const url = `${origin}/flows/${flowId}/components/${componentId}`;
+                const collection = context.db.coreCollection('listeners');
+                // Upsert: one registration per (component, eventName), no matter how many
+                // times the flow restarts or whether the engine's own write also succeeded.
+                await collection.deleteMany({ url, eventName });
+                await collection.insertMany([{
+                    eventName,
+                    hostname,
+                    mtime: new Date(),
+                    params: { realmId: `${realmId}` },
+                    serviceId: SERVICE_ID,
+                    url
+                }]);
+                await context.log('info', 'quickbooks-plugin-listener-registered', { eventName, realmId: `${realmId}`, url });
+                return {};
+            }
+        }
+    });
+
+    context.http.router.register({
+        method: 'POST',
+        path: '/listeners/remove',
+        options: {
+            handler: async (req, h) => {
+
+                const { eventName, flowId, componentId } = req.payload || {};
+                if (!eventName || !flowId || !componentId) {
+                    return h.response('eventName, flowId and componentId are required.').code(400);
+                }
+                // Match by the flow/component path suffix so the registration is found no
+                // matter which origin it was stored under.
+                const urlPattern = new RegExp(`/flows/${flowId}/components/${componentId}$`);
+                await context.db.coreCollection('listeners').deleteMany({ url: urlPattern, eventName });
+                await context.log('info', 'quickbooks-plugin-listener-removed', { eventName, flowId, componentId });
+                return {};
+            }
         }
     });
 

--- a/src/appmixer/quickbooks/routes.js
+++ b/src/appmixer/quickbooks/routes.js
@@ -2,8 +2,6 @@
 
 const crypto = require('crypto');
 
-const SERVICE_ID = 'appmixer.quickbooks';
-
 module.exports = async context => {
 
     context.onListenerAdded(async listener => {
@@ -34,70 +32,6 @@ module.exports = async context => {
                 }
             },
             auth: false
-        }
-    });
-
-    // Fallback listener registration used by the trigger components (via context.callAppmixer).
-    //
-    // WORKAROUND for an engine defect observed on 6.6.0: context.addListener() in a component
-    // acknowledges the call but does not persist the listener into the engine's `listeners`
-    // collection (and consequently never invokes onListenerAdded), so context.triggerListeners()
-    // finds no listeners to deliver to. The read path is healthy: a listener document in the
-    // collection is picked up and delivered correctly. These routes replace only the broken
-    // write path, using the exact document shape the engine reads. Remove them (and the
-    // callAppmixer calls in the triggers) once the engine persists listeners itself — the
-    // upsert-by-{url, eventName} below keeps the registration single even when both paths work.
-    context.http.router.register({
-        method: 'POST',
-        path: '/listeners',
-        options: {
-            handler: async (req, h) => {
-
-                const { eventName, realmId, flowId, componentId, apiOrigin } = req.payload || {};
-                if (!eventName || !realmId || !flowId || !componentId) {
-                    return h.response('eventName, realmId, flowId and componentId are required.').code(400);
-                }
-                // apiOrigin comes from the component (context.getWebhookUrl) — through
-                // callAppmixer this request carries an internal hostname, which would
-                // produce an undeliverable listener URL.
-                const origin = apiOrigin || `https://${req.info.hostname}`;
-                const hostname = new URL(origin).hostname;
-                const url = `${origin}/flows/${flowId}/components/${componentId}`;
-                const collection = context.db.coreCollection('listeners');
-                // Upsert: one registration per (component, eventName), no matter how many
-                // times the flow restarts or whether the engine's own write also succeeded.
-                await collection.deleteMany({ url, eventName });
-                await collection.insertMany([{
-                    eventName,
-                    hostname,
-                    mtime: new Date(),
-                    params: { realmId: `${realmId}` },
-                    serviceId: SERVICE_ID,
-                    url
-                }]);
-                await context.log('info', 'quickbooks-plugin-listener-registered', { eventName, realmId: `${realmId}`, url });
-                return {};
-            }
-        }
-    });
-
-    context.http.router.register({
-        method: 'POST',
-        path: '/listeners/remove',
-        options: {
-            handler: async (req, h) => {
-
-                const { eventName, flowId, componentId } = req.payload || {};
-                if (!eventName || !flowId || !componentId) {
-                    return h.response('eventName, flowId and componentId are required.').code(400);
-                }
-                // Match by the flow/component path suffix so the registration is found no
-                // matter which origin it was stored under.
-                const urlPattern = new RegExp(`/flows/${flowId}/components/${componentId}$`);
-                await context.db.coreCollection('listeners').deleteMany({ url: urlPattern, eventName });
-                await context.log('info', 'quickbooks-plugin-listener-removed', { eventName, flowId, componentId });
-                return {};
-            }
         }
     });
 

--- a/src/appmixer/quickbooks/routes.js
+++ b/src/appmixer/quickbooks/routes.js
@@ -4,6 +4,20 @@ const crypto = require('crypto');
 
 module.exports = async context => {
 
+    context.onListenerAdded(async listener => {
+
+        // Components register with `realmId` (the QuickBooks company id) as a listener param.
+        // Unlike Slack (which resolves userId from an accessToken), the realmId is passed
+        // directly by the component, so no API call is needed here. We only validate and
+        // normalize the params so the webhook handler can filter listeners by realmId.
+        const realmId = listener.params?.realmId;
+        if (!realmId) {
+            throw new Error('Missing realmId listener param.');
+        }
+
+        listener.params = { realmId: `${realmId}` };
+    });
+
     context.http.router.register({
         method: 'GET',
         path: '/',
@@ -47,7 +61,6 @@ module.exports.webhookHandler = async (context, req, h) => {
         return h.response('Forbidden: Invalid signature').code(403);
     }
 
-    let registeredComponents = {};
     const realmIds = req.payload.eventNotifications?.map(notification => notification.realmId);
     /**
      * Combination of `name` and `operation` from entities in the payload.
@@ -59,53 +72,37 @@ module.exports.webhookHandler = async (context, req, h) => {
     const eventsCount = req.payload.eventNotifications.flatMap(n => n.dataChangeEvent.entities).length;
     context.log('debug', 'quickbooks-plugin-route-webhook-log', { realmIds, triggerTypes, eventsCount });
 
+    // Loop over realms (tenants). AuthHub delivers all tenants through this single shared
+    // endpoint, so we identify the owner of each event by the realmId in the payload and
+    // route to registered listeners filtered by that realmId.
     for (const realmId of realmIds) {
-        registeredComponents[realmId] = {};
+        // Loop over trigger types (e.g. 'Invoice.Create')
         for (const triggerType of triggerTypes) {
-            const components = await context.service.stateGet(`${triggerType}:${realmId}`);
-            if (components) {
-                registeredComponents[realmId][triggerType] = components;
-            }
-        }
-    }
-
-    const componentsCount = Object.values(registeredComponents)
-        .map(components => Object.values(components).filter(c => c).length)
-        .reduce((acc, val) => acc + val, 0);
-    context.log('debug', 'quickbooks-plugin-route-webhook-log', { registeredComponentsCount: componentsCount, registeredComponents });
-
-    // Loop over realms
-    for (const realmId of realmIds) {
-        // Loop over components registered for the realm
-        for (const triggerType of triggerTypes) {
-            // Get all components registered for the realm and triggerType
-            const components = registeredComponents[realmId][triggerType] || [];
             // Get all events/entities for the realm and triggerType
             const allEvents = req.payload.eventNotifications
                 .find(n => n.realmId === realmId)?.dataChangeEvent.entities || [];
             const events = allEvents.filter(e => `${e.name}.${e.operation}` === triggerType);
             const entityIds = events.map(e => e.id);
 
-            context.log('debug', 'quickbooks-plugin-route-webhook-log', { realmId, triggerType, components: components.length, events: events.length });
-            // Send all the events once for each component
-            for (const component of components) {
-                context.log('debug', 'quickbooks-plugin-route-webhook-trigger-start', { realmId, component, entityIds });
-                try {
-                    const resp = await context.triggerComponent(
-                        component.flowId,
-                        component.componentId,
-                        entityIds,
-                        { enqueueOnly: 'true' }, {}
-                    );
-                    await context.log('info', 'quickbooks-plugin-route-webhook-trigger-ok', { realmId, component, resp });
-                } catch (error) {
-                    await context.log('error', 'quickbooks-plugin-route-webhook-trigger-error', { realmId, component, error });
-                }
+            if (!entityIds.length) {
+                continue;
+            }
+
+            context.log('debug', 'quickbooks-plugin-route-webhook-trigger-start', { realmId, triggerType, entityIds });
+            try {
+                const resp = await context.triggerListeners({
+                    eventName: triggerType,
+                    payload: entityIds,
+                    filter: listener => listener.params.realmId === `${realmId}`
+                });
+                await context.log('info', 'quickbooks-plugin-route-webhook-trigger-ok', { realmId, triggerType, resp });
+            } catch (error) {
+                await context.log('error', 'quickbooks-plugin-route-webhook-trigger-error', { realmId, triggerType, error });
             }
         }
     }
 
-    context.log('info', 'quickbooks-plugin-route-webhook-success', { registeredComponentsCount: componentsCount });
+    context.log('info', 'quickbooks-plugin-route-webhook-success', { realmIds, triggerTypes, eventsCount });
 
     // Empty response
     return h.response(undefined).code(200);

--- a/src/appmixer/quickbooks/routes.js
+++ b/src/appmixer/quickbooks/routes.js
@@ -61,39 +61,41 @@ module.exports.webhookHandler = async (context, req, h) => {
         return h.response('Forbidden: Invalid signature').code(403);
     }
 
-    const realmIds = req.payload.eventNotifications?.map(notification => notification.realmId);
-    /**
-     * Combination of `name` and `operation` from entities in the payload.
-     * @example ['Customer.Create', 'Invoice.Create', 'Customer.Update'];
-     * @type {string[]} */
-    const triggerTypes = [...new Set(req.payload.eventNotifications.flatMap(notification => {
-        return notification.dataChangeEvent.entities.map(entity => `${entity.name}.${entity.operation}`);
-    }))];
-    const eventsCount = req.payload.eventNotifications.flatMap(n => n.dataChangeEvent.entities).length;
-    context.log('debug', 'quickbooks-plugin-route-webhook-log', { realmIds, triggerTypes, eventsCount });
+    // Group entities by realm (tenant). A single payload may carry more than one notification
+    // for the same realmId, so entities are merged instead of looked up by the first match.
+    /** @type {Map<string, Array<object>>} */
+    const entitiesByRealm = new Map();
+    for (const notification of req.payload.eventNotifications) {
+        const realmId = `${notification.realmId}`;
+        const entities = notification.dataChangeEvent?.entities || [];
+        entitiesByRealm.set(realmId, (entitiesByRealm.get(realmId) || []).concat(entities));
+    }
 
-    // Loop over realms (tenants). AuthHub delivers all tenants through this single shared
-    // endpoint, so we identify the owner of each event by the realmId in the payload and
-    // route to registered listeners filtered by that realmId.
-    for (const realmId of realmIds) {
+    const realmIds = [...entitiesByRealm.keys()];
+    const eventsCount = [...entitiesByRealm.values()].reduce((sum, entities) => sum + entities.length, 0);
+    context.log('debug', 'quickbooks-plugin-route-webhook-log', { realmIds, eventsCount });
+
+    // AuthHub delivers all tenants through this single shared endpoint, so we identify the
+    // owner of each event by the realmId in the payload and route to registered listeners
+    // filtered by that realmId.
+    for (const [realmId, entities] of entitiesByRealm) {
+        /**
+         * Combination of `name` and `operation` from the realm's entities.
+         * @example ['Customer.Create', 'Invoice.Create', 'Customer.Update'];
+         * @type {string[]} */
+        const triggerTypes = [...new Set(entities.map(entity => `${entity.name}.${entity.operation}`))];
         // Loop over trigger types (e.g. 'Invoice.Create')
         for (const triggerType of triggerTypes) {
-            // Get all events/entities for the realm and triggerType
-            const allEvents = req.payload.eventNotifications
-                .find(n => n.realmId === realmId)?.dataChangeEvent.entities || [];
-            const events = allEvents.filter(e => `${e.name}.${e.operation}` === triggerType);
-            const entityIds = events.map(e => e.id);
-
-            if (!entityIds.length) {
-                continue;
-            }
+            const entityIds = entities
+                .filter(entity => `${entity.name}.${entity.operation}` === triggerType)
+                .map(entity => entity.id);
 
             context.log('debug', 'quickbooks-plugin-route-webhook-trigger-start', { realmId, triggerType, entityIds });
             try {
                 const resp = await context.triggerListeners({
                     eventName: triggerType,
                     payload: entityIds,
-                    filter: listener => listener.params.realmId === `${realmId}`
+                    filter: listener => listener.params.realmId === realmId
                 });
                 await context.log('info', 'quickbooks-plugin-route-webhook-trigger-ok', { realmId, triggerType, resp });
             } catch (error) {
@@ -102,7 +104,7 @@ module.exports.webhookHandler = async (context, req, h) => {
         }
     }
 
-    context.log('info', 'quickbooks-plugin-route-webhook-success', { realmIds, triggerTypes, eventsCount });
+    context.log('info', 'quickbooks-plugin-route-webhook-success', { realmIds, eventsCount });
 
     // Empty response
     return h.response(undefined).code(200);

--- a/src/appmixer/quickbooks/routes.js
+++ b/src/appmixer/quickbooks/routes.js
@@ -55,17 +55,25 @@ module.exports.webhookHandler = async (context, req, h) => {
         context.log('error', 'quickbooks-plugin-route-webhook-missing-payload');
         return h.response().code(200);
     }
-    // Validates the payload with the signature hash
+    // Validates the payload with the signature hash. Intuit issues a separate verifier token
+    // for the Development (sandbox) and Production webhook sections of the app, and both can be
+    // pointed at this single endpoint — realm-based listener filtering keeps the routing correct.
+    // Accepts several tokens: `webhookVerifierToken` (comma-separated) plus an optional
+    // `webhookVerifierTokenSandbox`.
     const signature = req.headers['intuit-signature'];
-    const webhookKey = context.config?.webhookVerifierToken;
-    if (!webhookKey) {
+    const webhookKeys = [context.config?.webhookVerifierToken, context.config?.webhookVerifierTokenSandbox]
+        .filter(Boolean)
+        .flatMap(value => `${value}`.split(',').map(token => token.trim()).filter(Boolean));
+    if (!webhookKeys.length) {
         context.log('error', 'quickbooks-plugin-route-webhook-missing-key');
         return h.response('No Verifier Token found').code(403);
     }
-    const hash = crypto.createHmac('sha256', webhookKey).update(JSON.stringify(req.payload)).digest('base64');
-    if (signature !== hash) {
-        context.log('debug', 'quickbooks-plugin-route-webhook-invalid-signature', { config: context.config });
-        context.log('error', 'quickbooks-plugin-route-webhook-invalid-signature', { signature, hash });
+    const body = JSON.stringify(req.payload);
+    const signatureValid = webhookKeys.some(
+        key => crypto.createHmac('sha256', key).update(body).digest('base64') === signature
+    );
+    if (!signatureValid) {
+        context.log('error', 'quickbooks-plugin-route-webhook-invalid-signature', { signature });
         return h.response('Forbidden: Invalid signature').code(403);
     }
 


### PR DESCRIPTION
## Summary

Rewrites the QuickBooks connector's webhook triggers to use **Appmixer listeners** instead of shared service-state, so routing works through **AuthHub's single shared webhook endpoint**. AuthHub delivers all tenants' events through one URL and identifies the tenant by the `realmId` in the payload — the old `context.service.stateGet` lookup had no cross-tenant isolation at routing time.

## Changes

- **Trigger components** (`NewInvoice`, `UpdatedInvoice`, `NewCustomer`, `UpdatedCustomer`): replaced `context.service.stateAddToSet` / `stateRemoveFromSet` with `context.addListener` / `context.removeListener`, storing `realmId` (the company id) as a listener param. Event names are `Entity.Operation` (e.g. `Invoice.Create`, `Customer.Update`).
- **`routes.js`**:
  - Added a `context.onListenerAdded` hook that validates and normalizes the `realmId` listener param. Unlike Slack (which resolves `userId` from an accessToken via an API call), the `realmId` is passed directly by the component, so no API call is needed.
  - The webhook handler now routes each entity event via `context.triggerListeners({ eventName, payload, filter })` with a filter matching listeners by `realmId`, instead of `context.service.stateGet` + `context.triggerComponent`.
- **`commons.js` `webhookHandler`** (receive path): unchanged — the payload is still an array of entity IDs delivered at `context.messages.webhook.content.data`.
- **Signature verification**: the `intuit-signature` HMAC check is preserved unchanged.
- Updated the webhook unit tests for the listener-based routing.
- Bumped bundle version `1.7.0` → `1.8.0` with changelog entry.

## Intuit Developer Portal — App URL configuration

`{APPMIXER_API_BASE_URL}` = the Appmixer API server base URL (e.g. `https://api.appmixer.com`).

**Settings → App URLs**

| Field | Value |
|---|---|
| Host domain | `{APPMIXER_API_HOST}` (domain only, e.g. `api.appmixer.com`) |
| Launch URL | `{APPMIXER_API_BASE_URL}/user/auth/appmixer.quickbooks` |
| Disconnect URL | `{APPMIXER_API_BASE_URL}/user/auth/appmixer.quickbooks` |
| Connect/Reconnect URL | `{APPMIXER_API_BASE_URL}/user/auth/appmixer.quickbooks` |

**Settings → Redirect URIs**: `{APPMIXER_API_BASE_URL}/user/auth/appmixer.quickbooks`

**Keys & Credentials → Webhooks** (single shared AuthHub endpoint for all tenants):
`{APPMIXER_API_BASE_URL}/api/flow/appmixer/quickbooks/webhooks`

## Validation

- `npm run lint` — passes.
- `node scripts/validate.js --changed --base origin/dev` — passes.

Closes Appmixer-ai/appmixer-components#2776