### PR TITLE
microsoft.calendar(patch): UpdatedEvent no longer fires on event creation

### DIFF
--- a/src/appmixer/microsoft/calendar/UpdatedEvent/UpdatedEvent.js
+++ b/src/appmixer/microsoft/calendar/UpdatedEvent/UpdatedEvent.js
@@ -86,7 +86,14 @@ module.exports = {
                         if (err.response?.status === 404) continue;
                         throw err;
                     }
-                    await context.sendJson(eventResponse.data, 'out');
+                    const event = eventResponse.data;
+                    // MS Graph delivers 'updated' notifications for newly created events too
+                    // (Exchange touches the event right after creation). Skip these creation
+                    // echoes so the trigger only fires on genuine updates.
+                    const createdAt = Date.parse(event.createdDateTime);
+                    const modifiedAt = Date.parse(event.lastModifiedDateTime);
+                    if (!isNaN(createdAt) && !isNaN(modifiedAt) && (modifiedAt - createdAt) < 5000) continue;
+                    await context.sendJson(event, 'out');
                 }
             }
 

--- a/src/appmixer/microsoft/calendar/bundle.json
+++ b/src/appmixer/microsoft/calendar/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.calendar",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "changelog": {
         "1.0.1": [
             "Initial release."
@@ -20,6 +20,7 @@
         "1.1.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Microsoft Graph (Calendar) API."
         ],
-        "1.2.0": ["Add New Event, Updated Event, Deleted Event and Event Start triggers."]
+        "1.2.0": ["Add New Event, Updated Event, Deleted Event and Event Start triggers."],
+        "1.2.1": ["Updated Event trigger no longer fires when an event is only created."]
     }
 }


### PR DESCRIPTION
## Problem

The **Updated Event** trigger fires when an event is merely created. MS Graph delivers `updated` change notifications for newly created events because Exchange touches the event right after creation, so an `updated`-only subscription still receives a creation echo.

## Fix

In `receive()`, after fetching the event, skip notifications where `lastModifiedDateTime` is within 5 seconds of `createdDateTime` — those are creation echoes, not genuine updates.

Trade-off: a genuine user edit made within 5 s of creating the event is skipped as well; acceptable for this quirk.

## Changes
- `UpdatedEvent/UpdatedEvent.js` — creation-echo filter
- `bundle.json` — 1.2.1 + changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGpcSUhCzN1wcZEXfhyUgP