### PR TITLE
fix(gladia,freshdesk,airtable): stop declaring sub-minute setTimeout delays

### DIFF
--- a/src/appmixer/airtable/bundle.json
+++ b/src/appmixer/airtable/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.airtable",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "changelog": {
         "1.0.4": [
             "Initial release"
@@ -36,6 +36,9 @@
         ],
         "3.2.0": [
             "Added MakeApiCall component for performing arbitrary authorized API calls to the Airtable API."
+        ],
+        "3.2.1": [
+            "Updated Record (webhook): the notification debounce now states the one-minute window it has always had, instead of a five-second one the engine never scheduled."
         ]
     }
 }

--- a/src/appmixer/airtable/records/UpdatedRecordWebhook/UpdatedRecordWebhook.js
+++ b/src/appmixer/airtable/records/UpdatedRecordWebhook/UpdatedRecordWebhook.js
@@ -2,6 +2,8 @@
 
 const commons = require('../../airtable-commons');
 
+const DEBOUNCE_MS = 60 * 1000;
+
 const registerWebhook = async (context) => {
 
     const { baseId, tableId } = context.properties;
@@ -54,9 +56,14 @@ module.exports = {
      */
     async receive(context) {
         if (context.messages.webhook) {
+            // Airtable's notification is only a ping; the payloads are fetched by
+            // cursor below. The timeout coalesces a burst of pings into a single
+            // fetch. One minute is the shortest window available: Appmixer rounds
+            // any shorter context.setTimeout delay up to a minute without saying
+            // so, so asking for less just misrepresents what this does.
             const stateTimeout = await context.stateGet('timeout');
             if (!stateTimeout) {
-                await context.setTimeout({}, 5000);
+                await context.setTimeout({}, DEBOUNCE_MS);
                 await context.stateSet('timeout', true);
             }
             return context.response();

--- a/src/appmixer/freshdesk/bundle.json
+++ b/src/appmixer/freshdesk/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.freshdesk",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "changelog": {
         "1.0.1": [
             "Initial version"
@@ -47,6 +47,9 @@
         "2.1.0": [
             "Added test() (Flow Test Mode) to all triggers: NewTicket, UpdatedTicket, DeletedTicket, NewConversation — emit one realistic item via a read-only call, reusing the same fetch/mapping path as tick().",
             "Replaced the axios/request/request-promise dependencies with a shared lib.apiCall helper built on context.httpRequest; no behavior change to existing components."
+        ],
+        "2.1.1": [
+            "Export Contacts: corrected the polling interval to the one the engine actually schedules. The component declared 30-second polls and a 30-minute ceiling; both were really 60, and the timeout message reported a duration that had never elapsed."
         ]
     }
 }

--- a/src/appmixer/freshdesk/contacts/ExportContacts/ExportContacts.js
+++ b/src/appmixer/freshdesk/contacts/ExportContacts/ExportContacts.js
@@ -2,8 +2,11 @@
 
 const { apiCall } = require('../../lib');
 
-const POLL_INTERVAL_MS = 30000;   // re-check every 30s
-const MAX_POLLS = 60;             // up to 30 minutes total (60 × 30s)
+// Appmixer silently rounds any context.setTimeout delay below one minute up to
+// one minute, so a shorter interval here would only make the constants lie: the
+// ceiling below and the timeout message are both derived from this value.
+const POLL_INTERVAL_MS = 60000;   // re-check every 60s (engine floor)
+const MAX_POLLS = 60;             // up to 60 minutes total (60 x 60s)
 
 module.exports = {
 

--- a/src/appmixer/gladia/bundle.json
+++ b/src/appmixer/gladia/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.gladia",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.0": [
             "Initial release. Adds API-key authentication via the x-gladia-key header and components for audio upload, asynchronous transcription with polling and audio-intelligence add-ons (diarization, translation, summarization, subtitles, sentiment analysis, PII redaction), retrieving a transcription, listing transcriptions, deleting a transcription, and a polling TranscriptionCompleted trigger."
@@ -13,6 +13,10 @@
             "The Transcription Completed trigger pages back to a persisted completion watermark, so bursts larger than one page are no longer missed and deletions cannot cause re-emits.",
             "Declared the diarization, translation, summarization, sentiment analysis and subtitle result schemas so add-on results can be wired downstream.",
             "Account validation no longer reports rate limits, outages or network errors as an invalid API key."
+        ],
+        "1.1.1": [
+            "Transcribe Audio: dropped a polling-interval setting that could never take effect (it was read from the service configuration, which only ever holds the auth fields) and raised a polling timeout shorter than one poll to one poll, so a low value no longer waits a minute just to fail on an already-expired deadline.",
+            "Documented that polling draws on the same request quota as every other component."
         ]
     }
 }

--- a/src/appmixer/gladia/core/TranscribeAudio/TranscribeAudio.js
+++ b/src/appmixer/gladia/core/TranscribeAudio/TranscribeAudio.js
@@ -2,8 +2,9 @@
 
 const lib = require('../../lib');
 
-// Appmixer will not schedule a continuation shorter than one minute, so that is
-// both the default and the floor for the polling interval.
+// Appmixer rounds any context.setTimeout delay below one minute up to one
+// minute, and does it silently, so one minute is both the floor and the only
+// sensible poll interval here. Every duration below is derived from it.
 const MIN_POLL_INTERVAL_SECONDS = 60;
 
 function parseCsv(value) {
@@ -151,11 +152,13 @@ module.exports = {
             return context.sendJson(created, 'out');
         }
 
-        const timeoutSeconds = Number(pollingTimeout) > 0 ? Number(pollingTimeout) : 300;
-        const pollIntervalSeconds = Math.max(
-            Number(context.config && context.config.pollIntervalSeconds) || MIN_POLL_INTERVAL_SECONDS,
-            MIN_POLL_INTERVAL_SECONDS
-        );
+        const pollIntervalSeconds = MIN_POLL_INTERVAL_SECONDS;
+
+        // The first poll cannot happen sooner than one interval from now. A
+        // shorter timeout than that would spend a minute waiting only to fail
+        // on a deadline that had already passed, so it is raised to one poll.
+        const requestedTimeout = Number(pollingTimeout) > 0 ? Number(pollingTimeout) : 300;
+        const timeoutSeconds = Math.max(requestedTimeout, pollIntervalSeconds);
 
         return context.setTimeout({
             jobId,

--- a/src/appmixer/gladia/core/TranscribeAudio/component.json
+++ b/src/appmixer/gladia/core/TranscribeAudio/component.json
@@ -115,7 +115,7 @@
                         "index": 12,
                         "label": "Polling Timeout (seconds)",
                         "defaultValue": 300,
-                        "tooltip": "Maximum time to wait for the transcription to finish when Wait For Completion is on."
+                        "tooltip": "Maximum time to wait for the transcription to finish when Wait For Completion is on. The job status is checked once a minute, so the effective resolution is 60 seconds and anything lower than that is raised to 60. When the timeout is reached the component fails; use Get Transcription with the job id to collect the result afterwards."
                     }
                 }
             }

--- a/src/appmixer/gladia/quota.js
+++ b/src/appmixer/gladia/quota.js
@@ -3,6 +3,14 @@
 // Gladia does not publish a hard per-minute request ceiling, so we throttle
 // conservatively and queue overflow so flows degrade gracefully instead of
 // hitting rate-limit errors.
+//
+// Note that the budget covers polling too: every continuation of Transcribe
+// Audio is a full receive() and costs one request, so a transcription waited
+// on costs 1 + one per minute of job duration, drawn from the same bucket as
+// every other Gladia component for that user. Queued polls only delay a
+// result, never lose one - the status is read before the deadline is checked -
+// but a flow running many long transcriptions at once will spend most of this
+// budget on polling.
 module.exports = {
 
     rules: [


### PR DESCRIPTION
## Why

The engine floors `context.setTimeout` at `WAITING_QUEUE_MIN_TIMEOUT` (60 000 ms) with `Math.max` and says nothing about it — no error, no warning, no log. Test mode takes a different path with **no floor at all** (`Math.min(timeout, 120000)` through `TestDispatcher`). A shorter delay therefore does what its author meant under `appmixer test component`, ships, and behaves differently in production — and anything computed from the intended value goes wrong with it.

Instruction change: Appmixer-ai/appmixer-skills#17.

## What changed

### freshdesk — `contacts/ExportContacts`

Declared `POLL_INTERVAL_MS = 30000  // re-check every 30s` and `MAX_POLLS = 60  // up to 30 minutes total (60 × 30s)`. Both were really 60, so the export waits up to an **hour**, and the timeout error — computed as `(MAX_POLLS * POLL_INTERVAL_MS) / 1000` — told the user "timed out after 1800s" once 3600 had passed.

Constants corrected to the real behaviour. **No behaviour change**: a slow contact export needs that hour, and cutting the ceiling to the documented 30 minutes would be a regression for anyone relying on it. The error message derives from the constants, so it fixed itself.

### airtable — `records/UpdatedRecordWebhook`

`context.setTimeout({}, 5000)` debounced Airtable's notification pings into a single cursor fetch. Really 60 s since forever. Named `DEBOUNCE_MS = 60 * 1000` with a comment on why shorter is not available, so the next reader does not "fix" it back. **No behaviour change.**

### gladia — `core/TranscribeAudio`

- Removed a poll-interval setting read from `context.config.pollIntervalSeconds`. `context.config` is an **alias for `context.auth`**, and the connector's auth block has no such field — the value was always `undefined`, so the setting could never take effect and the surrounding `Math.max` only made it look configurable.
- A **Polling Timeout below one interval is now raised to one interval**. The first poll cannot land sooner than 60 s, so a lower value could only burn a minute and then fail on a deadline that had already expired.
- Tooltip states the 60-second resolution and points at Get Transcription for collecting a result after a timeout.

### gladia — `quota.js`

Comment only. Each poll is a full `receive()` costing one request from the same per-user bucket as every other Gladia component, so a transcription waited on costs `1 + one per minute of job duration`. Worth noting that queued polls **delay** a result but never lose one — the status is read before the deadline is checked.

## Checks

- `node scripts/validate.js --changed` — clean (25 rules, incl. `bundle-bump-on-change` and `bundle-versions` via the pre-commit hook)
- `npx eslint` on all three connectors — clean
- Bumps: gladia 1.1.0 → **1.1.1**, freshdesk 2.1.0 → **2.1.1**, airtable 3.2.0 → **3.2.1**

`--connector freshdesk` / `--connector airtable` still report pre-existing legacy debt (`required-inputs-asserted`, `no-select-with-source`) untouched by this PR.