### PR TITLE
wiz: reword the 1.4.1 changelog

### DIFF
--- a/src/appmixer/wiz/bundle.json
+++ b/src/appmixer/wiz/bundle.json
@@ -42,14 +42,13 @@
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Wiz API."
         ],
         "1.4.1": [
-            "Long-running fixes: cap status-polling attempts/interval and upload-lock config so a single receive() cannot stall for tens of minutes; add a bounded timeout to all Wiz HTTP requests.",
-            "Upload Scan: drain the pending-documents backlog one threshold-sized batch per receive() (scheduled drains included, so one huge backlog no longer becomes a single oversized upload) and continue via a scheduled timeout instead of looping inside a single receive(); warn when the backlog grows past 5000 documents.",
-            "Status polling: enforce a wall-clock deadline (statusMaxTotalTime, capped at 5 minutes) on the whole polling session in addition to the per-attempt caps.",
-            "Find Cloud Resources: cap the record limit (default 100, max 10000), fix pagination so an empty later page no longer discards already-collected records, and route empty results to the notFound port.",
-            "Stop logging the full upload payload (size/count only) to avoid oversized log entries and exposure of security-findings data.",
-            "Status polling: surface the error Wiz keeps answering with (e.g. an unknown systemActivity id) instead of a bare \"Exceeded max attempts\", and fail immediately on authorization errors; Create and Upload Security Scan now shares the connector's single polling implementation.",
-            "Upload Scan: a drain continuation is scheduled 60s ahead - the engine's timeout scheduler does not deliver shorter timeouts, which left the rest of a drained backlog waiting in state.",
-            "Upload Scan: never upload a batch twice - a batch prepared by one receive() could be picked up and re-uploaded by a concurrent one; a batch is now claimed with a timestamp and only resumed when it is older than the upload lock TTL (crash recovery)."
+            "Upload Enrichment Documents: the pending documents backlog is drained one threshold-sized batch per message, scheduled drains included, so a large backlog is no longer uploaded as a single oversized request; the remainder continues in a follow-up timeout 60 seconds later instead of looping inside a single receive() call.",
+            "Upload Enrichment Documents: a batch is never uploaded twice; it is claimed with a timestamp and only resumed once it is older than the upload lock TTL, i.e. when it is a leftover of an interrupted run.",
+            "Upload Enrichment Documents: warn when the backlog grows past 5000 documents, and fix a crash in the drain scheduling when the component starts with a timeout ID already stored in its state.",
+            "Bounded every long-running operation: capped status polling attempts and interval, capped upload lock configuration, a wall-clock deadline for the whole polling session (statusMaxTotalTime, default and maximum 5 minutes), and a request timeout on all Wiz API calls (requestTimeout, default 60 seconds, maximum 2 minutes).",
+            "Create and Upload Security Scan, Upload Enrichment Documents: report the error Wiz keeps answering with, for example an unknown systemActivity ID, instead of a bare \"Exceeded max attempts\", and fail immediately on authorization errors; both components now share a single status polling implementation.",
+            "Find Cloud Resources: cap the record limit (default 100, maximum 10000), keep the records already collected when a later page comes back empty, and route an empty result to the notFound port.",
+            "Create and Upload Security Scan, Upload Enrichment Documents: log only the status and size of an upload instead of the whole payload, which produced oversized log entries and exposed security findings data."
         ]
     }
 }


### PR DESCRIPTION
## Summary

Rewords the `appmixer.wiz` 1.4.1 changelog that shipped with #1214 into release
notes that can go to the customer as they are:

- entries grouped by the component labels shown in the designer (`Upload
  Enrichment Documents`, `Create and Upload Security Scan`, `Find Cloud
  Resources`) instead of directory names,
- the duplicated status-polling and Upload Scan items merged (8 entries -> 7,
  each a single sentence, matching the style of the rest of the file),
- added the `scheduleDrain` `TypeError` fix, which shipped in 1.4.1 but was
  missing from the list.

Text only — no code change and no version bump, 1.4.1 is on `dev` but not
released yet.

Closes Appmixer-ai/appmixer-components#2793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AWZrdBSjYx8VbiUe7p4g8