### PR TITLE
hubbi(minor): add HubBI Flows API connector (start hubs, push records, hub event trigger)

### DIFF
--- a/src/appmixer/hubbi/artifacts/icon.svg
+++ b/src/appmixer/hubbi/artifacts/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" fill="#0B5FFF"/>
+  <circle cx="32" cy="32" r="7" fill="#FFFFFF"/>
+  <circle cx="14" cy="16" r="5" fill="#FFFFFF"/>
+  <circle cx="50" cy="16" r="5" fill="#FFFFFF"/>
+  <circle cx="14" cy="48" r="5" fill="#FFFFFF"/>
+  <circle cx="50" cy="48" r="5" fill="#FFFFFF"/>
+  <g stroke="#FFFFFF" stroke-width="3" stroke-linecap="round">
+    <line x1="27" y1="27" x2="18" y2="19"/>
+    <line x1="37" y1="27" x2="46" y2="19"/>
+    <line x1="27" y1="37" x2="18" y2="45"/>
+    <line x1="37" y1="37" x2="46" y2="45"/>
+  </g>
+</svg>

--- a/src/appmixer/hubbi/artifacts/test-flows/test-flow-makeapicall.json
+++ b/src/appmixer/hubbi/artifacts/test-flows/test-flow-makeapicall.json
@@ -1,0 +1,178 @@
+{
+    "name": "E2E HubBI - MakeApiCall list target hubs",
+    "type": "automation",
+    "flow": {
+        "7a205352-f70f-42a5-9f4a-4a4ea6649af2": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "c2e7535e-76ae-4189-b362-b51eae89ca84": {
+            "type": "appmixer.hubbi.core.MakeApiCall",
+            "x": 320,
+            "y": 16,
+            "source": {
+                "in": {
+                    "7a205352-f70f-42a5-9f4a-4a4ea6649af2": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "2.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "7a205352-f70f-42a5-9f4a-4a4ea6649af2": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "method": {},
+                                    "url": {},
+                                    "parameters": {},
+                                    "body": {},
+                                    "headers": {}
+                                },
+                                "lambda": {
+                                    "method": "GET",
+                                    "url": "/Flows/Home/ListTargetHubs"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "ac17cd03-1325-43e0-848f-43c4913805a3": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 640,
+            "y": 16,
+            "source": {
+                "in": {
+                    "c2e7535e-76ae-4189-b362-b51eae89ca84": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "c2e7535e-76ae-4189-b362-b51eae89ca84": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "9b1e-status": {
+                                            "variable": "$.c2e7535e-76ae-4189-b362-b51eae89ca84.out.status",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "expected": "200",
+                                                "assertion": "equal",
+                                                "field": "{{{9b1e-status}}}",
+                                                "type": "number"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "4769595c-3111-4df8-9621-3830f72c8634": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 900,
+            "y": 16,
+            "source": {
+                "in": {
+                    "ac17cd03-1325-43e0-848f-43c4913805a3": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 60
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "2cce5e33-8425-494b-a35d-0d81adbef8dd": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1160,
+            "y": 16,
+            "source": {
+                "in": {
+                    "4769595c-3111-4df8-9621-3830f72c8634": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "4769595c-3111-4df8-9621-3830f72c8634": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "tc-flowname": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "res-afterall": {
+                                            "variable": "$.4769595c-3111-4df8-9621-3830f72c8634.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "{{{tc-flowname}}}",
+                                    "result": "{{{res-afterall}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/hubbi/artifacts/test-flows/test-flow-makeapicall.json
+++ b/src/appmixer/hubbi/artifacts/test-flows/test-flow-makeapicall.json
@@ -84,8 +84,7 @@
                                             {
                                                 "expected": "200",
                                                 "assertion": "equal",
-                                                "field": "{{{9b1e-status}}}",
-                                                "type": "number"
+                                                "field": "{{{9b1e-status}}}"
                                             }
                                         ]
                                     }
@@ -143,15 +142,7 @@
                                 "type": "json2new",
                                 "modifiers": {
                                     "recipients": {},
-                                    "testCase": {
-                                        "tc-flowname": {
-                                            "functions": [
-                                                {
-                                                    "name": "g_flowName"
-                                                }
-                                            ]
-                                        }
-                                    },
+                                    "testCase": {},
                                     "result": {
                                         "res-afterall": {
                                             "variable": "$.4769595c-3111-4df8-9621-3830f72c8634.out",
@@ -161,7 +152,7 @@
                                 },
                                 "lambda": {
                                     "recipients": "test@appmixer.com",
-                                    "testCase": "{{{tc-flowname}}}",
+                                    "testCase": "E2E HubBI - MakeApiCall list target hubs",
                                     "result": "{{{res-afterall}}}"
                                 }
                             }

--- a/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthub.json
+++ b/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthub.json
@@ -40,7 +40,7 @@
                                             {
                                                 "type": "text",
                                                 "name": "conversionKey",
-                                                "text": "c1d2e3f4-0000-1111-2222-333344445555"
+                                                "text": "fc2b69aa-1853-44aa-9992-a43fb8bf9a2b"
                                             }
                                         ]
                                     }
@@ -128,15 +128,13 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "type": "string",
                                                 "assertion": "notEmpty",
                                                 "field": "{{{ck-check}}}"
                                             },
                                             {
                                                 "expected": "true",
                                                 "assertion": "equal",
-                                                "field": "{{{started-check}}}",
-                                                "type": "boolean"
+                                                "field": "{{{started-check}}}"
                                             }
                                         ]
                                     }
@@ -194,15 +192,7 @@
                                 "type": "json2new",
                                 "modifiers": {
                                     "recipients": {},
-                                    "testCase": {
-                                        "tc-flowname": {
-                                            "functions": [
-                                                {
-                                                    "name": "g_flowName"
-                                                }
-                                            ]
-                                        }
-                                    },
+                                    "testCase": {},
                                     "result": {
                                         "res-afterall": {
                                             "variable": "$.210776c3-20ff-4a24-82c2-ee8dac1b9a52.out",
@@ -212,7 +202,7 @@
                                 },
                                 "lambda": {
                                     "recipients": "test@appmixer.com",
-                                    "testCase": "{{{tc-flowname}}}",
+                                    "testCase": "E2E HubBI - StartHub without payload",
                                     "result": "{{{res-afterall}}}"
                                 }
                             }

--- a/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthub.json
+++ b/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthub.json
@@ -1,0 +1,229 @@
+{
+    "name": "E2E HubBI - StartHub without payload",
+    "type": "automation",
+    "flow": {
+        "4782d74c-0808-42d5-bc7d-e5b8059933e9": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f69578fc-3627-4d57-b9bf-b1a183760ee4": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 320,
+            "y": 16,
+            "source": {
+                "in": {
+                    "4782d74c-0808-42d5-bc7d-e5b8059933e9": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "4782d74c-0808-42d5-bc7d-e5b8059933e9": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "conversionKey",
+                                                "text": "c1d2e3f4-0000-1111-2222-333344445555"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "a8d66ba1-9f09-48e6-b78f-e420f6ecb1a6": {
+            "type": "appmixer.hubbi.core.StartHub",
+            "x": 576,
+            "y": 16,
+            "source": {
+                "in": {
+                    "f69578fc-3627-4d57-b9bf-b1a183760ee4": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "2.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "f69578fc-3627-4d57-b9bf-b1a183760ee4": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "conversionKey": {
+                                        "var-ck": {
+                                            "variable": "$.f69578fc-3627-4d57-b9bf-b1a183760ee4.out.conversionKey",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "conversionKey": "{{{var-ck}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "f6e8d185-8353-4c41-8b92-337e9f896da4": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 832,
+            "y": 16,
+            "source": {
+                "in": {
+                    "a8d66ba1-9f09-48e6-b78f-e420f6ecb1a6": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "a8d66ba1-9f09-48e6-b78f-e420f6ecb1a6": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "ck-check": {
+                                            "variable": "$.a8d66ba1-9f09-48e6-b78f-e420f6ecb1a6.out.conversionKey",
+                                            "functions": []
+                                        },
+                                        "started-check": {
+                                            "variable": "$.a8d66ba1-9f09-48e6-b78f-e420f6ecb1a6.out.started",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "type": "string",
+                                                "assertion": "notEmpty",
+                                                "field": "{{{ck-check}}}"
+                                            },
+                                            {
+                                                "expected": "true",
+                                                "assertion": "equal",
+                                                "field": "{{{started-check}}}",
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "210776c3-20ff-4a24-82c2-ee8dac1b9a52": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1088,
+            "y": 16,
+            "source": {
+                "in": {
+                    "f6e8d185-8353-4c41-8b92-337e9f896da4": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 60
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "2ebc2cc1-cdee-44b4-876c-593d799e6143": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1344,
+            "y": 16,
+            "source": {
+                "in": {
+                    "210776c3-20ff-4a24-82c2-ee8dac1b9a52": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "210776c3-20ff-4a24-82c2-ee8dac1b9a52": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "tc-flowname": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "res-afterall": {
+                                            "variable": "$.210776c3-20ff-4a24-82c2-ee8dac1b9a52.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "{{{tc-flowname}}}",
+                                    "result": "{{{res-afterall}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthubwithdata.json
+++ b/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthubwithdata.json
@@ -1,0 +1,243 @@
+{
+    "name": "E2E HubBI - StartHubWithData raw JSON records",
+    "type": "automation",
+    "flow": {
+        "218ebd83-8fa8-4f35-a9c2-eed81bb33942": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "504d7663-5cde-4ad1-926e-d26ee1221516": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 320,
+            "y": 16,
+            "source": {
+                "in": {
+                    "218ebd83-8fa8-4f35-a9c2-eed81bb33942": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "218ebd83-8fa8-4f35-a9c2-eed81bb33942": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "conversionKey",
+                                                "text": "a1b2c3d4-0000-1111-2222-333344445555"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "records",
+                                                "text": "[{\"Email\":\"e2e@appmixer.com\"}]"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "3ce51236-4751-4b8f-8786-74efa392daf4": {
+            "type": "appmixer.hubbi.core.StartHubWithData",
+            "x": 576,
+            "y": 16,
+            "source": {
+                "in": {
+                    "504d7663-5cde-4ad1-926e-d26ee1221516": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "2.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "504d7663-5cde-4ad1-926e-d26ee1221516": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "conversionKey": {
+                                        "var-ck": {
+                                            "variable": "$.504d7663-5cde-4ad1-926e-d26ee1221516.out.conversionKey",
+                                            "functions": []
+                                        }
+                                    },
+                                    "rawJson": {},
+                                    "records": {
+                                        "var-records": {
+                                            "variable": "$.504d7663-5cde-4ad1-926e-d26ee1221516.out.records",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "conversionKey": "{{{var-ck}}}",
+                                    "rawJson": true,
+                                    "records": "{{{var-records}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "4e17a39c-047f-4b65-817f-81f1c9ac63bb": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 832,
+            "y": 16,
+            "source": {
+                "in": {
+                    "3ce51236-4751-4b8f-8786-74efa392daf4": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "3ce51236-4751-4b8f-8786-74efa392daf4": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "ck-check": {
+                                            "variable": "$.3ce51236-4751-4b8f-8786-74efa392daf4.out.conversionKey",
+                                            "functions": []
+                                        },
+                                        "count-check": {
+                                            "variable": "$.3ce51236-4751-4b8f-8786-74efa392daf4.out.recordsCount",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "type": "string",
+                                                "assertion": "notEmpty",
+                                                "field": "{{{ck-check}}}"
+                                            },
+                                            {
+                                                "expected": "1",
+                                                "assertion": "equal",
+                                                "field": "{{{count-check}}}",
+                                                "type": "number"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "9ca9814e-db02-4b65-a159-1291eba9f1f5": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1088,
+            "y": 16,
+            "source": {
+                "in": {
+                    "4e17a39c-047f-4b65-817f-81f1c9ac63bb": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 60
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "3b91f533-37eb-4601-a304-6858a93d2d98": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1344,
+            "y": 16,
+            "source": {
+                "in": {
+                    "9ca9814e-db02-4b65-a159-1291eba9f1f5": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "9ca9814e-db02-4b65-a159-1291eba9f1f5": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {
+                                        "tc-flowname": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_flowName"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "result": {
+                                        "res-afterall": {
+                                            "variable": "$.9ca9814e-db02-4b65-a159-1291eba9f1f5.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "{{{tc-flowname}}}",
+                                    "result": "{{{res-afterall}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthubwithdata.json
+++ b/src/appmixer/hubbi/artifacts/test-flows/test-flow-starthubwithdata.json
@@ -40,7 +40,7 @@
                                             {
                                                 "type": "text",
                                                 "name": "conversionKey",
-                                                "text": "a1b2c3d4-0000-1111-2222-333344445555"
+                                                "text": "59bd2669-808c-480b-b594-034c372f45a4"
                                             },
                                             {
                                                 "type": "text",
@@ -142,15 +142,13 @@
                                     "expression": {
                                         "AND": [
                                             {
-                                                "type": "string",
                                                 "assertion": "notEmpty",
                                                 "field": "{{{ck-check}}}"
                                             },
                                             {
                                                 "expected": "1",
                                                 "assertion": "equal",
-                                                "field": "{{{count-check}}}",
-                                                "type": "number"
+                                                "field": "{{{count-check}}}"
                                             }
                                         ]
                                     }
@@ -208,15 +206,7 @@
                                 "type": "json2new",
                                 "modifiers": {
                                     "recipients": {},
-                                    "testCase": {
-                                        "tc-flowname": {
-                                            "functions": [
-                                                {
-                                                    "name": "g_flowName"
-                                                }
-                                            ]
-                                        }
-                                    },
+                                    "testCase": {},
                                     "result": {
                                         "res-afterall": {
                                             "variable": "$.9ca9814e-db02-4b65-a159-1291eba9f1f5.out",
@@ -226,7 +216,7 @@
                                 },
                                 "lambda": {
                                     "recipients": "test@appmixer.com",
-                                    "testCase": "{{{tc-flowname}}}",
+                                    "testCase": "E2E HubBI - StartHubWithData raw JSON records",
                                     "result": "{{{res-afterall}}}"
                                 }
                             }

--- a/src/appmixer/hubbi/auth.js
+++ b/src/appmixer/hubbi/auth.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// HubBI is deployed per tenant, so the base URL is part of the credentials rather than a
+// constant. Every call carries the clientKey query param and a Bearer JWT. HubBI exposes no
+// authorization-code flow for the Flows API, hence apiKey rather than OAuth2.
+module.exports = {
+
+    type: 'apiKey',
+
+    definition: {
+
+        tokenType: 'authentication-token',
+
+        auth: {
+            baseUrl: {
+                type: 'text',
+                name: 'Base URL',
+                tooltip: 'Your HubBI tenant base URL, e.g. <code>https://test-app.hubbi.nl</code> (no trailing slash).'
+            },
+            token: {
+                type: 'text',
+                name: 'API Token',
+                tooltip: 'Your HubBI JWT. Sent as <code>Authorization: Bearer &lt;token&gt;</code> on every request.'
+            },
+            clientKey: {
+                type: 'text',
+                name: 'Client Key',
+                tooltip: 'Your HubBI client identifier (UUID). Passed as the <code>clientKey</code> query parameter on every request.'
+            }
+        },
+
+        // Mask the client key to first/last three characters, e.g. "HubBI (abc...123)".
+        accountNameFromProfileInfo: context => {
+            const key = (context.clientKey || '').toString();
+            const masked = key.length > 6 ? `${key.slice(0, 3)}...${key.slice(-3)}` : key;
+            return `HubBI (${masked})`;
+        },
+
+        // There is no dedicated profile endpoint; probe ListTargetHubs to confirm the
+        // credentials work and reach a real tenant.
+        requestProfileInfo: async context => {
+            const baseUrl = (context.baseUrl || '').replace(/\/+$/, '');
+            const { data } = await context.httpRequest({
+                method: 'GET',
+                url: `${baseUrl}/Flows/Home/ListTargetHubs`,
+                params: { clientKey: context.clientKey },
+                headers: {
+                    Authorization: `Bearer ${context.token}`
+                }
+            });
+            return data;
+        },
+
+        validate: async context => {
+            const baseUrl = (context.baseUrl || '').replace(/\/+$/, '');
+            await context.httpRequest({
+                method: 'GET',
+                url: `${baseUrl}/Flows/Home/ListTargetHubs`,
+                params: { clientKey: context.clientKey },
+                headers: {
+                    Authorization: `Bearer ${context.token}`
+                }
+            });
+            // If the request doesn't throw, the credentials are valid.
+            return true;
+        }
+    }
+};

--- a/src/appmixer/hubbi/bundle.json
+++ b/src/appmixer/hubbi/bundle.json
@@ -1,0 +1,14 @@
+{
+    "name": "appmixer.hubbi",
+    "version": "2.0.0",
+    "changelog": {
+        "2.0.0": [
+            "Initial public release of the HubBI Flows API connector.",
+            "Actions: StartHub (fire-and-forget) and StartHubWithData (push one or more records).",
+            "Trigger: NewHubEvent (webhook) with dynamic output port options and test() support for Flow Test Mode.",
+            "MakeApiCall component for arbitrary HubBI Flows API requests.",
+            "Private hub/field picker helpers: ListSourceHubsWithPostData, ListSourceHubsWithoutPostData, ListTargetHubs, GetSourceFields, GetTargetFields.",
+            "Replaces the removed HubsList endpoint with the three dedicated list endpoints (source-with-data, source-without-data, target)."
+        ]
+    }
+}

--- a/src/appmixer/hubbi/core/GetSourceFields/GetSourceFields.js
+++ b/src/appmixer/hubbi/core/GetSourceFields/GetSourceFields.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const lib = require('../../lib');
+
+const SCHEMA = {
+    name: { type: 'string', title: 'Field Name', example: 'Email' },
+    type: { type: 'string', title: '.NET Type', example: 'String' },
+    required: { type: 'boolean', title: 'Required', example: false },
+    inspectorType: { type: 'string', title: 'Inspector Type', example: 'text' },
+    schemaType: { type: 'string', title: 'JSON Schema Type', example: 'string' }
+};
+
+module.exports = {
+
+    async receive(context) {
+
+        const { conversionKey, outputType } = context.messages.in.content;
+
+        if (context.properties.generateOutputPortOptions) {
+            return lib.getOutputPortOptions(context, outputType, SCHEMA, { label: 'Source Fields', value: 'result' });
+        }
+
+        if (!conversionKey) {
+            throw new context.CancelError('Hub (Conversion Key) is required!');
+        }
+
+        const fields = await lib.getFields(context, lib.ENDPOINTS.sourceFields, conversionKey);
+
+        return lib.sendArrayOutput({ context, outputType, records: fields });
+    }
+};

--- a/src/appmixer/hubbi/core/GetSourceFields/component.json
+++ b/src/appmixer/hubbi/core/GetSourceFields/component.json
@@ -1,0 +1,83 @@
+{
+    "name": "appmixer.hubbi.core.GetSourceFields",
+    "description": "Return the source field definitions (name, .NET type, required) that a HubBI hub accepts. Used internally.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": true,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "conversionKey": {
+                        "type": "string"
+                    },
+                    "outputType": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "conversionKey"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "conversionKey": {
+                        "type": "text",
+                        "label": "Hub",
+                        "index": 0,
+                        "tooltip": "The source hub (conversion key). Pick from the list or type a conversion key by hand.",
+                        "source": {
+                            "url": "/component/appmixer/hubbi/core/ListSourceHubsWithPostData?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/outputType": "array"
+                                },
+                                "transform": "./ListSourceHubsWithPostData#toSelectArray"
+                            }
+                        }
+                    },
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 1,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            { "label": "First Item Only", "value": "first" },
+                            { "label": "All items at once", "value": "array" },
+                            { "label": "One item at a time", "value": "object" },
+                            { "label": "Store to CSV file", "value": "file" }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/GetSourceFields?outPort=out&ignoreAuth=true",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/conversionKey": "inputs/in/conversionKey",
+                        "in/outputType": "inputs/in/outputType"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/GetTargetFields/GetTargetFields.js
+++ b/src/appmixer/hubbi/core/GetTargetFields/GetTargetFields.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const lib = require('../../lib');
+
+const SCHEMA = {
+    name: { type: 'string', title: 'Field Name', example: 'FullName' },
+    type: { type: 'string', title: '.NET Type', example: 'String' },
+    required: { type: 'boolean', title: 'Required', example: false },
+    inspectorType: { type: 'string', title: 'Inspector Type', example: 'text' },
+    schemaType: { type: 'string', title: 'JSON Schema Type', example: 'string' }
+};
+
+module.exports = {
+
+    async receive(context) {
+
+        const { conversionKey, outputType } = context.messages.in.content;
+
+        if (context.properties.generateOutputPortOptions) {
+            return lib.getOutputPortOptions(context, outputType, SCHEMA, { label: 'Target Fields', value: 'result' });
+        }
+
+        if (!conversionKey) {
+            throw new context.CancelError('Hub (Conversion Key) is required!');
+        }
+
+        const fields = await lib.getFields(context, lib.ENDPOINTS.targetFields, conversionKey);
+
+        return lib.sendArrayOutput({ context, outputType, records: fields });
+    }
+};

--- a/src/appmixer/hubbi/core/GetTargetFields/component.json
+++ b/src/appmixer/hubbi/core/GetTargetFields/component.json
@@ -1,0 +1,83 @@
+{
+    "name": "appmixer.hubbi.core.GetTargetFields",
+    "description": "Return the target field definitions (name, .NET type, required) that a HubBI hub emits. Used internally.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": true,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "conversionKey": {
+                        "type": "string"
+                    },
+                    "outputType": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "conversionKey"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "conversionKey": {
+                        "type": "text",
+                        "label": "Hub",
+                        "index": 0,
+                        "tooltip": "The target hub (conversion key). Pick from the list or type a conversion key by hand.",
+                        "source": {
+                            "url": "/component/appmixer/hubbi/core/ListTargetHubs?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/outputType": "array"
+                                },
+                                "transform": "./ListTargetHubs#toSelectArray"
+                            }
+                        }
+                    },
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 1,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            { "label": "First Item Only", "value": "first" },
+                            { "label": "All items at once", "value": "array" },
+                            { "label": "One item at a time", "value": "object" },
+                            { "label": "Store to CSV file", "value": "file" }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/GetTargetFields?outPort=out&ignoreAuth=true",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/conversionKey": "inputs/in/conversionKey",
+                        "in/outputType": "inputs/in/outputType"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/ListSourceHubsWithPostData/ListSourceHubsWithPostData.js
+++ b/src/appmixer/hubbi/core/ListSourceHubsWithPostData/ListSourceHubsWithPostData.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const lib = require('../../lib');
+
+const SCHEMA = {
+    name: { type: 'string', title: 'Hub Name', example: 'Contacts Import' },
+    conversionKey: { type: 'string', title: 'Conversion Key', example: 'a1b2c3d4-0000-1111-2222-333344445555' }
+};
+
+module.exports = {
+
+    async receive(context) {
+
+        const { outputType } = context.messages.in.content;
+
+        if (context.properties.generateOutputPortOptions) {
+            return lib.getOutputPortOptions(context, outputType, SCHEMA, { label: 'Source Hubs', value: 'result' });
+        }
+
+        const hubs = await lib.listHubs(context, lib.ENDPOINTS.listSourceHubsWithPostData);
+
+        return lib.sendArrayOutput({ context, outputType, records: hubs });
+    },
+
+    toSelectArray(msg) {
+        const items = msg.result || (Array.isArray(msg) ? msg : []);
+        return items.map(hub => ({ label: hub.name || hub.conversionKey, value: hub.conversionKey }));
+    }
+};

--- a/src/appmixer/hubbi/core/ListSourceHubsWithPostData/component.json
+++ b/src/appmixer/hubbi/core/ListSourceHubsWithPostData/component.json
@@ -1,0 +1,61 @@
+{
+    "name": "appmixer.hubbi.core.ListSourceHubsWithPostData",
+    "description": "List HubBI source hubs that accept a payload of records. Used internally to populate hub pickers.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": true,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outputType": {
+                        "type": "string"
+                    }
+                }
+            },
+            "inspector": {
+                "inputs": {
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 0,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            { "label": "First Item Only", "value": "first" },
+                            { "label": "All items at once", "value": "array" },
+                            { "label": "One item at a time", "value": "object" },
+                            { "label": "Store to CSV file", "value": "file" }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/ListSourceHubsWithPostData?outPort=out&ignoreAuth=true",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/outputType": "inputs/in/outputType"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/ListSourceHubsWithoutPostData/ListSourceHubsWithoutPostData.js
+++ b/src/appmixer/hubbi/core/ListSourceHubsWithoutPostData/ListSourceHubsWithoutPostData.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const lib = require('../../lib');
+
+const SCHEMA = {
+    name: { type: 'string', title: 'Hub Name', example: 'Nightly Sync' },
+    conversionKey: { type: 'string', title: 'Conversion Key', example: 'c1d2e3f4-0000-1111-2222-333344445555' }
+};
+
+module.exports = {
+
+    async receive(context) {
+
+        const { outputType } = context.messages.in.content;
+
+        if (context.properties.generateOutputPortOptions) {
+            return lib.getOutputPortOptions(context, outputType, SCHEMA, { label: 'Source Hubs', value: 'result' });
+        }
+
+        const hubs = await lib.listHubs(context, lib.ENDPOINTS.listSourceHubsWithoutPostData);
+
+        return lib.sendArrayOutput({ context, outputType, records: hubs });
+    },
+
+    toSelectArray(msg) {
+        const items = msg.result || (Array.isArray(msg) ? msg : []);
+        return items.map(hub => ({ label: hub.name || hub.conversionKey, value: hub.conversionKey }));
+    }
+};

--- a/src/appmixer/hubbi/core/ListSourceHubsWithoutPostData/component.json
+++ b/src/appmixer/hubbi/core/ListSourceHubsWithoutPostData/component.json
@@ -1,0 +1,61 @@
+{
+    "name": "appmixer.hubbi.core.ListSourceHubsWithoutPostData",
+    "description": "List HubBI source hubs that are started without a payload. Used internally to populate hub pickers.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": true,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outputType": {
+                        "type": "string"
+                    }
+                }
+            },
+            "inspector": {
+                "inputs": {
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 0,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            { "label": "First Item Only", "value": "first" },
+                            { "label": "All items at once", "value": "array" },
+                            { "label": "One item at a time", "value": "object" },
+                            { "label": "Store to CSV file", "value": "file" }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/ListSourceHubsWithoutPostData?outPort=out&ignoreAuth=true",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/outputType": "inputs/in/outputType"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/ListTargetHubs/ListTargetHubs.js
+++ b/src/appmixer/hubbi/core/ListTargetHubs/ListTargetHubs.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const lib = require('../../lib');
+
+const SCHEMA = {
+    name: { type: 'string', title: 'Hub Name', example: 'Contacts Export' },
+    conversionKey: { type: 'string', title: 'Conversion Key', example: 'b1a2c3d4-0000-1111-2222-333344445555' }
+};
+
+module.exports = {
+
+    async receive(context) {
+
+        const { outputType } = context.messages.in.content;
+
+        if (context.properties.generateOutputPortOptions) {
+            return lib.getOutputPortOptions(context, outputType, SCHEMA, { label: 'Target Hubs', value: 'result' });
+        }
+
+        const hubs = await lib.listHubs(context, lib.ENDPOINTS.listTargetHubs);
+
+        return lib.sendArrayOutput({ context, outputType, records: hubs });
+    },
+
+    toSelectArray(msg) {
+        const items = msg.result || (Array.isArray(msg) ? msg : []);
+        return items.map(hub => ({ label: hub.name || hub.conversionKey, value: hub.conversionKey }));
+    }
+};

--- a/src/appmixer/hubbi/core/ListTargetHubs/component.json
+++ b/src/appmixer/hubbi/core/ListTargetHubs/component.json
@@ -1,0 +1,61 @@
+{
+    "name": "appmixer.hubbi.core.ListTargetHubs",
+    "description": "List HubBI target hubs (hubs that emit records). Used internally to populate hub pickers.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": true,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "outputType": {
+                        "type": "string"
+                    }
+                }
+            },
+            "inspector": {
+                "inputs": {
+                    "outputType": {
+                        "type": "select",
+                        "label": "Output Type",
+                        "index": 0,
+                        "defaultValue": "array",
+                        "tooltip": "Choose whether you want to receive the result set as one complete list, or first item only or one item at a time or stream the items to a file.",
+                        "options": [
+                            { "label": "First Item Only", "value": "first" },
+                            { "label": "All items at once", "value": "array" },
+                            { "label": "One item at a time", "value": "object" },
+                            { "label": "Store to CSV file", "value": "file" }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/ListTargetHubs?outPort=out&ignoreAuth=true",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true
+                    },
+                    "messages": {
+                        "in/outputType": "inputs/in/outputType"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/MakeApiCall/MakeApiCall.js
+++ b/src/appmixer/hubbi/core/MakeApiCall/MakeApiCall.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const lib = require('../../lib');
+
+function kvToObj(arr) {
+    if (!arr || !Array.isArray(arr)) {
+        return {};
+    }
+    const out = {};
+    for (const row of arr) {
+        if (!row || typeof row !== 'object') {
+            continue;
+        }
+        const key = row.key;
+        if (typeof key !== 'string' || key.length === 0) {
+            continue;
+        }
+        out[key] = row.value;
+    }
+    return out;
+}
+
+module.exports = {
+
+    async receive(context) {
+
+        const { method, url, headers: headersKV, parameters: parametersKV, body } = context.messages.in.content;
+
+        if (!method) {
+            throw new context.CancelError('HTTP Method is required!');
+        }
+        if (!url) {
+            throw new context.CancelError('URL is required!');
+        }
+
+        const extraHeaders = kvToObj(headersKV);
+        const queryParams = kvToObj(parametersKV);
+
+        const baseUrl = lib.baseUrl(context);
+        const targetUrl = url.startsWith('http://') || url.startsWith('https://')
+            ? url
+            : `${baseUrl}${url.startsWith('/') ? url : '/' + url}`;
+
+        const requestOptions = {
+            method,
+            url: targetUrl,
+            params: {
+                clientKey: context.auth.clientKey,
+                ...queryParams
+            },
+            headers: {
+                Authorization: `Bearer ${context.auth.token}`,
+                'Content-Type': 'application/json',
+                ...extraHeaders
+            }
+        };
+
+        if (body) {
+            let parsedBody;
+            try {
+                parsedBody = typeof body === 'object' ? body : JSON.parse(body);
+            } catch (err) {
+                throw new context.CancelError('Request Body must be valid JSON.');
+            }
+            requestOptions.data = parsedBody;
+        }
+
+        const response = await context.httpRequest(requestOptions);
+
+        return context.sendJson({
+            status: response.status,
+            headers: response.headers,
+            body: response.data
+        }, 'out');
+    }
+};

--- a/src/appmixer/hubbi/core/MakeApiCall/component.json
+++ b/src/appmixer/hubbi/core/MakeApiCall/component.json
@@ -1,0 +1,110 @@
+{
+    "name": "appmixer.hubbi.core.MakeApiCall",
+    "description": "Make an authenticated request to the HubBI Flows API. The clientKey query parameter and Bearer token are added automatically.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": false,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "method": {
+                        "type": "string",
+                        "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "headers": {
+                        "type": "string"
+                    },
+                    "parameters": {
+                        "type": "string"
+                    },
+                    "body": {
+                        "type": "string"
+                    }
+                },
+                "required": ["method", "url"]
+            },
+            "inspector": {
+                "inputs": {
+                    "url": {
+                        "type": "text",
+                        "index": 1,
+                        "label": "URL",
+                        "tooltip": "The API endpoint path relative to your tenant base URL, e.g. <code>/Flows/Home/ListTargetHubs</code>. A full URL is also accepted."
+                    },
+                    "method": {
+                        "type": "select",
+                        "index": 2,
+                        "label": "HTTP Method",
+                        "defaultValue": "GET",
+                        "tooltip": "The HTTP method to use.",
+                        "options": [
+                            { "label": "GET", "value": "GET" },
+                            { "label": "POST", "value": "POST" },
+                            { "label": "PUT", "value": "PUT" },
+                            { "label": "PATCH", "value": "PATCH" },
+                            { "label": "DELETE", "value": "DELETE" }
+                        ]
+                    },
+                    "parameters": {
+                        "type": "key-value",
+                        "index": 3,
+                        "label": "Query Parameters",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "tooltip": "Extra query parameters. clientKey is added automatically."
+                    },
+                    "body": {
+                        "type": "textarea",
+                        "index": 4,
+                        "label": "Request Body",
+                        "tooltip": "Request body as JSON. Applies to POST/PUT/PATCH."
+                    },
+                    "headers": {
+                        "type": "key-value",
+                        "index": 5,
+                        "label": "Request Headers",
+                        "keyLabel": "Key",
+                        "valueLabel": "Value",
+                        "tooltip": "Extra request headers. Authorization is added automatically."
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "options": [
+                {
+                    "label": "Status Code",
+                    "value": "status",
+                    "schema": { "type": "integer", "example": 200 }
+                },
+                {
+                    "label": "Response Headers",
+                    "value": "headers",
+                    "schema": { "type": "object", "properties": {}, "example": {} }
+                },
+                {
+                    "label": "Response Body",
+                    "value": "body",
+                    "schema": { "type": "object", "properties": {}, "example": {} }
+                }
+            ]
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/NewHubEvent/NewHubEvent.js
+++ b/src/appmixer/hubbi/core/NewHubEvent/NewHubEvent.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const lib = require('../../lib');
+
+module.exports = {
+
+    // HubBI has no API to register a webhook, so start() cannot subscribe. Instead the trigger
+    // surfaces a read-only Webhook URL that the user copies into HubBI's own configuration; here
+    // we only record it in state.
+    async start(context) {
+        await context.saveState({ webhookUrl: context.getWebhookUrl() });
+    },
+
+    async receive(context) {
+
+        // Dynamic inspector: expose the read-only Webhook URL for the user to copy into HubBI.
+        if (context.properties.generateInspector) {
+            return context.sendJson({
+                inputs: {
+                    webhookUrl: {
+                        type: 'text',
+                        label: 'Webhook URL',
+                        readonly: true,
+                        defaultValue: context.getWebhookUrl(),
+                        tooltip: 'HubBI cannot register webhooks automatically. Copy this URL into your HubBI hub configuration so HubBI posts events here.'
+                    }
+                }
+            }, 'out');
+        }
+
+        // Dynamic output port options built from the hub's target field definitions. Unlike the
+        // List helpers (whose options come from a static schema and can set ignoreAuth=true), this
+        // path genuinely calls TargetFields and needs context.auth — so the source is left
+        // authenticated. Degrade to a generic option if the fields can't be fetched yet.
+        if (context.properties.generateOutputPortOptions) {
+            const conversionKey = context.properties.conversionKey;
+            const keyPicked = conversionKey && conversionKey.toString().indexOf('{{') === -1;
+            let fields = [];
+            if (keyPicked) {
+                try {
+                    fields = await lib.getFields(context, lib.ENDPOINTS.targetFields, conversionKey);
+                } catch (err) {
+                    await context.log({ step: 'Could not load target fields for output port options', message: err.message });
+                }
+            }
+            return context.sendJson(lib.fieldsToOutPortOptions(fields), 'out');
+        }
+
+        // Incoming webhook event from HubBI.
+        if (context.messages.webhook) {
+
+            const { data } = context.messages.webhook.content;
+            const event = data || {};
+            const configuredKey = context.properties.conversionKey;
+            const eventKey = event.conversionKey || event.ConversionKey;
+            const records = event.records || event.Records || (Array.isArray(event) ? event : []);
+
+            // Acknowledge (but do not emit) events for a different hub or with no records.
+            if (configuredKey && eventKey && eventKey !== configuredKey) {
+                await context.log({ step: 'Ignored event for a different hub', eventKey, configuredKey });
+                return context.response();
+            }
+            if (!Array.isArray(records) || records.length === 0) {
+                await context.log({ step: 'Ignored empty event', eventKey });
+                return context.response();
+            }
+
+            for (const record of records) {
+                await context.sendJson(record, 'out');
+            }
+            return context.response();
+        }
+    },
+
+    // Flow Test Mode: HubBI exposes no endpoint for past events, so synthesize a sample record
+    // from the hub's target field definitions (one fixed value per mapped type).
+    async test(context) {
+
+        const conversionKey = context.properties.conversionKey;
+        if (!conversionKey) {
+            throw new context.CancelError('Select a hub before testing.');
+        }
+
+        const fields = await lib.getFields(context, lib.ENDPOINTS.targetFields, conversionKey);
+        if (!fields.length) {
+            throw new context.CancelError('The selected hub has no target fields to synthesize a test record from.');
+        }
+
+        return context.sendJson(lib.synthesizeRecord(fields), 'out');
+    }
+};

--- a/src/appmixer/hubbi/core/NewHubEvent/component.json
+++ b/src/appmixer/hubbi/core/NewHubEvent/component.json
@@ -1,0 +1,74 @@
+{
+    "name": "appmixer.hubbi.core.NewHubEvent",
+    "description": "Fires when HubBI posts a hub event to the webhook URL. The output fields are built from the selected hub's target field definitions.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": false,
+    "webhook": true,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "properties": {
+        "schema": {
+            "type": "object",
+            "properties": {
+                "conversionKey": {
+                    "type": "string"
+                },
+                "webhookUrl": {}
+            },
+            "required": [
+                "conversionKey"
+            ]
+        },
+        "inspector": {
+            "inputs": {
+                "conversionKey": {
+                    "type": "text",
+                    "label": "Hub",
+                    "index": 0,
+                    "tooltip": "The target hub (conversion key) whose events you want to receive. Pick from the list or type a conversion key by hand.",
+                    "source": {
+                        "url": "/component/appmixer/hubbi/core/ListTargetHubs?outPort=out",
+                        "data": {
+                            "messages": {
+                                "in/outputType": "array"
+                            },
+                            "transform": "./ListTargetHubs#toSelectArray"
+                        }
+                    }
+                },
+                "webhookUrl": {
+                    "index": 1,
+                    "source": {
+                        "url": "/component/appmixer/hubbi/core/NewHubEvent?outPort=out",
+                        "data": {
+                            "properties": {
+                                "generateInspector": true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "outPorts": [
+        {
+            "name": "out",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/NewHubEvent?outPort=out",
+                "data": {
+                    "properties": {
+                        "generateOutputPortOptions": true,
+                        "conversionKey": "properties/conversionKey"
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/NewHubEvent/component.json
+++ b/src/appmixer/hubbi/core/NewHubEvent/component.json
@@ -43,7 +43,6 @@
                     }
                 },
                 "webhookUrl": {
-                    "index": 1,
                     "source": {
                         "url": "/component/appmixer/hubbi/core/NewHubEvent?outPort=out",
                         "data": {

--- a/src/appmixer/hubbi/core/StartHub/StartHub.js
+++ b/src/appmixer/hubbi/core/StartHub/StartHub.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const lib = require('../../lib');
+
+module.exports = {
+
+    async receive(context) {
+
+        const { conversionKey } = context.messages.in.content;
+
+        if (!conversionKey) {
+            throw new context.CancelError('Hub (Conversion Key) is required!');
+        }
+
+        // Fire-and-forget: HubsStart just kicks off the hub, there is no payload.
+        await lib.hubbiRequest(context, {
+            method: 'GET',
+            endpoint: lib.ENDPOINTS.hubsStart,
+            conversionKey
+        });
+
+        return context.sendJson({ conversionKey, started: true }, 'out');
+    }
+};

--- a/src/appmixer/hubbi/core/StartHub/component.json
+++ b/src/appmixer/hubbi/core/StartHub/component.json
@@ -1,0 +1,70 @@
+{
+    "name": "appmixer.hubbi.core.StartHub",
+    "description": "Start a HubBI hub (fire-and-forget), without sending any payload.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": false,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "conversionKey": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "conversionKey"
+                ]
+            },
+            "inspector": {
+                "inputs": {
+                    "conversionKey": {
+                        "type": "text",
+                        "label": "Hub",
+                        "index": 0,
+                        "tooltip": "The hub to start (conversion key). Pick from the list or type a conversion key by hand.",
+                        "source": {
+                            "url": "/component/appmixer/hubbi/core/ListSourceHubsWithoutPostData?outPort=out",
+                            "data": {
+                                "messages": {
+                                    "in/outputType": "array"
+                                },
+                                "transform": "./ListSourceHubsWithoutPostData#toSelectArray"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "conversionKey": {
+                        "type": "string",
+                        "title": "Conversion Key",
+                        "example": "c1d2e3f4-0000-1111-2222-333344445555"
+                    },
+                    "started": {
+                        "type": "boolean",
+                        "title": "Started",
+                        "example": true
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/core/StartHubWithData/StartHubWithData.js
+++ b/src/appmixer/hubbi/core/StartHubWithData/StartHubWithData.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const lib = require('../../lib');
+
+// The inspector is generated from the selected hub's SourceFields, so the input form changes
+// depending on which hub is picked (there is no static field list). A "raw JSON" toggle lets the
+// user supply a full array of records for bulk pushes instead of the generated per-field inputs.
+async function generateInspector(context) {
+
+    const conversionKey = context.properties.conversionKey;
+    const rawJson = context.properties.rawJson;
+    const keyPicked = conversionKey && conversionKey.toString().indexOf('{{') === -1;
+
+    let fields = [];
+    if (keyPicked && !rawJson) {
+        fields = await lib.getFields(context, lib.ENDPOINTS.sourceFields, conversionKey);
+    }
+
+    const inputs = {
+        conversionKey: {
+            type: 'text',
+            label: 'Hub',
+            index: 0,
+            tooltip: 'The hub to start (conversion key). Pick from the list or type a conversion key by hand.',
+            source: {
+                url: '/component/appmixer/hubbi/core/ListSourceHubsWithPostData?outPort=out',
+                data: {
+                    messages: { 'in/outputType': 'array' },
+                    transform: './ListSourceHubsWithPostData#toSelectArray'
+                }
+            }
+        },
+        rawJson: {
+            type: 'toggle',
+            label: 'Input records as raw JSON',
+            index: 1,
+            defaultValue: false,
+            tooltip: 'Turn on to provide a JSON array of records (useful for bulk pushes). Turn off to fill the hub fields one by one.'
+        }
+    };
+
+    const schema = {
+        conversionKey: { type: 'string' },
+        rawJson: { type: 'boolean' }
+    };
+
+    if (rawJson) {
+        inputs.records = {
+            type: 'textarea',
+            label: 'Records (JSON array)',
+            index: 2,
+            tooltip: 'A JSON array of record objects, e.g. [{"Email":"a@b.com"},{"Email":"c@d.com"}].'
+        };
+        schema.records = { type: 'string' };
+    } else {
+        Object.assign(inputs, lib.fieldsToInspectorInputs(fields, 10));
+        Object.assign(schema, lib.fieldsToInspectorSchema(fields));
+    }
+
+    return context.sendJson({ schema, inputs }, 'out');
+}
+
+module.exports = {
+
+    async receive(context) {
+
+        if (context.properties.generateInspector) {
+            return generateInspector(context);
+        }
+
+        const content = context.messages.in.content || {};
+        const { conversionKey, rawJson, records: rawRecords, ...fieldValues } = content;
+
+        if (!conversionKey) {
+            throw new context.CancelError('Hub (Conversion Key) is required!');
+        }
+
+        let records;
+        if (rawJson) {
+            try {
+                records = typeof rawRecords === 'object' ? rawRecords : JSON.parse(rawRecords || '[]');
+            } catch (err) {
+                throw new context.CancelError('Records must be a valid JSON array.');
+            }
+            if (!Array.isArray(records)) {
+                records = [records];
+            }
+        } else {
+            const record = {};
+            Object.keys(fieldValues).forEach(key => {
+                const value = fieldValues[key];
+                if (value !== undefined && value !== null && value !== '') {
+                    record[key] = value;
+                }
+            });
+            records = [record];
+        }
+
+        // HubsStartWithData takes a JSON array body — all records go in one request.
+        await lib.hubbiRequest(context, {
+            method: 'POST',
+            endpoint: lib.ENDPOINTS.hubsStartWithData,
+            conversionKey,
+            body: records
+        });
+
+        return context.sendJson({ conversionKey, recordsCount: records.length }, 'out');
+    }
+};

--- a/src/appmixer/hubbi/core/StartHubWithData/component.json
+++ b/src/appmixer/hubbi/core/StartHubWithData/component.json
@@ -1,0 +1,50 @@
+{
+    "name": "appmixer.hubbi.core.StartHubWithData",
+    "description": "Start a HubBI hub with a payload of one or more records. The record fields are built from the selected hub's source field definitions.",
+    "author": "Appmixer <info@appmixer.com>",
+    "version": "2.0.0",
+    "private": false,
+    "auth": {
+        "service": "appmixer:hubbi"
+    },
+    "quota": {
+        "manager": "appmixer:hubbi",
+        "resources": "requests"
+    },
+    "inPorts": [
+        {
+            "name": "in",
+            "source": {
+                "url": "/component/appmixer/hubbi/core/StartHubWithData?outPort=out",
+                "data": {
+                    "properties": {
+                        "generateInspector": true,
+                        "conversionKey": "inputs/in/conversionKey",
+                        "rawJson": "inputs/in/rawJson"
+                    }
+                }
+            }
+        }
+    ],
+    "outPorts": [
+        {
+            "name": "out",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "conversionKey": {
+                        "type": "string",
+                        "title": "Conversion Key",
+                        "example": "a1b2c3d4-0000-1111-2222-333344445555"
+                    },
+                    "recordsCount": {
+                        "type": "integer",
+                        "title": "Records Count",
+                        "example": 3
+                    }
+                }
+            }
+        }
+    ],
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}

--- a/src/appmixer/hubbi/lib.js
+++ b/src/appmixer/hubbi/lib.js
@@ -1,0 +1,336 @@
+'use strict';
+
+const pathModule = require('path');
+
+const DEFAULT_PREFIX = 'hubbi-objects-export';
+
+// All Flows API endpoints live under {baseUrl}/Flows/Home/. Every call carries clientKey;
+// hub-scoped calls also carry conversionKey. HubsStartWithData is the only POST.
+const ENDPOINTS = {
+    listSourceHubsWithPostData: 'ListSourceHubsWithPostData',
+    listSourceHubsWithoutPostData: 'ListSourceHubsWithoutPostData',
+    listTargetHubs: 'ListTargetHubs',
+    sourceFields: 'SourceFields',
+    targetFields: 'TargetFields',
+    hubsStart: 'HubsStart',
+    hubsStartWithData: 'HubsStartWithData'
+};
+
+const lib = {
+
+    ENDPOINTS,
+
+    baseUrl(context) {
+        return ((context.auth && context.auth.baseUrl) || '').replace(/\/+$/, '');
+    },
+
+    /**
+     * Perform a HubBI Flows API request. Adds the clientKey (and optional conversionKey) query
+     * params and the Bearer token, and routes failures through rethrowHubbiError so the engine's
+     * retry behaviour matches HubBI's semantics.
+     * @param {object} context
+     * @param {object} options - { method, endpoint, conversionKey, body, params }
+     * @returns {Promise<*>} The response body.
+     */
+    async hubbiRequest(context, { method = 'GET', endpoint, conversionKey, body, params = {} } = {}) {
+
+        const query = { clientKey: context.auth.clientKey, ...params };
+        if (conversionKey) {
+            query.conversionKey = conversionKey;
+        }
+
+        const request = {
+            method,
+            url: `${lib.baseUrl(context)}/Flows/Home/${endpoint}`,
+            params: query,
+            headers: {
+                Authorization: `Bearer ${context.auth.token}`,
+                'Content-Type': 'application/json'
+            }
+        };
+        if (body !== undefined) {
+            request.data = body;
+        }
+
+        try {
+            const response = await context.httpRequest(request);
+            return response.data;
+        } catch (err) {
+            return lib.rethrowHubbiError(context, err);
+        }
+    },
+
+    /**
+     * Override the engine's default retry classification for two HubBI-specific statuses:
+     *  - 409 Conflict: rethrown as a plain Error so the engine treats it as unknown and RETRIES
+     *    (it would otherwise be dropped as a permanent client error).
+     *  - 423 Locked: converted to CancelError so the engine does NOT retry (it would otherwise
+     *    retry indefinitely).
+     * Everything else is rethrown unchanged.
+     */
+    rethrowHubbiError(context, err) {
+
+        const status = err && err.response && err.response.status;
+        const detail = (err && err.response && err.response.data) || (err && err.message) || '';
+
+        if (status === 409) {
+            throw new Error(`HubBI returned 409 Conflict: ${lib.stringifyDetail(detail)}`);
+        }
+        if (status === 423) {
+            throw new context.CancelError(`HubBI returned 423 Locked: ${lib.stringifyDetail(detail)}`);
+        }
+        throw err;
+    },
+
+    stringifyDetail(detail) {
+        if (detail === null || detail === undefined) {
+            return '';
+        }
+        return typeof detail === 'string' ? detail : JSON.stringify(detail);
+    },
+
+    async listHubs(context, endpoint) {
+        const data = await lib.hubbiRequest(context, { method: 'GET', endpoint });
+        return lib.normalizeHubs(data);
+    },
+
+    async getFields(context, endpoint, conversionKey) {
+        const data = await lib.hubbiRequest(context, { method: 'GET', endpoint, conversionKey });
+        return lib.normalizeFields(data);
+    },
+
+    // HubBI is a .NET service; list/field payloads may arrive PascalCase or wrapped. Normalize
+    // defensively so a shape change (this API has changed under us before) is less likely to break
+    // the pickers.
+    normalizeHubs(data) {
+        const arr = Array.isArray(data)
+            ? data
+            : (data && (data.hubs || data.Hubs || data.result || data.data)) || [];
+        return arr
+            .map(item => ({
+                name: item.name || item.Name || item.hubName || item.HubName || item.label || item.Label || '',
+                conversionKey: item.conversionKey || item.ConversionKey || item.key || item.Key || item.id || item.Id || ''
+            }))
+            .filter(hub => hub.conversionKey);
+    },
+
+    normalizeFields(data) {
+        const arr = Array.isArray(data)
+            ? data
+            : (data && (data.fields || data.Fields || data.result || data.data)) || [];
+        return arr
+            .map(item => {
+                const name = item.name || item.Name || item.fieldName || item.FieldName || '';
+                const netType = item.type || item.Type || item.dataType || item.DataType || item.netType || item.NetType || 'String';
+                const required = !!(item.required || item.Required || item.isRequired || item.IsRequired);
+                const mapped = lib.mapFieldType(netType);
+                return {
+                    name,
+                    type: netType,
+                    required,
+                    inspectorType: mapped.inspectorType,
+                    schemaType: mapped.schemaType,
+                    schemaFormat: mapped.schemaFormat
+                };
+            })
+            .filter(field => field.name);
+    },
+
+    /**
+     * Map a .NET type name to an Appmixer inspector type and a JSON Schema type (+ optional
+     * format), so e.g. a DateTime field renders as a date-time picker. Unknown types degrade to
+     * string.
+     */
+    mapFieldType(dotNetType) {
+
+        const type = (dotNetType || '').toString().trim();
+
+        switch (type) {
+            case 'Byte':
+            case 'SByte':
+            case 'Int16':
+            case 'Int32':
+            case 'Int64':
+            case 'UInt16':
+            case 'UInt32':
+            case 'UInt64':
+                return { inspectorType: 'number', schemaType: 'integer' };
+            case 'Single':
+            case 'Float':
+            case 'Double':
+            case 'Decimal':
+                return { inspectorType: 'number', schemaType: 'number' };
+            case 'Boolean':
+            case 'Bool':
+                return { inspectorType: 'toggle', schemaType: 'boolean' };
+            case 'Date':
+            case 'DateTime':
+            case 'DateTimeOffset':
+                return { inspectorType: 'date-time', schemaType: 'string', schemaFormat: 'date-time' };
+            case 'Guid':
+            case 'Char':
+            case 'String':
+            default:
+                return { inspectorType: 'text', schemaType: 'string' };
+        }
+    },
+
+    // Build inspector inputs (one per field) for a dynamically generated record form.
+    fieldsToInspectorInputs(fields, startIndex = 10) {
+        const inputs = {};
+        fields.forEach((field, i) => {
+            const input = {
+                type: field.inspectorType,
+                label: field.name,
+                index: startIndex + i,
+                tooltip: `HubBI source field "${field.name}" (${field.type}).`
+            };
+            if (field.required) {
+                input.required = true;
+            }
+            inputs[field.name] = input;
+        });
+        return inputs;
+    },
+
+    // Matching JSON Schema properties for the dynamically generated inputs above.
+    fieldsToInspectorSchema(fields) {
+        const properties = {};
+        fields.forEach(field => {
+            const property = { type: field.schemaType };
+            if (field.schemaFormat) {
+                property.format = field.schemaFormat;
+            }
+            properties[field.name] = property;
+        });
+        return properties;
+    },
+
+    // Per-field option list for a trigger's dynamic output port (value = field name).
+    fieldsToOutPortOptions(fields) {
+        if (!fields.length) {
+            return [{
+                label: 'Records',
+                value: 'records',
+                schema: { type: 'array', items: { type: 'object' } }
+            }];
+        }
+        return fields.map(field => {
+            const schema = { type: field.schemaType, example: lib.sampleValue(field) };
+            if (field.schemaFormat) {
+                schema.format = field.schemaFormat;
+            }
+            return { label: field.name, value: field.name, schema };
+        });
+    },
+
+    // A fixed, plausible value per mapped type — used by NewHubEvent.test() to synthesize a
+    // sample record (HubBI exposes no endpoint for past events).
+    sampleValue(field) {
+        if (field.schemaType === 'integer') {
+            return 42;
+        }
+        if (field.schemaType === 'number') {
+            return 3.14;
+        }
+        if (field.schemaType === 'boolean') {
+            return true;
+        }
+        if (field.schemaFormat === 'date-time') {
+            return '2025-01-15T10:30:00Z';
+        }
+        if (field.type === 'Guid') {
+            return '00000000-0000-0000-0000-000000000000';
+        }
+        return 'sample';
+    },
+
+    synthesizeRecord(fields) {
+        const record = {};
+        fields.forEach(field => {
+            record[field.name] = lib.sampleValue(field);
+        });
+        return record;
+    },
+
+    async sendArrayOutput({ context, outputPortName = 'out', outputType = 'array', records = [] }) {
+
+        if (outputType === 'first') {
+            if (records.length === 0) {
+                throw new context.CancelError('No records available for first output type');
+            }
+            await context.sendJson({ ...records[0], index: 0, count: records.length }, outputPortName);
+        } else if (outputType === 'object') {
+            for (let index = 0; index < records.length; index++) {
+                await context.sendJson({ ...records[index], index, count: records.length }, outputPortName);
+            }
+        } else if (outputType === 'array') {
+            await context.sendJson({ result: records, count: records.length }, outputPortName);
+        } else if (outputType === 'file') {
+            const csvString = toCsv(records);
+            const buffer = Buffer.from(csvString, 'utf8');
+            const componentName = context.flowDescriptor[context.componentId].label || context.componentId;
+            const fileName = `${(context.config && context.config.outputFilePrefix) || DEFAULT_PREFIX}-${componentName}.csv`;
+            const savedFile = await context.saveFileStream(pathModule.normalize(fileName), buffer);
+            await context.log({ step: 'File was saved', fileName, fileId: savedFile.fileId });
+            await context.sendJson({ fileId: savedFile.fileId }, outputPortName);
+        } else {
+            throw new context.CancelError('Unsupported outputType ' + outputType);
+        }
+    },
+
+    getOutputPortOptions(context, outputType, itemSchema, { label, value }) {
+
+        if (outputType === 'object' || outputType === 'first') {
+            const options = Object.keys(itemSchema).reduce((res, field) => {
+                const schema = itemSchema[field];
+                const { title: fieldLabel, ...schemaWithoutTitle } = schema;
+                res.push({ label: fieldLabel, value: field, schema: schemaWithoutTitle });
+                return res;
+            }, [
+                { label: 'Current Item Index', value: 'index', schema: { type: 'integer' } },
+                { label: 'Items Count', value: 'count', schema: { type: 'integer' } }
+            ]);
+            return context.sendJson(options, 'out');
+        }
+
+        if (outputType === 'array') {
+            return context.sendJson([{
+                label,
+                value,
+                schema: {
+                    type: 'array',
+                    items: { type: 'object', properties: itemSchema }
+                }
+            }, {
+                label: 'Items Count',
+                value: 'count',
+                schema: { type: 'integer' }
+            }], 'out');
+        }
+
+        if (outputType === 'file') {
+            return context.sendJson([{ label: 'File ID', value: 'fileId' }], 'out');
+        }
+    }
+};
+
+function toCsv(array) {
+    if (!array || array.length === 0) {
+        return '';
+    }
+    const headers = Object.keys(array[0]);
+    return [
+        headers.join(','),
+        ...array.map(item => {
+            return Object.values(item).map(property => {
+                if (typeof property === 'object') {
+                    return JSON.stringify(property);
+                }
+                return property;
+            }).join(',');
+        })
+    ].join('\n');
+}
+
+module.exports = lib;

--- a/src/appmixer/hubbi/quota.js
+++ b/src/appmixer/hubbi/quota.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+
+    rules: [
+        {
+            limit: 5,
+            window: 1000,
+            queueing: 'fifo',
+            resource: 'requests'
+        }
+    ]
+};

--- a/src/appmixer/hubbi/service.json
+++ b/src/appmixer/hubbi/service.json
@@ -1,0 +1,8 @@
+{
+    "name": "appmixer.hubbi",
+    "label": "HubBI",
+    "category": "applications",
+    "description": "Drive HubBI hubs (data conversion pipelines) from Appmixer — start hubs, push records, and receive hub events.",
+    "version": "2.0.0",
+    "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzBCNUZGRiIvPgogIDxjaXJjbGUgY3g9IjMyIiBjeT0iMzIiIHI9IjciIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSIxNCIgY3k9IjE2IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSIxNiIgcj0iNSIgZmlsbD0iI0ZGRkZGRiIvPgogIDxjaXJjbGUgY3g9IjE0IiBjeT0iNDgiIHI9IjUiIGZpbGw9IiNGRkZGRkYiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjQ4IiByPSI1IiBmaWxsPSIjRkZGRkZGIi8+CiAgPGcgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICA8bGluZSB4MT0iMjciIHkxPSIyNyIgeDI9IjE4IiB5Mj0iMTkiLz4KICAgIDxsaW5lIHgxPSIzNyIgeTE9IjI3IiB4Mj0iNDYiIHkyPSIxOSIvPgogICAgPGxpbmUgeDE9IjI3IiB5MT0iMzciIHgyPSIxOCIgeTI9IjQ1Ii8+CiAgICA8bGluZSB4MT0iMzciIHkxPSIzNyIgeDI9IjQ2IiB5Mj0iNDUiLz4KICA8L2c+Cjwvc3ZnPgo="
+}


### PR DESCRIPTION
## HubBI — Flows API connector

Adds `src/appmixer/hubbi`, a new **action + trigger** connector for HubBI's Flows API — the surface HubBI exposes for driving its "hubs" (data-conversion pipelines) from the outside. The API is small and purpose-built (no CRUD, no read API for past events, no pagination), so the connector maps onto it one-to-one.

Implements the connector described in Appmixer-ai/appmixer-components#2787.

### Authentication (`apiKey`)
HubBI is deployed per tenant, so the base URL is part of the credentials:

| Field | Notes |
|---|---|
| `baseUrl` | Tenant base URL, e.g. `https://test-app.hubbi.nl` |
| `token` | HubBI JWT, sent as `Authorization: Bearer <token>` |
| `clientKey` | Client identifier (UUID), sent as the `clientKey` query param on every call |

`validate`/`requestProfileInfo` probe `ListTargetHubs`; the account name masks the client key to first/last three characters (`HubBI (abc...123)`). No OAuth2 — HubBI exposes no authorization-code flow for the Flows API.

### Components

| Component | Type | Public | Purpose |
|---|---|:-:|---|
| `StartHub` | Action | ✅ | Start a hub with no payload (`HubsStart`) |
| `StartHubWithData` | Action | ✅ | Start a hub with one or more records (`HubsStartWithData`, POST) |
| `NewHubEvent` | Trigger (webhook) | ✅ | Fires when HubBI posts a hub event |
| `MakeApiCall` | Action | ✅ | Arbitrary authenticated Flows API request |
| `ListSourceHubsWithPostData` | List | — | Hub picker source |
| `ListSourceHubsWithoutPostData` | List | — | Hub picker source |
| `ListTargetHubs` | List | — | Hub picker source + auth validation |
| `GetSourceFields` | List | — | Source field definitions |
| `GetTargetFields` | List | — | Target field definitions |

### Design notes
- **Input/output shapes are generated from the hub, not hardcoded.** `StartHubWithData` builds its inspector from the selected hub's `SourceFields` (with a raw-JSON toggle for bulk pushes); `NewHubEvent` builds its output port options from `TargetFields`.
- **.NET type mapping.** `lib.mapFieldType()` maps HubBI's .NET type names (`Int32`, `Double`, `DateTime`, `Guid`, `Boolean`, …) to an Appmixer inspector type and a JSON Schema type; unknown types degrade to `string`.
- **Bulk records.** `StartHubWithData` sends a JSON **array** body in one request and reports the record count.
- **Custom retry classification.** `lib.rethrowHubbiError()` rethrows **409 Conflict** as a plain `Error` (engine treats as unknown → retries) and converts **423 Locked** to `CancelError` (engine does not retry).
- **Manual webhook registration.** HubBI has no API to register webhooks, so `NewHubEvent.start()` only records the URL in state and the trigger surfaces a read-only **Webhook URL** for the user to paste into HubBI.
- **Foreign/empty events acknowledged, not emitted.** Events for a different `conversionKey`, or with no records, are logged and answered with `context.response()`.
- **`test()` synthesizes rather than fetches.** No endpoint exists for past events, so Flow Test Mode builds a sample record from the hub's target field definitions.
- **Quota:** 5 req/s, FIFO (`quota.js`).

### Follow-ups from the issue addressed here
- Hub pickers are `text` (typeahead) bound to dynamic sources, so a conversion key can still be typed by hand (fixes `no-select-with-source`).
- `GetSourceFields`/`GetTargetFields` pass their required `conversionKey` to the port-options request (fixes `dynamic-outport-required-inputs` for those).
- `MakeApiCall` added (satisfies `connector-has-makeapicall`).
- `version` set in `service.json`.

### Validation
- `npm run lint` — clean.
- `node scripts/validate.js --connector hubbi` — **1 remaining advisory**: `dynamic-outport-required-inputs` recommends `ignoreAuth=true` on `NewHubEvent`'s output-port source. This is left **intentionally authenticated**: unlike the List helpers (whose options come from a static schema), `NewHubEvent`'s option generation genuinely calls `TargetFields` and needs `context.auth`, exactly as the issue's §7.2 caveat warns. The call is guarded so it degrades to a generic option if fields can't be fetched.

### Notes / assumptions for review
- The exact JSON shapes of the HubBI list/field endpoints were not verifiable without a live tenant; the connector normalizes both PascalCase and camelCase defensively (`lib.normalizeHubs`/`normalizeFields`). Worth confirming against a real tenant.
- Bundle version is `2.0.0` per the issue (the connector carried 1.x versions during earlier development, including the removed `HubsList` endpoint).
- No E2E flows and no live-tenant verification in this PR — those are handled in a separate step and require a HubBI test tenant.

Closes Appmixer-ai/appmixer-components#2787
