### PR TITLE
cliniko: verify.json — live verification spec for appmixer connector verify

### DIFF
--- a/src/appmixer/cliniko/artifacts/samples/FindAppointments.json
+++ b/src/appmixer/cliniko/artifacts/samples/FindAppointments.json
@@ -1,0 +1,70 @@
+{
+    "component": "FindAppointments",
+    "out": {
+        "archived_at": null,
+        "booking_ip_address": null,
+        "cancellation_note": null,
+        "cancellation_reason": null,
+        "cancellation_reason_description": "string",
+        "cancelled_at": null,
+        "conflicts": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "created_at": "string",
+        "deleted_at": null,
+        "did_not_arrive": false,
+        "email_reminder_sent": false,
+        "ends_at": "string",
+        "has_patient_appointment_notes": false,
+        "id": "string",
+        "invoice_status": null,
+        "notes": "string",
+        "online_booking_policy_accepted": null,
+        "patient_arrived": false,
+        "patient_name": "string",
+        "repeat_rule": {},
+        "repeats": null,
+        "sms_reminder_sent": false,
+        "starts_at": "string",
+        "telehealth_url": "string",
+        "treatment_note_status": null,
+        "updated_at": "string",
+        "appointment_type": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "business": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "practitioner": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "patient": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "attendees": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "patient_id": "string",
+        "practitioner_id": "string",
+        "business_id": "string",
+        "appointment_type_id": "string",
+        "patient_case_id": null,
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/FindAvailableTimes.json
+++ b/src/appmixer/cliniko/artifacts/samples/FindAvailableTimes.json
@@ -1,0 +1,8 @@
+{
+    "component": "FindAvailableTimes",
+    "out": {
+        "appointment_start": "string",
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/FindInvoices.json
+++ b/src/appmixer/cliniko/artifacts/samples/FindInvoices.json
@@ -1,0 +1,59 @@
+{
+    "component": "FindInvoices",
+    "out": {
+        "archived_at": null,
+        "calculation_method": 0,
+        "calculation_method_description": "string",
+        "closed_at": "string",
+        "created_at": "string",
+        "deleted_at": null,
+        "discounted_amount": "string",
+        "id": "string",
+        "invoice_to": "string",
+        "issue_date": "string",
+        "net_amount": "string",
+        "notes": "string",
+        "number": 0,
+        "online_payment_url": null,
+        "patient_extra_information": "string",
+        "status_description": "string",
+        "status": 0,
+        "tax_amount": "string",
+        "total_amount": "string",
+        "updated_at": "string",
+        "business": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "patient": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "practitioner": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "invoice_items": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "reversed_invoices": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "patient_id": "string",
+        "practitioner_id": "string",
+        "business_id": "string",
+        "appointment_id": null,
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/FindPatients.json
+++ b/src/appmixer/cliniko/artifacts/samples/FindPatients.json
@@ -1,0 +1,99 @@
+{
+    "component": "FindPatients",
+    "out": {
+        "accepted_email_marketing": false,
+        "accepted_privacy_policy": null,
+        "accepted_sms_marketing": false,
+        "address_1": "string",
+        "address_2": "string",
+        "address_3": "string",
+        "appointment_notes": "string",
+        "archived_at": null,
+        "city": "string",
+        "country_code": "string",
+        "country": "string",
+        "created_at": "string",
+        "custom_fields": null,
+        "date_of_birth": "string",
+        "deleted_at": null,
+        "dva_card_number": null,
+        "email": null,
+        "emergency_contact": "string",
+        "first_name": "string",
+        "follow_ups_communication_channels_description": "string",
+        "follow_ups_communication_channels": [
+            0
+        ],
+        "gender_identity": "string",
+        "gender": null,
+        "id": "string",
+        "invoice_default_to": "string",
+        "invoice_email": null,
+        "invoice_extra_information": "string",
+        "label": "string",
+        "last_name": "string",
+        "medicare": "string",
+        "medicare_reference_number": null,
+        "merged_at": null,
+        "notes": "string",
+        "occupation": "string",
+        "old_reference_id": "string",
+        "patient_phone_numbers": [],
+        "post_code": "string",
+        "preferred_first_name": null,
+        "pronouns": null,
+        "receives_cancellation_emails": false,
+        "receives_confirmation_emails": false,
+        "referral_source": null,
+        "reminder_type": "string",
+        "reminders_communication_channels_description": "string",
+        "reminders_communication_channels": [
+            0
+        ],
+        "sex": "string",
+        "state": "string",
+        "time_zone": null,
+        "title": "string",
+        "updated_at": "string",
+        "latest_booking": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointments": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "attendees": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "invoices": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "patient_attachments": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "medical_alerts": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "relationships": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/GetAppointment.json
+++ b/src/appmixer/cliniko/artifacts/samples/GetAppointment.json
@@ -1,0 +1,68 @@
+{
+    "component": "GetAppointment",
+    "out": {
+        "archived_at": null,
+        "booking_ip_address": null,
+        "cancellation_note": null,
+        "cancellation_reason": null,
+        "cancellation_reason_description": "string",
+        "cancelled_at": null,
+        "conflicts": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "created_at": "string",
+        "deleted_at": null,
+        "did_not_arrive": false,
+        "email_reminder_sent": false,
+        "ends_at": "string",
+        "has_patient_appointment_notes": false,
+        "id": "string",
+        "invoice_status": null,
+        "notes": "string",
+        "online_booking_policy_accepted": null,
+        "patient_arrived": false,
+        "patient_name": "string",
+        "repeat_rule": {},
+        "repeats": null,
+        "sms_reminder_sent": false,
+        "starts_at": "string",
+        "telehealth_url": "string",
+        "treatment_note_status": null,
+        "updated_at": "string",
+        "appointment_type": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "business": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "practitioner": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "patient": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "attendees": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "patient_id": "string",
+        "practitioner_id": "string",
+        "business_id": "string",
+        "appointment_type_id": "string",
+        "patient_case_id": null
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/GetNextAvailableTime.json
+++ b/src/appmixer/cliniko/artifacts/samples/GetNextAvailableTime.json
@@ -1,0 +1,6 @@
+{
+    "component": "GetNextAvailableTime",
+    "out": {
+        "appointment_start": "string"
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/GetPatient.json
+++ b/src/appmixer/cliniko/artifacts/samples/GetPatient.json
@@ -1,0 +1,97 @@
+{
+    "component": "GetPatient",
+    "out": {
+        "accepted_email_marketing": false,
+        "accepted_privacy_policy": null,
+        "accepted_sms_marketing": false,
+        "address_1": "string",
+        "address_2": "string",
+        "address_3": "string",
+        "appointment_notes": "string",
+        "archived_at": null,
+        "city": "string",
+        "country_code": "string",
+        "country": "string",
+        "created_at": "string",
+        "custom_fields": null,
+        "date_of_birth": "string",
+        "deleted_at": null,
+        "dva_card_number": null,
+        "email": null,
+        "emergency_contact": "string",
+        "first_name": "string",
+        "follow_ups_communication_channels_description": "string",
+        "follow_ups_communication_channels": [
+            0
+        ],
+        "gender_identity": "string",
+        "gender": null,
+        "id": "string",
+        "invoice_default_to": "string",
+        "invoice_email": null,
+        "invoice_extra_information": "string",
+        "label": "string",
+        "last_name": "string",
+        "medicare": "string",
+        "medicare_reference_number": null,
+        "merged_at": null,
+        "notes": "string",
+        "occupation": "string",
+        "old_reference_id": "string",
+        "patient_phone_numbers": [],
+        "post_code": "string",
+        "preferred_first_name": null,
+        "pronouns": null,
+        "receives_cancellation_emails": false,
+        "receives_confirmation_emails": false,
+        "referral_source": null,
+        "reminder_type": "string",
+        "reminders_communication_channels_description": "string",
+        "reminders_communication_channels": [
+            0
+        ],
+        "sex": "string",
+        "state": "string",
+        "time_zone": null,
+        "title": "string",
+        "updated_at": "string",
+        "latest_booking": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointments": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "attendees": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "invoices": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "patient_attachments": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "medical_alerts": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "relationships": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        }
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/ListAppointmentTypes.json
+++ b/src/appmixer/cliniko/artifacts/samples/ListAppointmentTypes.json
@@ -1,0 +1,50 @@
+{
+    "component": "ListAppointmentTypes",
+    "out": {
+        "add_deposit_to_account_credit": null,
+        "appointment_confirmation_template_ids": null,
+        "appointment_follow_up_template_ids": null,
+        "appointment_reminder_template_ids": null,
+        "archived_at": null,
+        "category": null,
+        "color": "string",
+        "created_at": "string",
+        "deposit_price": null,
+        "description": null,
+        "duration_in_minutes": 0,
+        "id": "string",
+        "max_attendees": 0,
+        "name": "string",
+        "online_bookings_lead_time_hours": null,
+        "online_payments_enabled": false,
+        "online_payments_mode": null,
+        "show_in_online_bookings": false,
+        "telehealth_enabled": false,
+        "updated_at": "string",
+        "billable_item": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointment_type_billable_items": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointment_type_products": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "practitioners": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/ListBusinesses.json
+++ b/src/appmixer/cliniko/artifacts/samples/ListBusinesses.json
@@ -1,0 +1,48 @@
+{
+    "component": "ListBusinesses",
+    "out": {
+        "additional_information": null,
+        "additional_invoice_information": null,
+        "address_1": null,
+        "address_2": null,
+        "appointment_reminders_enabled": false,
+        "appointment_type_ids": [
+            "string"
+        ],
+        "archived_at": null,
+        "business_name": "string",
+        "business_registration_name": null,
+        "business_registration_value": null,
+        "city": null,
+        "contact_information": null,
+        "country_code": "string",
+        "country": "string",
+        "created_at": "string",
+        "display_name": null,
+        "email_reply_to": null,
+        "id": "string",
+        "label": "string",
+        "post_code": null,
+        "show_in_online_bookings": false,
+        "state": null,
+        "time_zone": "string",
+        "time_zone_identifier": "string",
+        "updated_at": "string",
+        "website_address": null,
+        "practitioners": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointments": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/samples/ListPractitioners.json
+++ b/src/appmixer/cliniko/artifacts/samples/ListPractitioners.json
@@ -1,0 +1,48 @@
+{
+    "component": "ListPractitioners",
+    "out": {
+        "active": false,
+        "created_at": "string",
+        "description": null,
+        "designation": null,
+        "display_name": "string",
+        "first_name": "string",
+        "id": "string",
+        "label": "string",
+        "last_name": "string",
+        "show_in_online_bookings": false,
+        "title": null,
+        "updated_at": "string",
+        "user": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointments": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "appointment_types": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "invoices": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "practitioner_reference_numbers": {
+            "links": {
+                "self": "string"
+            }
+        },
+        "links": {
+            "self": "string"
+        },
+        "user_id": "string",
+        "index": 0,
+        "count": 0
+    }
+}

--- a/src/appmixer/cliniko/artifacts/verify.json
+++ b/src/appmixer/cliniko/artifacts/verify.json
@@ -1,0 +1,44 @@
+{
+    "fixtures": {
+        "businessId": { "from": "ListBusinesses", "path": "id" },
+        "practitionerId": { "from": "ListPractitioners", "path": "id" },
+        "appointmentTypeId": { "from": "ListAppointmentTypes", "path": "id" },
+        "patientId": { "from": "FindPatients", "path": "id" },
+        "appointmentId": { "from": "FindAppointments", "path": "id" }
+    },
+    "read": [
+        { "component": "ListPractitioners" },
+        { "component": "ListBusinesses" },
+        { "component": "ListAppointmentTypes" },
+        { "component": "FindPatients" },
+        { "component": "FindAppointments" },
+        { "component": "FindInvoices" },
+        { "component": "FindContacts" },
+        { "component": "FindTreatmentNotes" },
+        { "component": "GetPatient", "inputs": { "patientId": "{patientId}" } },
+        { "component": "GetAppointment", "inputs": { "appointmentId": "{appointmentId}" } },
+        { "component": "FindAvailableTimes", "inputs": {
+            "businessId": "{businessId}",
+            "practitionerId": "{practitionerId}",
+            "appointmentTypeId": "{appointmentTypeId}"
+        } },
+        { "component": "GetNextAvailableTime", "inputs": {
+            "businessId": "{businessId}",
+            "practitionerId": "{practitionerId}",
+            "appointmentTypeId": "{appointmentTypeId}"
+        } }
+    ],
+    "roundtrip": [
+        {
+            "component": "CreateContact",
+            "input": "typeCode",
+            "base": { "lastName": "Verify Roundtrip" },
+            "valueField": "type_code",
+            "labelField": "type",
+            "cleanup": {
+                "component": "MakeApiCall",
+                "inputs": { "url": "/contacts/{id}/archive", "method": "POST" }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds the live-verification assets for **`appmixer connector verify cliniko`** (Appmixer-ai/appmixer-cli#423) — cliniko is the pilot connector for the command; merge the CLI PR first or alongside. Both files live in **`artifacts/`** with the connector's other non-runtime assets (test-flows, ai-artifacts) — never packed into the published module.

## `artifacts/verify.json` — recipes, not data

Not samples: it holds *instructions*. (1) How to obtain fixture IDs from the connected account — `"businessId": { "from": "ListBusinesses", "path": "id" }` — so nothing tenant-specific is ever committed; the same file works on any Cliniko account. (2) Which read checks need those inputs. (3) The roundtrip definition: which select input, which returned fields to compare, and how to clean up (via `MakeApiCall`, since Cliniko has no contact-delete action).

Covers schema-conformance for all 12 read components and an enum-roundtrip on `CreateContact.typeCode` — the exact input whose inverted label/value mapping shipped in 1.0.0 and was only caught by a live E2E run.

## `artifacts/samples/` — recorded output shapes (Vláďa's idea)

Written by `appmixer connector verify cliniko --record` against a live account: the **shape** of each read component's output with every value replaced by a type placeholder. Payloads carry patient PII — grep the directory for a name or an email: nothing survives. With these committed, `appmixer connector verify cliniko --offline` re-checks declared-schema-vs-payload conformance with **no credentials**, so the check can run in CI. Re-record when Cliniko adds fields or a mapping changes.

## Verified live

- With fixtures: `3 pass, 0 fail, 8 warn` (`--write`); the roundtrip created 3 contacts and archived all of them — account left at 0.
- Sabotaging the `type_code` mapping back to the 1.0.0 state makes the roundtrip name all three inversions and exit 1.
- `--offline` (no credentials) reproduces the same conformance results from the committed samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g7A4beDMYJu9kqmNu26Pp
