### PR TITLE
utils.test.ProcessE2EResults: clear the test case from the opposite result store

### DIFF
--- a/scripts/validators/_ignore-list.js
+++ b/scripts/validators/_ignore-list.js
@@ -171,9 +171,10 @@ module.exports = [
         messageIncludes: 'no MakeApiCall component',
         paths: [
             'appmixer/utils/bundle.json',
+            'appmixer/utils/test/bundle.json',
             'appmixer/system/bundle.json'
         ],
-        reason: 'Internal/utility connectors (flow control, converters, storage, engine events) with no external service or stored credentials — there is no third-party API to call.'
+        reason: 'Internal/utility connectors (flow control, converters, storage, engine events) with no external service or stored credentials — there is no third-party API to call. utils/test is the E2E-flow harness module (Assert, AfterAll, ProcessE2EResults) and talks only to the engine and the internal stores.'
     },
     {
         validator: 'connector-has-makeapicall',

--- a/src/appmixer/utils/artifacts/test-flows/test-flow-e2e-utils-test-afterall-passthrough.json
+++ b/src/appmixer/utils/artifacts/test-flows/test-flow-e2e-utils-test-afterall-passthrough.json
@@ -1,0 +1,191 @@
+{
+    "name": "E2E Utils Test - single-input AfterAll passthrough",
+    "description": "End-to-end test for appmixer.utils.test - covers AfterAll's single-input passthrough branch (one connected source, no aggregation) with a multi-clause Assert, and the ProcessE2EResults success-store write.",
+    "type": "automation",
+    "flow": {
+        "a0e893f0-cef1-4e3b-af4f-b65062e52a8e": {
+            "type": "appmixer.utils.controls.OnStart",
+            "label": "On Start",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "82db737b-f51e-40ed-a418-38f883832e77": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "label": "Set Variables",
+            "x": 288,
+            "y": 16,
+            "source": {
+                "in": {
+                    "a0e893f0-cef1-4e3b-af4f-b65062e52a8e": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "a0e893f0-cef1-4e3b-af4f-b65062e52a8e": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "marker",
+                                                "text": "utils-test-passthrough"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "129304d4-6e78-4f9a-80ca-520cd7539b0a": {
+            "type": "appmixer.utils.test.Assert",
+            "label": "Assert marker and start time",
+            "x": 512,
+            "y": 16,
+            "source": {
+                "in": {
+                    "82db737b-f51e-40ed-a418-38f883832e77": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "82db737b-f51e-40ed-a418-38f883832e77": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "ref-marker": {
+                                            "variable": "$.82db737b-f51e-40ed-a418-38f883832e77.out.marker",
+                                            "functions": []
+                                        },
+                                        "ref-started": {
+                                            "variable": "$.a0e893f0-cef1-4e3b-af4f-b65062e52a8e.out.started",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{ref-marker}}}",
+                                                "assertion": "equal",
+                                                "expected": "utils-test-passthrough",
+                                                "type": "string",
+                                                "label": "SetVariable marker reaches the Assert unchanged"
+                                            },
+                                            {
+                                                "field": "{{{ref-started}}}",
+                                                "assertion": "notEmpty",
+                                                "label": "OnStart start time is not empty"
+                                            },
+                                            {
+                                                "field": "{{{ref-started}}}",
+                                                "assertion": "regex",
+                                                "regex": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T",
+                                                "label": "OnStart start time is an ISO 8601 timestamp"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "d50603b6-3298-4f95-87d3-bc8388e05abe": {
+            "type": "appmixer.utils.test.AfterAll",
+            "label": "After All",
+            "x": 736,
+            "y": 16,
+            "source": {
+                "in": {
+                    "129304d4-6e78-4f9a-80ca-520cd7539b0a": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "b171fc2a-fe2f-4133-9026-9bd57082b834": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "label": "Process E2E Results",
+            "x": 960,
+            "y": 16,
+            "source": {
+                "in": {
+                    "d50603b6-3298-4f95-87d3-bc8388e05abe": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "d50603b6-3298-4f95-87d3-bc8388e05abe": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "ref-result": {
+                                            "variable": "$.d50603b6-3298-4f95-87d3-bc8388e05abe.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "E2E Utils Test - single-input AfterAll passthrough",
+                                    "result": "{{{ref-result}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/utils/artifacts/test-flows/test-flow-e2e-utils-test-assertions.json
+++ b/src/appmixer/utils/artifacts/test-flows/test-flow-e2e-utils-test-assertions.json
@@ -1,0 +1,282 @@
+{
+    "name": "E2E Utils Test - assertions and AfterAll aggregation",
+    "description": "End-to-end test for appmixer.utils.test - exercises all three Assert assertion types (equal, notEmpty, regex) on parallel branches, AfterAll's multi-input aggregation, and the ProcessE2EResults success-store write.",
+    "type": "automation",
+    "flow": {
+        "34b68eff-f841-4cd8-bc79-0eeb7b1040d4": {
+            "type": "appmixer.utils.controls.OnStart",
+            "label": "On Start",
+            "x": 64,
+            "y": 16,
+            "source": {},
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "4f7d5233-1660-4558-880b-41fc9a95203f": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "label": "Set Variables",
+            "x": 288,
+            "y": 16,
+            "source": {
+                "in": {
+                    "34b68eff-f841-4cd8-bc79-0eeb7b1040d4": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "34b68eff-f841-4cd8-bc79-0eeb7b1040d4": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "expectedText",
+                                                "text": "appmixer-utils-test-e2e"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "name": "expectedNumber",
+                                                "text": "42"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "ecf4c0b9-c956-402f-b3a1-6eb3b68dfccf": {
+            "type": "appmixer.utils.test.Assert",
+            "label": "Assert equal",
+            "x": 512,
+            "y": 16,
+            "source": {
+                "in": {
+                    "4f7d5233-1660-4558-880b-41fc9a95203f": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4f7d5233-1660-4558-880b-41fc9a95203f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "ref-expected-text": {
+                                            "variable": "$.4f7d5233-1660-4558-880b-41fc9a95203f.out.expectedText",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{ref-expected-text}}}",
+                                                "assertion": "equal",
+                                                "expected": "appmixer-utils-test-e2e",
+                                                "type": "string",
+                                                "label": "SetVariable text variable survives the transform"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "8e3d3af0-e129-47e5-a3f3-2500c2ba37c2": {
+            "type": "appmixer.utils.test.Assert",
+            "label": "Assert notEmpty",
+            "x": 512,
+            "y": 144,
+            "source": {
+                "in": {
+                    "4f7d5233-1660-4558-880b-41fc9a95203f": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4f7d5233-1660-4558-880b-41fc9a95203f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "ref-started": {
+                                            "variable": "$.34b68eff-f841-4cd8-bc79-0eeb7b1040d4.out.started",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{ref-started}}}",
+                                                "assertion": "notEmpty",
+                                                "label": "OnStart start time is reachable from a downstream branch"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "45d3b6db-d18f-466f-9277-f56ed0a97091": {
+            "type": "appmixer.utils.test.Assert",
+            "label": "Assert regex",
+            "x": 512,
+            "y": 272,
+            "source": {
+                "in": {
+                    "4f7d5233-1660-4558-880b-41fc9a95203f": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "4f7d5233-1660-4558-880b-41fc9a95203f": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "ref-expected-number": {
+                                            "variable": "$.4f7d5233-1660-4558-880b-41fc9a95203f.out.expectedNumber",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "field": "{{{ref-expected-number}}}",
+                                                "assertion": "regex",
+                                                "regex": "^[0-9]+$",
+                                                "label": "SetVariable numeric text variable matches ^[0-9]+$"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "6e62ddb9-3db8-43dd-aec4-e20e702015ea": {
+            "type": "appmixer.utils.test.AfterAll",
+            "label": "After All",
+            "x": 736,
+            "y": 144,
+            "source": {
+                "in": {
+                    "ecf4c0b9-c956-402f-b3a1-6eb3b68dfccf": [
+                        "out"
+                    ],
+                    "8e3d3af0-e129-47e5-a3f3-2500c2ba37c2": [
+                        "out"
+                    ],
+                    "45d3b6db-d18f-466f-9277-f56ed0a97091": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "073bf46c-e9c4-4f50-bd22-c3f134b08d82": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "label": "Process E2E Results",
+            "x": 960,
+            "y": 144,
+            "source": {
+                "in": {
+                    "6e62ddb9-3db8-43dd-aec4-e20e702015ea": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "6e62ddb9-3db8-43dd-aec4-e20e702015ea": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "ref-result": {
+                                            "variable": "$.6e62ddb9-3db8-43dd-aec4-e20e702015ea.out",
+                                            "functions": []
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.ai",
+                                    "testCase": "E2E Utils Test - assertions and AfterAll aggregation",
+                                    "result": "{{{ref-result}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    }
+}

--- a/src/appmixer/utils/test/ProcessE2EResults/ProcessE2EResults.js
+++ b/src/appmixer/utils/test/ProcessE2EResults/ProcessE2EResults.js
@@ -17,9 +17,19 @@ async function sendEmail(context, recipients, subject, text, html) {
     await context.log({ step: 'Email sent', message, result });
 }
 
-async function storeResult(context, storeId, key, value) {
+// Stores the result under `key` in `storeId` and drops the same key from `oppositeStoreId` so that
+// at most one record per test case exists and it always reflects the latest outcome.
+async function storeResult(context, storeId, oppositeStoreId, key, value) {
 
-    return context.store.set(storeId, key, value);
+    await context.store.set(storeId, key, value);
+
+    try {
+        await context.store.remove(oppositeStoreId, key);
+    } catch (err) {
+        // The key is usually not there at all (first run, or same outcome as before). Removing a
+        // missing key must not fail the whole component.
+        await context.log({ step: 'Could not remove stale result', storeId: oppositeStoreId, key, error: err.message });
+    }
 }
 
 module.exports = {
@@ -72,7 +82,7 @@ module.exports = {
                             </tr>
                         `).join('')}
                 </table>`;
-            await storeResult(context, failedStoreId, testCase, result);
+            await storeResult(context, failedStoreId, successStoreId, testCase, result);
             await sendEmail(context, content.recipients, subject, text, getHTML(metadata, details));
             return;
         }
@@ -114,10 +124,10 @@ module.exports = {
             const subject = `${testCase} failed`;
             const text = `The following errors were found:\n\n${JSON.stringify(failedAsserts)}\n\nFull test results `
                 + `were:\n\n${JSON.stringify(arrayResults)}`;
-            await storeResult(context, failedStoreId, testCase, result);
+            await storeResult(context, failedStoreId, successStoreId, testCase, result);
             await sendEmail(context, content.recipients, subject, text, getHTML(metadata, details));
         } else {
-            await storeResult(context, successStoreId, testCase, result);
+            await storeResult(context, successStoreId, failedStoreId, testCase, result);
         }
     }
 };

--- a/src/appmixer/utils/test/bundle.json
+++ b/src/appmixer/utils/test/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.utils.test",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "changelog": {
         "1.0.0": [
             "Initial version."
@@ -13,6 +13,9 @@
         ],
         "1.1.1": [
             "Fixed issue with ProcessE2EResults not sending emails."
+        ],
+        "1.1.2": [
+            "ProcessE2EResults now removes the test case from the opposite result store, so a test case never appears as both succeeded and failed."
         ]
     }
 }


### PR DESCRIPTION
## Problem

`appmixer.utils.test.ProcessE2EResults` writes each E2E result into either the success store or the failed store, keyed by test case name. A re-run overwrote its own key **within** a store, but the record in the **opposite** store was never removed.

So a test case that failed once and later passed stayed listed as both:

```
✓ E2E Cliniko - Invoices  (2026-08-24T09:45:50.714Z)
✗ E2E Cliniko - Invoices  (2026-08-24T09:44:21.740Z)   <- stale
```

Consumers of the stores (e.g. `appmixer e2e results`) then reported failures that no longer existed. The CLI works around it by deduplicating on `updatedAt`, but the stores themselves stayed dirty.

## Change

`src/appmixer/utils/test/ProcessE2EResults/ProcessE2EResults.js` — `storeResult()` now takes the opposite store id as well and removes the same key from it after the write. Applied at all three call sites:

| Branch | Writes to | Clears from |
|---|---|---|
| timed out | `failedStoreId` | `successStoreId` |
| failed asserts | `failedStoreId` | `successStoreId` |
| success | `successStoreId` | `failedStoreId` |

Removing a key that is not there is the *normal* case (first run, or same outcome as before), so the removal is wrapped in `try/catch` — the error is logged via `context.log` and swallowed rather than failing the component. Both store ids are declared `required` in `component.json`, so neither is ever undefined.

Net effect: for any test case at most one record exists across the two stores, and it is the latest outcome.

`src/appmixer/utils/test/bundle.json` — patch bump to `1.1.2` with a changelog entry.

## Also included

`scripts/validators/_ignore-list.js` — added `appmixer/utils/test/bundle.json` to the existing `connector-has-makeapicall` ignore-list entry. This is pre-existing debt that the strict per-file validator only surfaces once `utils/test/bundle.json` is touched; the entry already covers `appmixer/utils` and `appmixer/system` for exactly this reason, and `utils/test` is the E2E harness module (Assert / AfterAll / ProcessE2EResults) with no third-party API to call. Only the path matching was too narrow to catch the per-module bundle.

I deliberately did **not** bump `ProcessE2EResults/component.json` — the component's public contract (ports, inspector) is unchanged, and touching that file drags three unrelated pre-existing findings into the strict validator run (`component-icon-svg` PNG icon, `no-select-with-source` on the two store selects, `required-inputs-asserted` missing `CancelError` guards). Those are real but out of scope here and better fixed as their own change.

## Verification

- `npm run lint` — clean
- `node scripts/validate.js --changed --base origin/dev` — **passed** (1 report suppressed by the ignore-list entry above)
- `appmixer connector verify --offline` skipped: `src/appmixer/utils/artifacts/samples/` does not exist, so there are no recorded samples to compare against
- No publishing or live-instance runs, per the scope of this step

Closes Appmixer-ai/appmixer-components#2800
