### PR TITLE
facebook, facebookbusiness, dropbox, fakturoid(patch): fix MakeApiCall component names

### DIFF
--- a/src/appmixer/dropbox/bundle.json
+++ b/src/appmixer/dropbox/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.dropbox",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "engine": ">=5.0",
     "changelog": {
         "1.0.0": [
@@ -39,7 +39,7 @@
         "1.4.0": [
             "Added test() (Flow Test Mode) to all triggers: NewFile, NewFolder."
         ],
-        "1.5.0": [
+        "1.5.1": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Dropbox API."
         ]
     }

--- a/src/appmixer/dropbox/files/MakeApiCall/component.json
+++ b/src/appmixer/dropbox/files/MakeApiCall/component.json
@@ -1,5 +1,5 @@
 {
-    "name": "appmixer.dropbox.core.MakeApiCall",
+    "name": "appmixer.dropbox.files.MakeApiCall",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Performs an arbitrary authorized API call to the Dropbox API.",
     "version": "1.0.0",

--- a/src/appmixer/facebook/bundle.json
+++ b/src/appmixer/facebook/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.facebook",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -19,7 +19,7 @@
         "2.1.0": [
             "Added test() (Flow Test Mode) to the NewPagePost trigger."
         ],
-        "2.2.0": [
+        "2.2.1": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Facebook Graph API."
         ]
     }

--- a/src/appmixer/facebook/page/MakeApiCall/component.json
+++ b/src/appmixer/facebook/page/MakeApiCall/component.json
@@ -1,5 +1,5 @@
 {
-    "name": "appmixer.facebook.core.MakeApiCall",
+    "name": "appmixer.facebook.page.MakeApiCall",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Performs an arbitrary authorized API call to the Facebook Graph API.",
     "version": "1.0.0",

--- a/src/appmixer/facebookbusiness/bundle.json
+++ b/src/appmixer/facebookbusiness/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.facebookbusiness",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -21,7 +21,7 @@
         "3.0.1": [
             "Added output examples to component schemas."
         ],
-        "3.1.0": [
+        "3.1.1": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Facebook Marketing API."
         ]
     }

--- a/src/appmixer/facebookbusiness/marketing/MakeApiCall/component.json
+++ b/src/appmixer/facebookbusiness/marketing/MakeApiCall/component.json
@@ -1,5 +1,5 @@
 {
-    "name": "appmixer.facebookbusiness.core.MakeApiCall",
+    "name": "appmixer.facebookbusiness.marketing.MakeApiCall",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Performs an arbitrary authorized API call to the Facebook Marketing API.",
     "version": "1.0.0",

--- a/src/appmixer/fakturoid/accounting/MakeApiCall/component.json
+++ b/src/appmixer/fakturoid/accounting/MakeApiCall/component.json
@@ -1,5 +1,5 @@
 {
-    "name": "appmixer.fakturoid.core.MakeApiCall",
+    "name": "appmixer.fakturoid.accounting.MakeApiCall",
     "author": "Appmixer <info@appmixer.com>",
     "description": "Performs an arbitrary authorized API call to the Fakturoid API.",
     "version": "1.0.0",

--- a/src/appmixer/fakturoid/bundle.json
+++ b/src/appmixer/fakturoid/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.fakturoid",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -8,7 +8,7 @@
         "1.1.0": [
             "Added test() (Flow Test Mode) to all triggers: NewInvoice, NewEvent, NewTodo, ReportUpdated, AccountUpdated."
         ],
-        "1.2.0": [
+        "1.2.1": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Fakturoid API."
         ]
     }


### PR DESCRIPTION
## Summary

Publish of `appmixer.facebook` failed with:

```
appmixer/facebook/page/MakeApiCall/component.json name property doesn't match the file path
```

An audit of all MakeApiCall components found the same copy-paste mistake in 4 connectors — the `name` property said `<vendor>.core.MakeApiCall` while the component lives in a non-core module. Same class of bug as the docusign fix (#1199).

| Connector | Fixed name | Bundle |
|---|---|---|
| facebook | `appmixer.facebook.page.MakeApiCall` | 2.2.0 → 2.2.1 |
| facebookbusiness | `appmixer.facebookbusiness.marketing.MakeApiCall` | 3.1.0 → 3.1.1 |
| dropbox | `appmixer.dropbox.files.MakeApiCall` | 1.5.0 → 1.5.1 |
| fakturoid | `appmixer.fakturoid.accounting.MakeApiCall` | 1.2.0 → 1.2.1 |

The unreleased changelog entry was renamed to the patch version in each bundle.json (one version per PR, docusign #1199 pattern). The wrong names were never published anywhere (publish fails on the mismatch), so no `appmixer remove` is needed.

## Test plan

- `node scripts/validate.js --changed` passes (only pre-existing dropbox `auth.scope` warning, unrelated)
- All other MakeApiCall components in the repo verified to match their paths