### PR TITLE
microsoft: surface Graph error body in makeRequest instead of bare status code

### DIFF
--- a/src/appmixer/microsoft/artifacts/test-flows/test-flow-calendar-event-lifecycle.json
+++ b/src/appmixer/microsoft/artifacts/test-flows/test-flow-calendar-event-lifecycle.json
@@ -251,10 +251,12 @@
                             "out": {
                                 "type": "json2new",
                                 "modifiers": {
-                                    "outputType": {}
+                                    "outputType": {},
+                                    "maxRecords": {}
                                 },
                                 "lambda": {
-                                    "outputType": "array"
+                                    "outputType": "array",
+                                    "maxRecords": 5
                                 }
                             }
                         }
@@ -491,7 +493,7 @@
                                                     "name": "g_jsonPath",
                                                     "params": [
                                                         {
-                                                            "value": "$[0].id"
+                                                            "value": "$.result[0].id"
                                                         }
                                                     ]
                                                 }

--- a/src/appmixer/microsoft/artifacts/test-flows/test-flow-calendar-event-lifecycle.json
+++ b/src/appmixer/microsoft/artifacts/test-flows/test-flow-calendar-event-lifecycle.json
@@ -1,0 +1,637 @@
+{
+    "name": "E2E Microsoft Calendar - Event Lifecycle",
+    "type": "automation",
+    "flow": {
+        "3a43a949-d14e-4354-86c9-100e3ac8350c": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 100,
+            "y": 320,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "8989f722-f128-4c3f-ab4a-3479a035872c": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 300,
+            "y": 320,
+            "source": {
+                "in": {
+                    "3a43a949-d14e-4354-86c9-100e3ac8350c": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "3a43a949-d14e-4354-86c9-100e3ac8350c": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "subject",
+                                                "text": "E2E Microsoft Calendar Event"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "updatedSubject",
+                                                "text": "E2E Microsoft Calendar Event Updated"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "location",
+                                                "text": "Appmixer E2E Room"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "body",
+                                                "text": "Created by the Microsoft connector E2E test flow."
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": {
+            "type": "appmixer.microsoft.calendar.CreateEvent",
+            "x": 500,
+            "y": 320,
+            "source": {
+                "in": {
+                    "8989f722-f128-4c3f-ab4a-3479a035872c": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "8989f722-f128-4c3f-ab4a-3479a035872c": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "subject": {
+                                        "4e287c45-86f5-44d6-9392-e45d56bbe3d6": {
+                                            "variable": "$.8989f722-f128-4c3f-ab4a-3479a035872c.out.subject",
+                                            "functions": []
+                                        }
+                                    },
+                                    "location": {
+                                        "ee23c2ed-24bc-46ef-884e-927627ec9780": {
+                                            "variable": "$.8989f722-f128-4c3f-ab4a-3479a035872c.out.location",
+                                            "functions": []
+                                        }
+                                    },
+                                    "body": {
+                                        "40157d7b-25e9-4055-b696-a2cedc476e8c": {
+                                            "variable": "$.8989f722-f128-4c3f-ab4a-3479a035872c.out.body",
+                                            "functions": []
+                                        }
+                                    },
+                                    "start": {
+                                        "953bcd5c-4609-49fb-85ac-c8c1bb3d87d3": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_now"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "end": {
+                                        "2ec437ab-a7d3-4314-a345-63c387140127": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_now"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "subject": "{{{4e287c45-86f5-44d6-9392-e45d56bbe3d6}}}",
+                                    "location": "{{{ee23c2ed-24bc-46ef-884e-927627ec9780}}}",
+                                    "body": "{{{40157d7b-25e9-4055-b696-a2cedc476e8c}}}",
+                                    "start": "{{{953bcd5c-4609-49fb-85ac-c8c1bb3d87d3}}}",
+                                    "end": "{{{2ec437ab-a7d3-4314-a345-63c387140127}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "f5d8bea0-e26a-4483-aaa0-6cf95e3a483b": {
+            "type": "appmixer.microsoft.calendar.GetEvent",
+            "x": 700,
+            "y": 320,
+            "source": {
+                "in": {
+                    "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "eventId": {
+                                        "9fcfdb04-7b60-46cc-8294-61feef321e31": {
+                                            "variable": "$.fcf085b0-3d24-49d0-9666-3f35d2a1cf28.out.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "eventId": "{{{9fcfdb04-7b60-46cc-8294-61feef321e31}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "2a0b10a8-6cd1-4504-9fb0-694e80b340a7": {
+            "type": "appmixer.microsoft.calendar.UpdateEvent",
+            "x": 900,
+            "y": 320,
+            "source": {
+                "in": {
+                    "f5d8bea0-e26a-4483-aaa0-6cf95e3a483b": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "f5d8bea0-e26a-4483-aaa0-6cf95e3a483b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "eventId": {
+                                        "45285ca9-ab9f-4e44-84b0-01baa41223a5": {
+                                            "variable": "$.fcf085b0-3d24-49d0-9666-3f35d2a1cf28.out.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "subject": {
+                                        "26d90158-4d1b-4a81-b38c-4261d039897d": {
+                                            "variable": "$.8989f722-f128-4c3f-ab4a-3479a035872c.out.updatedSubject",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "eventId": "{{{45285ca9-ab9f-4e44-84b0-01baa41223a5}}}",
+                                    "subject": "{{{26d90158-4d1b-4a81-b38c-4261d039897d}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "550edb77-6bf9-456a-87a4-651a8acc147e": {
+            "type": "appmixer.microsoft.calendar.ListEvents",
+            "x": 700,
+            "y": 520,
+            "source": {
+                "in": {
+                    "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "outputType": "array"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "5f56acd6-77c6-40fa-933b-809be6885c8a": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 120,
+            "source": {
+                "in": {
+                    "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "fcf085b0-3d24-49d0-9666-3f35d2a1cf28": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "a71d2211-67e0-406c-8a33-b3664ac01f66": {
+                                            "variable": "$.fcf085b0-3d24-49d0-9666-3f35d2a1cf28.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "2028e961-5b91-4a70-9673-7f8fd68b5c29": {
+                                            "variable": "$.fcf085b0-3d24-49d0-9666-3f35d2a1cf28.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.subject"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{a71d2211-67e0-406c-8a33-b3664ac01f66}}}",
+                                                "assertion": "notEmpty"
+                                            },
+                                            {
+                                                "field": "{{{2028e961-5b91-4a70-9673-7f8fd68b5c29}}}",
+                                                "assertion": "equal",
+                                                "expected": "E2E Microsoft Calendar Event"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "826ffb34-1e20-4340-895c-c6188eed1e70": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 260,
+            "source": {
+                "in": {
+                    "f5d8bea0-e26a-4483-aaa0-6cf95e3a483b": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "f5d8bea0-e26a-4483-aaa0-6cf95e3a483b": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "9ed01dc8-fab6-4c6d-963c-6e43e16e04ab": {
+                                            "variable": "$.f5d8bea0-e26a-4483-aaa0-6cf95e3a483b.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "39135698-39f6-45f8-b0c5-6c1f3a580afe": {
+                                            "variable": "$.f5d8bea0-e26a-4483-aaa0-6cf95e3a483b.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.subject"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{9ed01dc8-fab6-4c6d-963c-6e43e16e04ab}}}",
+                                                "assertion": "notEmpty"
+                                            },
+                                            {
+                                                "field": "{{{39135698-39f6-45f8-b0c5-6c1f3a580afe}}}",
+                                                "assertion": "equal",
+                                                "expected": "E2E Microsoft Calendar Event"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "e1686eaf-cbcd-4159-814b-9064e952b989": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 400,
+            "source": {
+                "in": {
+                    "2a0b10a8-6cd1-4504-9fb0-694e80b340a7": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "2a0b10a8-6cd1-4504-9fb0-694e80b340a7": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "55f2964f-b061-4fac-867e-fcde83950cfa": {
+                                            "variable": "$.2a0b10a8-6cd1-4504-9fb0-694e80b340a7.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.subject"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{55f2964f-b061-4fac-867e-fcde83950cfa}}}",
+                                                "assertion": "equal",
+                                                "expected": "E2E Microsoft Calendar Event Updated"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "751423ea-c51a-4516-8d89-29ba480c41bd": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 540,
+            "source": {
+                "in": {
+                    "550edb77-6bf9-456a-87a4-651a8acc147e": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "550edb77-6bf9-456a-87a4-651a8acc147e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "38b2cd35-d2ce-4eac-81c0-87448098ae40": {
+                                            "variable": "$.550edb77-6bf9-456a-87a4-651a8acc147e.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{38b2cd35-d2ce-4eac-81c0-87448098ae40}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "3961d2f2-64f3-4341-b5a8-65757b3ca4e4": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1600,
+            "y": 320,
+            "source": {
+                "in": {
+                    "5f56acd6-77c6-40fa-933b-809be6885c8a": [
+                        "out"
+                    ],
+                    "826ffb34-1e20-4340-895c-c6188eed1e70": [
+                        "out"
+                    ],
+                    "e1686eaf-cbcd-4159-814b-9064e952b989": [
+                        "out"
+                    ],
+                    "751423ea-c51a-4516-8d89-29ba480c41bd": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cd01654a-d626-412d-a494-c8a22cdfd2a6": {
+            "type": "appmixer.microsoft.calendar.DeleteEvent",
+            "x": 1800,
+            "y": 320,
+            "source": {
+                "in": {
+                    "3961d2f2-64f3-4341-b5a8-65757b3ca4e4": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "3961d2f2-64f3-4341-b5a8-65757b3ca4e4": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "eventId": {
+                                        "d66b9717-e70c-41f1-a85e-a8868d7b64f9": {
+                                            "variable": "$.fcf085b0-3d24-49d0-9666-3f35d2a1cf28.out.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "eventId": "{{{d66b9717-e70c-41f1-a85e-a8868d7b64f9}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "6806ee97-740b-45fa-9450-910c6539246b": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 2000,
+            "y": 320,
+            "source": {
+                "in": {
+                    "cd01654a-d626-412d-a494-c8a22cdfd2a6": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "cd01654a-d626-412d-a494-c8a22cdfd2a6": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "42875ad9-84ce-49f5-9917-9a0c3f636a61": {
+                                            "variable": "$.3961d2f2-64f3-4341-b5a8-65757b3ca4e4.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "E2E Microsoft Calendar - Event Lifecycle",
+                                    "result": "{{{42875ad9-84ce-49f5-9917-9a0c3f636a61}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/artifacts/test-flows/test-flow-mail-draft-lifecycle.json
+++ b/src/appmixer/microsoft/artifacts/test-flows/test-flow-mail-draft-lifecycle.json
@@ -1,0 +1,493 @@
+{
+    "name": "E2E Microsoft Mail - Draft Lifecycle",
+    "type": "automation",
+    "flow": {
+        "837ef1ef-c688-4290-a3df-9fd06feeb21a": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 100,
+            "y": 320,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "a14b679f-2806-4e56-a605-6befb36d8a1e": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 300,
+            "y": 320,
+            "source": {
+                "in": {
+                    "837ef1ef-c688-4290-a3df-9fd06feeb21a": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "837ef1ef-c688-4290-a3df-9fd06feeb21a": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "toRecipients",
+                                                "text": "e2e.microsoft.test@appmixer.com"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "subject",
+                                                "text": "E2E Microsoft Mail Draft"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "content",
+                                                "text": "Draft body created by the Microsoft connector E2E test flow."
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "fd375b7a-24e8-4726-9f89-e24673afe22f": {
+            "type": "appmixer.microsoft.mail.CreateDraft",
+            "x": 500,
+            "y": 320,
+            "source": {
+                "in": {
+                    "a14b679f-2806-4e56-a605-6befb36d8a1e": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "a14b679f-2806-4e56-a605-6befb36d8a1e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "toRecipients": {
+                                        "0e7e81a3-ec3c-41bf-b464-189dd55c340e": {
+                                            "variable": "$.a14b679f-2806-4e56-a605-6befb36d8a1e.out.toRecipients",
+                                            "functions": []
+                                        }
+                                    },
+                                    "subject": {
+                                        "6ce87645-1360-4081-a70d-3a5cc109fe60": {
+                                            "variable": "$.a14b679f-2806-4e56-a605-6befb36d8a1e.out.subject",
+                                            "functions": []
+                                        }
+                                    },
+                                    "content": {
+                                        "ad389d84-8f90-40a9-b503-c7a054343dec": {
+                                            "variable": "$.a14b679f-2806-4e56-a605-6befb36d8a1e.out.content",
+                                            "functions": []
+                                        }
+                                    },
+                                    "contentType": {}
+                                },
+                                "lambda": {
+                                    "toRecipients": "{{{0e7e81a3-ec3c-41bf-b464-189dd55c340e}}}",
+                                    "subject": "{{{6ce87645-1360-4081-a70d-3a5cc109fe60}}}",
+                                    "content": "{{{ad389d84-8f90-40a9-b503-c7a054343dec}}}",
+                                    "contentType": "Text"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ad26a6ac-ed0c-4a64-a6fa-03498b7b2c3c": {
+            "type": "appmixer.microsoft.mail.GetEmail",
+            "x": 700,
+            "y": 320,
+            "source": {
+                "in": {
+                    "fd375b7a-24e8-4726-9f89-e24673afe22f": [
+                        "email"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "fd375b7a-24e8-4726-9f89-e24673afe22f": {
+                            "email": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "messageId": {
+                                        "79970d46-a2e6-42dc-9d94-fa1234d7b501": {
+                                            "variable": "$.fd375b7a-24e8-4726-9f89-e24673afe22f.email.id",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "messageId": "{{{79970d46-a2e6-42dc-9d94-fa1234d7b501}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "4b261097-99fc-4f86-8e47-8a51c22b4f06": {
+            "type": "appmixer.microsoft.mail.ListEmails",
+            "x": 700,
+            "y": 520,
+            "source": {
+                "in": {
+                    "fd375b7a-24e8-4726-9f89-e24673afe22f": [
+                        "email"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "fd375b7a-24e8-4726-9f89-e24673afe22f": {
+                            "email": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "outputType": "emails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "96ec3974-a278-4863-9814-532b381d5ef5": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 120,
+            "source": {
+                "in": {
+                    "fd375b7a-24e8-4726-9f89-e24673afe22f": [
+                        "email"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "fd375b7a-24e8-4726-9f89-e24673afe22f": {
+                            "email": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "6a51f431-2d5f-4ce3-b116-eae5b2cce982": {
+                                            "variable": "$.fd375b7a-24e8-4726-9f89-e24673afe22f.email",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{6a51f431-2d5f-4ce3-b116-eae5b2cce982}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "edc3452f-72f1-4686-bd0f-f9e6ee5a8cb7": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 320,
+            "source": {
+                "in": {
+                    "ad26a6ac-ed0c-4a64-a6fa-03498b7b2c3c": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "ad26a6ac-ed0c-4a64-a6fa-03498b7b2c3c": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "fa08e804-9902-4e9e-bdec-6d870a8993eb": {
+                                            "variable": "$.ad26a6ac-ed0c-4a64-a6fa-03498b7b2c3c.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "e9198c65-87f0-4905-a7b2-74ddbcde6be5": {
+                                            "variable": "$.ad26a6ac-ed0c-4a64-a6fa-03498b7b2c3c.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.subject"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{fa08e804-9902-4e9e-bdec-6d870a8993eb}}}",
+                                                "assertion": "notEmpty"
+                                            },
+                                            {
+                                                "field": "{{{e9198c65-87f0-4905-a7b2-74ddbcde6be5}}}",
+                                                "assertion": "equal",
+                                                "expected": "E2E Microsoft Mail Draft"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "0c2dc65c-94f6-4286-b37c-c0a9b504960d": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1300,
+            "y": 520,
+            "source": {
+                "in": {
+                    "4b261097-99fc-4f86-8e47-8a51c22b4f06": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "4b261097-99fc-4f86-8e47-8a51c22b4f06": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "afeb0d5f-5068-44f9-ac94-ea1a6c5a4841": {
+                                            "variable": "$.4b261097-99fc-4f86-8e47-8a51c22b4f06.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{afeb0d5f-5068-44f9-ac94-ea1a6c5a4841}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "d46840fb-6573-4165-b3e6-1aa269c9cdda": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1600,
+            "y": 320,
+            "source": {
+                "in": {
+                    "96ec3974-a278-4863-9814-532b381d5ef5": [
+                        "out"
+                    ],
+                    "edc3452f-72f1-4686-bd0f-f9e6ee5a8cb7": [
+                        "out"
+                    ],
+                    "0c2dc65c-94f6-4286-b37c-c0a9b504960d": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "93e0160e-d389-4f91-8a75-bb561102ed90": {
+            "type": "appmixer.microsoft.mail.MakeApiCall",
+            "x": 1800,
+            "y": 320,
+            "source": {
+                "in": {
+                    "d46840fb-6573-4165-b3e6-1aa269c9cdda": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "d46840fb-6573-4165-b3e6-1aa269c9cdda": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {
+                                        "f1888fee-0724-4c79-9e1e-a35978d72dbc": {
+                                            "variable": "$.fd375b7a-24e8-4726-9f89-e24673afe22f.email.id",
+                                            "functions": []
+                                        }
+                                    },
+                                    "method": {}
+                                },
+                                "lambda": {
+                                    "url": "https://graph.microsoft.com/v1.0/me/messages/{{{f1888fee-0724-4c79-9e1e-a35978d72dbc}}}",
+                                    "method": "DELETE"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "64e125c1-cc73-4cfc-9259-e27d2fc3ef35": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 2000,
+            "y": 320,
+            "source": {
+                "in": {
+                    "93e0160e-d389-4f91-8a75-bb561102ed90": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "93e0160e-d389-4f91-8a75-bb561102ed90": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "88e5b50e-b8c4-44ee-9ce6-ce6f92c549e2": {
+                                            "variable": "$.d46840fb-6573-4165-b3e6-1aa269c9cdda.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "E2E Microsoft Mail - Draft Lifecycle",
+                                    "result": "{{{88e5b50e-b8c4-44ee-9ce6-ce6f92c549e2}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/artifacts/test-flows/test-flow-mail-draft-lifecycle.json
+++ b/src/appmixer/microsoft/artifacts/test-flows/test-flow-mail-draft-lifecycle.json
@@ -182,10 +182,12 @@
                             "email": {
                                 "type": "json2new",
                                 "modifiers": {
-                                    "outputType": {}
+                                    "outputType": {},
+                                    "limit": {}
                                 },
                                 "lambda": {
-                                    "outputType": "emails"
+                                    "outputType": "emails",
+                                    "limit": 5
                                 }
                             }
                         }
@@ -348,7 +350,7 @@
                                                     "name": "g_jsonPath",
                                                     "params": [
                                                         {
-                                                            "value": "$[0].id"
+                                                            "value": "$.emails[0].id"
                                                         }
                                                     ]
                                                 }

--- a/src/appmixer/microsoft/artifacts/test-flows/test-flow-teams-channel-messaging.json
+++ b/src/appmixer/microsoft/artifacts/test-flows/test-flow-teams-channel-messaging.json
@@ -257,12 +257,14 @@
                                             ]
                                         }
                                     },
-                                    "outputType": {}
+                                    "outputType": {},
+                                    "limit": {}
                                 },
                                 "lambda": {
                                     "teamId": "{{{d540fc2e-d7ee-4b40-894f-95c2ab9536a1}}}",
                                     "channelId": "{{{db555ddd-c92c-4180-a8ea-04d81e76c085}}}",
-                                    "outputType": "items"
+                                    "outputType": "items",
+                                    "limit": 5
                                 }
                             }
                         }
@@ -462,7 +464,7 @@
                                                     "name": "g_jsonPath",
                                                     "params": [
                                                         {
-                                                            "value": "$[0].id"
+                                                            "value": "$.messages[0].id"
                                                         }
                                                     ]
                                                 }

--- a/src/appmixer/microsoft/artifacts/test-flows/test-flow-teams-channel-messaging.json
+++ b/src/appmixer/microsoft/artifacts/test-flows/test-flow-teams-channel-messaging.json
@@ -1,0 +1,569 @@
+{
+    "name": "E2E Microsoft Teams - Channel Messaging",
+    "type": "automation",
+    "flow": {
+        "ad00f53d-c768-4e8c-91a2-7afbdfc8e83d": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 100,
+            "y": 320,
+            "source": {},
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "03d0f419-a181-4254-bb4d-7f30dee14872": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 300,
+            "y": 320,
+            "source": {
+                "in": {
+                    "ad00f53d-c768-4e8c-91a2-7afbdfc8e83d": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "ad00f53d-c768-4e8c-91a2-7afbdfc8e83d": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "content",
+                                                "text": "Hello from the Microsoft connector E2E test flow."
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "9456a5e0-f51b-464b-82c3-730753cffbf1": {
+            "type": "appmixer.microsoft.teams.ListTeams",
+            "x": 500,
+            "y": 320,
+            "source": {
+                "in": {
+                    "03d0f419-a181-4254-bb4d-7f30dee14872": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "03d0f419-a181-4254-bb4d-7f30dee14872": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {},
+                                "lambda": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "93a8617e-9b39-46f0-93c2-4ef72546d050": {
+            "type": "appmixer.microsoft.teams.ListChannels",
+            "x": 700,
+            "y": 320,
+            "source": {
+                "in": {
+                    "9456a5e0-f51b-464b-82c3-730753cffbf1": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "9456a5e0-f51b-464b-82c3-730753cffbf1": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "teamId": {
+                                        "9d834de0-e423-4895-8478-07afda423e31": {
+                                            "variable": "$.9456a5e0-f51b-464b-82c3-730753cffbf1.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "teamId": "{{{9d834de0-e423-4895-8478-07afda423e31}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "b042d148-53ee-4e2d-af9a-b87ddd31ad37": {
+            "type": "appmixer.microsoft.teams.SendChannelMessage",
+            "x": 900,
+            "y": 320,
+            "source": {
+                "in": {
+                    "93a8617e-9b39-46f0-93c2-4ef72546d050": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "93a8617e-9b39-46f0-93c2-4ef72546d050": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "teamId": {
+                                        "91601fcd-4eb6-4aa5-8c67-6055643b5021": {
+                                            "variable": "$.9456a5e0-f51b-464b-82c3-730753cffbf1.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "channelId": {
+                                        "af302d72-3e19-4bfa-bd8f-726797bc41d6": {
+                                            "variable": "$.93a8617e-9b39-46f0-93c2-4ef72546d050.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "content": {
+                                        "f94ae29a-33cf-421d-a8f6-96d386188f3e": {
+                                            "variable": "$.03d0f419-a181-4254-bb4d-7f30dee14872.out.content",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "teamId": "{{{91601fcd-4eb6-4aa5-8c67-6055643b5021}}}",
+                                    "channelId": "{{{af302d72-3e19-4bfa-bd8f-726797bc41d6}}}",
+                                    "content": "{{{f94ae29a-33cf-421d-a8f6-96d386188f3e}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "153c1618-9909-4218-9c34-8b036b341047": {
+            "type": "appmixer.microsoft.teams.ListChannelMessages",
+            "x": 1100,
+            "y": 320,
+            "source": {
+                "in": {
+                    "b042d148-53ee-4e2d-af9a-b87ddd31ad37": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "b042d148-53ee-4e2d-af9a-b87ddd31ad37": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "teamId": {
+                                        "d540fc2e-d7ee-4b40-894f-95c2ab9536a1": {
+                                            "variable": "$.9456a5e0-f51b-464b-82c3-730753cffbf1.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "channelId": {
+                                        "db555ddd-c92c-4180-a8ea-04d81e76c085": {
+                                            "variable": "$.93a8617e-9b39-46f0-93c2-4ef72546d050.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputType": {}
+                                },
+                                "lambda": {
+                                    "teamId": "{{{d540fc2e-d7ee-4b40-894f-95c2ab9536a1}}}",
+                                    "channelId": "{{{db555ddd-c92c-4180-a8ea-04d81e76c085}}}",
+                                    "outputType": "items"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "13662bf3-864e-43b1-a25a-f92faeff309d": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1400,
+            "y": 120,
+            "source": {
+                "in": {
+                    "9456a5e0-f51b-464b-82c3-730753cffbf1": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "9456a5e0-f51b-464b-82c3-730753cffbf1": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "cfaf1a58-1475-41fa-95fe-2e30e25f40bd": {
+                                            "variable": "$.9456a5e0-f51b-464b-82c3-730753cffbf1.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{cfaf1a58-1475-41fa-95fe-2e30e25f40bd}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "66b4aa4a-091a-4516-9cab-1fdc92111a1f": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1400,
+            "y": 260,
+            "source": {
+                "in": {
+                    "93a8617e-9b39-46f0-93c2-4ef72546d050": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "93a8617e-9b39-46f0-93c2-4ef72546d050": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "8c78c743-9f19-44ba-8dca-26ca80bd80a4": {
+                                            "variable": "$.93a8617e-9b39-46f0-93c2-4ef72546d050.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{8c78c743-9f19-44ba-8dca-26ca80bd80a4}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "ae9b17cb-7234-4ae7-8e74-83da37c8b5ea": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1400,
+            "y": 400,
+            "source": {
+                "in": {
+                    "b042d148-53ee-4e2d-af9a-b87ddd31ad37": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "b042d148-53ee-4e2d-af9a-b87ddd31ad37": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "a4654af9-b5e3-40a9-8b85-80f5a04924fa": {
+                                            "variable": "$.b042d148-53ee-4e2d-af9a-b87ddd31ad37.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{a4654af9-b5e3-40a9-8b85-80f5a04924fa}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "8282e42c-1fdf-480e-b12e-21b328475d57": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 1400,
+            "y": 540,
+            "source": {
+                "in": {
+                    "153c1618-9909-4218-9c34-8b036b341047": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "transform": {
+                    "in": {
+                        "153c1618-9909-4218-9c34-8b036b341047": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "2f6a0a9d-f140-40d0-a860-051e14ee9bad": {
+                                            "variable": "$.153c1618-9909-4218-9c34-8b036b341047.out",
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$[0].id"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{2f6a0a9d-f140-40d0-a860-051e14ee9bad}}}",
+                                                "assertion": "notEmpty"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "c11b4949-6019-4c08-a6f6-3fd5e89986fe": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1700,
+            "y": 320,
+            "source": {
+                "in": {
+                    "13662bf3-864e-43b1-a25a-f92faeff309d": [
+                        "out"
+                    ],
+                    "66b4aa4a-091a-4516-9cab-1fdc92111a1f": [
+                        "out"
+                    ],
+                    "ae9b17cb-7234-4ae7-8e74-83da37c8b5ea": [
+                        "out"
+                    ],
+                    "8282e42c-1fdf-480e-b12e-21b328475d57": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "ec27290c-1cf5-476a-9d82-1758a53f2d94": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1900,
+            "y": 320,
+            "source": {
+                "in": {
+                    "c11b4949-6019-4c08-a6f6-3fd5e89986fe": [
+                        "out"
+                    ]
+                }
+            },
+            "version": "1.0.0",
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "c11b4949-6019-4c08-a6f6-3fd5e89986fe": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "951f07a4-6de6-4389-ae52-ce27788c3192": {
+                                            "variable": "$.c11b4949-6019-4c08-a6f6-3fd5e89986fe.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "E2E Microsoft Teams - Channel Messaging",
+                                    "result": "{{{951f07a4-6de6-4389-ae52-ce27788c3192}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/microsoft/calendar/bundle.json
+++ b/src/appmixer/microsoft/calendar/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.calendar",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "changelog": {
         "1.0.1": [
             "Initial release."
@@ -21,6 +21,7 @@
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Microsoft Graph (Calendar) API."
         ],
         "1.2.0": ["Add New Event, Updated Event, Deleted Event and Event Start triggers."],
-        "1.2.1": ["Updated Event trigger no longer fires when an event is only created."]
+        "1.2.1": ["Updated Event trigger no longer fires when an event is only created."],
+        "1.2.2": ["Failed Microsoft Graph requests now surface the Graph error code, message and request-id instead of only the bare HTTP status code."]
     }
 }

--- a/src/appmixer/microsoft/calendar/commons.js
+++ b/src/appmixer/microsoft/calendar/commons.js
@@ -1,23 +1,28 @@
 'use strict';
 
+const commons = require('../microsoft-commons');
 const baseUrl = 'https://graph.microsoft.com/v1.0';
 
 module.exports = {
 
     async makeRequest(context, options) {
 
-        return await context.httpRequest({
-            url: options.url || `${baseUrl}${options.path}`,
-            method: options.method,
-            data: options.data,
-            params: options.params,
-            headers: {
-                Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`,
-                accept: 'application/json',
-                // Caller-supplied headers (e.g. Prefer: outlook.timezone) extend/override the defaults.
-                ...options.headers
-            }
-        });
+        try {
+            return await context.httpRequest({
+                url: options.url || `${baseUrl}${options.path}`,
+                method: options.method,
+                data: options.data,
+                params: options.params,
+                headers: {
+                    Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`,
+                    accept: 'application/json',
+                    // Caller-supplied headers (e.g. Prefer: outlook.timezone) extend/override the defaults.
+                    ...options.headers
+                }
+            });
+        } catch (error) {
+            throw commons.graphError(error);
+        }
     },
 
     /** Time before expiration to renew the subscription. */

--- a/src/appmixer/microsoft/mail/bundle.json
+++ b/src/appmixer/microsoft/mail/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.mail",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -52,6 +52,9 @@
         ],
         "2.0.0": [
             "BREAKING: GetAttachments (relabeled 'Get Attachments Metadata') now returns attachment metadata only (id, name, contentType, size, isInline, lastModifiedDateTime). The contentBytes, contentId and contentLocation fields are no longer included in the output — to get the attachment content, call the Download Attachment component instead."
+        ],
+        "2.0.1": [
+            "Failed Microsoft Graph requests now surface the Graph error code, message and request-id instead of only the bare HTTP status code."
         ]
     }
 }

--- a/src/appmixer/microsoft/mail/commons.js
+++ b/src/appmixer/microsoft/mail/commons.js
@@ -1,19 +1,24 @@
 'use strict';
+const commons = require('../microsoft-commons');
 const baseUrl = 'https://graph.microsoft.com/v1.0';
 module.exports = {
 
     async makeRequest(context, options) {
 
-        return await context.httpRequest({
-            url: options.url || `${baseUrl}${options.path}`,
-            method: options.method,
-            data: options.data,
-            params: options.params,
-            headers: {
-                Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`,
-                accept: 'application/json'
-            }
-        });
+        try {
+            return await context.httpRequest({
+                url: options.url || `${baseUrl}${options.path}`,
+                method: options.method,
+                data: options.data,
+                params: options.params,
+                headers: {
+                    Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`,
+                    accept: 'application/json'
+                }
+            });
+        } catch (error) {
+            throw commons.graphError(error);
+        }
     },
 
     /** Time before expiration to renew the subscription. */

--- a/src/appmixer/microsoft/microsoft-commons.js
+++ b/src/appmixer/microsoft/microsoft-commons.js
@@ -89,6 +89,38 @@ module.exports = {
     },
 
     /**
+     * Turn a failed Microsoft Graph request into an Error that carries the Graph
+     * error code, human-readable message and request-id, instead of the bare
+     * `Request failed with status code <n>` that axios throws by default.
+     *
+     * When the response has no parseable Graph error body (e.g. a non-JSON body
+     * or a network error) the original error is returned unchanged, so nothing is
+     * swallowed and no `undefined` leaks into the message.
+     * @param {Error} error - the AxiosError thrown by context.httpRequest
+     * @return {Error}
+     */
+    graphError(error) {
+
+        const graphError = error?.response?.data?.error;
+        if (!graphError || !graphError.code) {
+            return error;
+        }
+
+        const requestId = error.response?.headers?.['request-id'];
+        let message = `Microsoft Graph error ${graphError.code}`;
+        if (graphError.message) {
+            message += `: ${graphError.message}`;
+        }
+        if (requestId) {
+            message += ` (request-id: ${requestId})`;
+        }
+
+        const wrapped = new Error(message);
+        wrapped.cause = error;
+        return wrapped;
+    },
+
+    /**
      * Catch errors from Microsoft API and set the message to something helpful
      * This message will be logged by Logstash and can be inspected on insights
      * @param {Function} asyncFunc

--- a/src/appmixer/microsoft/teams/bundle.json
+++ b/src/appmixer/microsoft/teams/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.microsoft.teams",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "changelog": {
         "1.0.0": [
             "Initial version"
@@ -23,6 +23,9 @@
         ],
         "1.3.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Microsoft Graph (Teams) API."
+        ],
+        "1.3.1": [
+            "Failed Microsoft Graph requests now surface the Graph error code, message and request-id instead of only the bare HTTP status code."
         ]
     }
 }

--- a/src/appmixer/microsoft/teams/commons.js
+++ b/src/appmixer/microsoft/teams/commons.js
@@ -1,18 +1,23 @@
 'use strict';
+const commons = require('../microsoft-commons');
 const baseUrl = 'https://graph.microsoft.com/v1.0';
 module.exports = {
 
     async makeRequest(context, options) {
 
-        return await context.httpRequest({
-            url: options.url || `${baseUrl}${options.path}`,
-            method: options.method,
-            data: options.data,
-            params: options.params,
-            headers: {
-                Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`,
-                accept: 'application/json'
-            }
-        });
+        try {
+            return await context.httpRequest({
+                url: options.url || `${baseUrl}${options.path}`,
+                method: options.method,
+                data: options.data,
+                params: options.params,
+                headers: {
+                    Authorization: `Bearer ${context.auth?.accessToken || context.accessToken}`,
+                    accept: 'application/json'
+                }
+            });
+        } catch (error) {
+            throw commons.graphError(error);
+        }
     }
 };


### PR DESCRIPTION
## Summary

`makeRequest` in the Microsoft connector modules wrapped `context.httpRequest` (a bare axios instance) without a try/catch, so a non-2xx Graph response propagated as a raw `AxiosError` whose message is only `Request failed with status code <n>`. Everything needed to diagnose the failure — the Graph `error.code` (e.g. `MailboxNotEnabledForRESTAPI`), the human-readable `error.message`, and the `request-id` header Microsoft support asks for — was dropped. This is what left the Freshdesk ticket 9719 customer unable to tell why their `SendEmail` (POST /me/sendMail) call 404'd.

## Change

- Added a shared `graphError(error)` helper to `microsoft/microsoft-commons.js` that re-throws an `Error` carrying the Graph `error.code`, `error.message` and the `request-id` response header. When the response has no parseable Graph error body (non-JSON body, network error, etc.) the **original error is returned unchanged**, so nothing is swallowed and no `undefined` leaks into the message.
- Wrapped the `makeRequest` calls in `mail`, `calendar` and `teams` `commons.js` with it.

Example resulting message:

```
Microsoft Graph error MailboxNotEnabledForRESTAPI: The mailbox is either inactive, soft-deleted, or is hosted on-premise. (request-id: 8f2c...)
```

## Scope notes

The issue asked to check `dynamics`, `sharepoint`, `onedrive`, `teams`, `calendar` and any other `microsoft/*/commons.js` for the same unwrapped pattern. After review:

- **mail, calendar, teams** — each has the identical unwrapped `makeRequest` wrapping `context.httpRequest`. Fixed.
- **onedrive / sharepoint** — do not use this `makeRequest` pattern; they go through the `onedrive-api` library wrapped by the existing `commons.formatError` helper, which already extracts the API error message. Left as-is.
- **dynamics** — has no `makeRequest` wrapper (calls `context.httpRequest` directly in scattered places); out of scope for this focused fix.

The related `getMailAttachments` base64 size-guard / upload-session gap called out under "out of scope" in the issue is **not** addressed here and should be tracked separately.

## Validation

- `npm run lint` — passes
- `node scripts/validate.js --changed --base origin/dev` — passes
- Patch-bumped `bundle.json` for mail (2.0.1), calendar (1.2.2) and teams (1.3.1) with changelog entries.

Closes Appmixer-ai/appmixer-components#2789
