### PR TITLE
gohighlevel(patch): add Ed25519 X-GHL-Signature webhook verification helper

### DIFF
--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-appointment-scheduling.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-appointment-scheduling.json
@@ -1,64 +1,87 @@
 {
     "flow": {
-        "after-all": {
+        "0d18d15f-3fca-5e41-b2d3-6e21ec237000": {
             "config": {
                 "properties": {
                     "timeout": 30
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "assert-appointment": [
+                    "4e3ecc6f-88b8-55c9-ad97-f321a55cfa09": [
                         "out"
                     ],
-                    "assert-list-calendars": [
+                    "caeca176-d348-5aea-8dd5-7d2e8751434d": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.AfterAll",
-            "x": 1360,
-            "y": 80
+            "x": 1184,
+            "y": 16
         },
-        "assert-appointment": {
+        "33802334-31cf-5169-9a25-2f2a579151b0": {
             "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
                 "transform": {
                     "in": {
-                        "create-appointment": {
+                        "afd3b15e-b99c-5056-afb5-fb5f48af6d1a": {
                             "out": {
                                 "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "assertion": "notEmpty",
-                                                "field": "{{{appt-id-var}}}"
-                                            },
-                                            {
-                                                "assertion": "equal",
-                                                "expected": "E2E Test Appointment",
-                                                "field": "{{{appt-title-var}}}"
-                                            },
-                                            {
-                                                "assertion": "equal",
-                                                "expected": "new",
-                                                "field": "{{{appt-status-var}}}"
-                                            }
-                                        ]
-                                    }
+                                    "address": "123 E2E Street, Austin, TX",
+                                    "appointmentStatus": "new",
+                                    "calendarId": "{{{var-calendar-id}}}",
+                                    "contactId": "{{{var-contact-id}}}",
+                                    "endTime": "{{{var-end-time}}}",
+                                    "startTime": "{{{var-start-time}}}",
+                                    "title": "{{{var-title}}}"
                                 },
                                 "modifiers": {
-                                    "expression": {
-                                        "appt-id-var": {
+                                    "address": {},
+                                    "appointmentStatus": {},
+                                    "calendarId": {
+                                        "var-calendar-id": {
                                             "functions": [],
-                                            "variable": "$.create-appointment.out.id"
-                                        },
-                                        "appt-status-var": {
+                                            "variable": "$.59fdca13-dcfa-5957-be54-03e856bf8172.out.calendarId"
+                                        }
+                                    },
+                                    "contactId": {
+                                        "var-contact-id": {
                                             "functions": [],
-                                            "variable": "$.create-appointment.out.appointmentStatus"
-                                        },
-                                        "appt-title-var": {
+                                            "variable": "$.59fdca13-dcfa-5957-be54-03e856bf8172.out.contactId"
+                                        }
+                                    },
+                                    "endTime": {
+                                        "var-end-time": {
+                                            "functions": [
+                                                {
+                                                    "hashParams": {
+                                                        "minutes": {
+                                                            "value": 30
+                                                        }
+                                                    },
+                                                    "name": "g_addTimeSpan"
+                                                }
+                                            ],
+                                            "variable": "$.afd3b15e-b99c-5056-afb5-fb5f48af6d1a.out.result"
+                                        }
+                                    },
+                                    "startTime": {
+                                        "var-start-time": {
                                             "functions": [],
-                                            "variable": "$.create-appointment.out.title"
+                                            "variable": "$.afd3b15e-b99c-5056-afb5-fb5f48af6d1a.out.result"
+                                        }
+                                    },
+                                    "title": {
+                                        "var-title": {
+                                            "functions": [],
+                                            "variable": "$.59fdca13-dcfa-5957-be54-03e856bf8172.out.appointmentTitle"
                                         }
                                     }
                                 },
@@ -68,22 +91,71 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "create-appointment": [
+                    "afd3b15e-b99c-5056-afb5-fb5f48af6d1a": [
                         "out"
                     ]
                 }
             },
-            "type": "appmixer.utils.test.Assert",
-            "x": 1168,
-            "y": 144
+            "type": "appmixer.gohighlevel.core.CreateAppointment",
+            "x": 736,
+            "y": 16
         },
-        "assert-list-calendars": {
+        "3dcfb300-b937-5388-984d-bfaf521a5b28": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "0d18d15f-3fca-5e41-b2d3-6e21ec237000": {
+                            "out": {
+                                "lambda": {
+                                    "headers": "[{\"key\": \"Version\", \"value\": \"2021-07-28\"}]",
+                                    "method": "DELETE",
+                                    "url": "/calendars/events/{{{var-appointment-id}}}"
+                                },
+                                "modifiers": {
+                                    "headers": {},
+                                    "method": {},
+                                    "url": {
+                                        "var-appointment-id": {
+                                            "functions": [],
+                                            "variable": "$.33802334-31cf-5169-9a25-2f2a579151b0.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "0d18d15f-3fca-5e41-b2d3-6e21ec237000": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.MakeApiCall",
+            "x": 1408,
+            "y": 16
+        },
+        "4e3ecc6f-88b8-55c9-ad97-f321a55cfa09": {
             "config": {
                 "transform": {
                     "in": {
-                        "list-calendars": {
+                        "4f0fdc05-5334-5b60-a9cf-85990e0075a2": {
                             "out": {
                                 "lambda": {
                                     "expression": {
@@ -99,7 +171,7 @@
                                     "expression": {
                                         "calendars-var": {
                                             "functions": [],
-                                            "variable": "$.list-calendars.out.calendars"
+                                            "variable": "$.4f0fdc05-5334-5b60-a9cf-85990e0075a2.out.calendars"
                                         }
                                     }
                                 },
@@ -109,222 +181,47 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "list-calendars": [
+                    "4f0fdc05-5334-5b60-a9cf-85990e0075a2": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.Assert",
-            "x": 1168,
-            "y": 16
+            "x": 736,
+            "y": 176
         },
-        "compute-end": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "compute-start": {
-                            "out": {
-                                "lambda": {
-                                    "code": "(() => { const d = new Date('{{{start-time}}}'); d.setMinutes(d.getMinutes() + 30); return d.toISOString(); })()",
-                                    "variables": {
-                                        "ADD": [
-                                            {
-                                                "toggle": false,
-                                                "type": "text"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "modifiers": {
-                                    "code": {
-                                        "start-time": {
-                                            "functions": [],
-                                            "variable": "$.compute-start.out.result"
-                                        }
-                                    },
-                                    "variables": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "compute-start": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.controls.CodeBlock",
-            "x": 688,
-            "y": 144
-        },
-        "compute-start": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "set-variables": {
-                            "out": {
-                                "lambda": {
-                                    "code": "(() => { const d = new Date(); d.setDate(d.getDate() + 7 + (Date.now() % 7)); const day = d.getDay(); if (day === 0) d.setDate(d.getDate() + 1); if (day === 6) d.setDate(d.getDate() + 2); d.setHours(10, 0, 0, 0); return d.toISOString(); })()"
-                                },
-                                "modifiers": {
-                                    "code": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "set-variables": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.controls.CodeBlock",
-            "x": 480,
-            "y": 144
-        },
-        "create-appointment": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                },
-                "transform": {
-                    "in": {
-                        "compute-end": {
-                            "out": {
-                                "lambda": {
-                                    "calendarId": "{{{var-calendar-id}}}",
-                                    "contactId": "{{{var-contact-id}}}",
-                                    "endTime": "{{{var-end-time}}}",
-                                    "startTime": "{{{var-start-time}}}",
-                                    "title": "{{{var-title}}}"
-                                },
-                                "modifiers": {
-                                    "calendarId": {
-                                        "var-calendar-id": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.calendarId"
-                                        }
-                                    },
-                                    "contactId": {
-                                        "var-contact-id": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.contactId"
-                                        }
-                                    },
-                                    "endTime": {
-                                        "var-end-time": {
-                                            "functions": [],
-                                            "variable": "$.compute-end.out.result"
-                                        }
-                                    },
-                                    "startTime": {
-                                        "var-start-time": {
-                                            "functions": [],
-                                            "variable": "$.compute-start.out.result"
-                                        }
-                                    },
-                                    "title": {
-                                        "var-title": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.appointmentTitle"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "compute-end": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.CreateAppointment",
-            "x": 976,
-            "y": 144
-        },
-        "list-calendars": {
+        "4f0fdc05-5334-5b60-a9cf-85990e0075a2": {
             "config": {
                 "properties": {
                     "account": "69bd20b72e33e81a1e686f91"
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "set-variables": [
+                    "59fdca13-dcfa-5957-be54-03e856bf8172": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.gohighlevel.core.ListCalendars",
-            "x": 976,
-            "y": 16
+            "x": 512,
+            "y": 176
         },
-        "on-start": {
-            "config": {},
-            "source": {},
-            "type": "appmixer.utils.controls.OnStart",
-            "x": -80,
-            "y": 16
-        },
-        "process-results": {
-            "config": {
-                "properties": {},
-                "transform": {
-                    "in": {
-                        "after-all": {
-                            "out": {
-                                "lambda": {
-                                    "recipients": "auth@appmixer.ai",
-                                    "result": "{{{result-var}}}",
-                                    "testCase": "E2E Gohighlevel - Appointment Scheduling"
-                                },
-                                "modifiers": {
-                                    "recipients": {},
-                                    "result": {
-                                        "result-var": {
-                                            "functions": [],
-                                            "variable": "$.after-all.out"
-                                        }
-                                    },
-                                    "testCase": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "after-all": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 1552,
-            "y": 80
-        },
-        "set-variables": {
+        "59fdca13-dcfa-5957-be54-03e856bf8172": {
             "config": {
                 "transform": {
                     "in": {
-                        "on-start": {
+                        "767095e8-4235-50ec-807b-57ac77a94968": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -356,15 +253,169 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "on-start": [
+                    "767095e8-4235-50ec-807b-57ac77a94968": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.controls.SetVariable",
             "x": 288,
+            "y": 16
+        },
+        "767095e8-4235-50ec-807b-57ac77a94968": {
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16
+        },
+        "afd3b15e-b99c-5056-afb5-fb5f48af6d1a": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "59fdca13-dcfa-5957-be54-03e856bf8172": {
+                            "out": {
+                                "lambda": {
+                                    "code": "(() => { const d = new Date(); d.setUTCDate(d.getUTCDate() + 7); while (d.getUTCDay() !== 1) { d.setUTCDate(d.getUTCDate() + 1); } d.setUTCHours(10, 0, 0, 0); return d.toISOString(); })()"
+                                },
+                                "modifiers": {
+                                    "code": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "59fdca13-dcfa-5957-be54-03e856bf8172": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.controls.CodeBlock",
+            "x": 512,
+            "y": 16
+        },
+        "caeca176-d348-5aea-8dd5-7d2e8751434d": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "33802334-31cf-5169-9a25-2f2a579151b0": {
+                            "out": {
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{appt-id-var}}}"
+                                            },
+                                            {
+                                                "assertion": "equal",
+                                                "expected": "E2E Test Appointment",
+                                                "field": "{{{appt-title-var}}}"
+                                            },
+                                            {
+                                                "assertion": "equal",
+                                                "expected": "new",
+                                                "field": "{{{appt-status-var}}}"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "modifiers": {
+                                    "expression": {
+                                        "appt-id-var": {
+                                            "functions": [],
+                                            "variable": "$.33802334-31cf-5169-9a25-2f2a579151b0.out.id"
+                                        },
+                                        "appt-status-var": {
+                                            "functions": [],
+                                            "variable": "$.33802334-31cf-5169-9a25-2f2a579151b0.out.appointmentStatus"
+                                        },
+                                        "appt-title-var": {
+                                            "functions": [],
+                                            "variable": "$.33802334-31cf-5169-9a25-2f2a579151b0.out.title"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "33802334-31cf-5169-9a25-2f2a579151b0": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.Assert",
+            "x": 960,
+            "y": 16
+        },
+        "e456b3f0-605b-5db4-9024-fa3c2f2f4580": {
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "3dcfb300-b937-5388-984d-bfaf521a5b28": {
+                            "out": {
+                                "lambda": {
+                                    "recipients": "auth@appmixer.ai",
+                                    "result": "{{{result-var}}}",
+                                    "testCase": "E2E Gohighlevel - Appointment Scheduling"
+                                },
+                                "modifiers": {
+                                    "recipients": {},
+                                    "result": {
+                                        "result-var": {
+                                            "functions": [],
+                                            "variable": "$.0d18d15f-3fca-5e41-b2d3-6e21ec237000.out"
+                                        }
+                                    },
+                                    "testCase": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "3dcfb300-b937-5388-984d-bfaf521a5b28": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1632,
             "y": 16
         }
     },

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-contact-crud.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-contact-crud.json
@@ -1,82 +1,10 @@
 {
     "flow": {
-        "after-all": {
-            "config": {
-                "properties": {
-                    "timeout": 30
-                }
-            },
-            "source": {
-                "in": {
-                    "assert-create": [
-                        "out"
-                    ],
-                    "assert-get": [
-                        "out"
-                    ],
-                    "assert-update": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.AfterAll",
-            "x": 1200,
-            "y": 144
-        },
-        "assert-create": {
+        "15b8a710-94c5-5510-b931-784519d59200": {
             "config": {
                 "transform": {
                     "in": {
-                        "create-contact": {
-                            "out": {
-                                "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "assertion": "notEmpty",
-                                                "field": "{{{field-id}}}"
-                                            },
-                                            {
-                                                "assertion": "notEmpty",
-                                                "field": "{{{field-email}}}"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "modifiers": {
-                                    "expression": {
-                                        "field-email": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.email"
-                                        },
-                                        "field-id": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.id"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "create-contact": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.Assert",
-            "x": 1008,
-            "y": 16
-        },
-        "assert-get": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "get-contact": {
+                        "ff209e25-4db3-5147-a6db-cee40bd37810": {
                             "out": {
                                 "lambda": {
                                     "expression": {
@@ -97,11 +25,11 @@
                                     "expression": {
                                         "field-get-email": {
                                             "functions": [],
-                                            "variable": "$.get-contact.out.email"
+                                            "variable": "$.ff209e25-4db3-5147-a6db-cee40bd37810.out.email"
                                         },
                                         "field-get-first-name": {
                                             "functions": [],
-                                            "variable": "$.get-contact.out.firstName"
+                                            "variable": "$.ff209e25-4db3-5147-a6db-cee40bd37810.out.firstName"
                                         }
                                     }
                                 },
@@ -111,86 +39,54 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "get-contact": [
+                    "ff209e25-4db3-5147-a6db-cee40bd37810": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.Assert",
-            "x": 1008,
-            "y": 144
+            "x": 960,
+            "y": 176
         },
-        "assert-update": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "update-contact": {
-                            "out": {
-                                "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "assertion": "notEmpty",
-                                                "field": "{{{field-updated-id}}}"
-                                            },
-                                            {
-                                                "assertion": "equal",
-                                                "expected": "E2EUpdated",
-                                                "field": "{{{field-updated-first-name}}}"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "modifiers": {
-                                    "expression": {
-                                        "field-updated-first-name": {
-                                            "functions": [],
-                                            "variable": "$.update-contact.out.firstName"
-                                        },
-                                        "field-updated-id": {
-                                            "functions": [],
-                                            "variable": "$.update-contact.out.id"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "update-contact": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.Assert",
-            "x": 1008,
-            "y": 272
-        },
-        "create-contact": {
+        "288c0c8d-edf9-54b4-9ad4-60657d02c917": {
             "config": {
                 "properties": {
                     "account": "69bd20b72e33e81a1e686f91"
                 },
                 "transform": {
                     "in": {
-                        "set-variables": {
+                        "333bb1cc-0718-536f-a3e6-e44320f17324": {
                             "out": {
                                 "lambda": {
+                                    "address1": "123 E2E Street",
+                                    "city": "Austin",
+                                    "companyName": "Appmixer E2E",
+                                    "country": "US",
                                     "email": "{{{var-email-prefix}}}-{{{var-ts}}}@appmixer-test.com",
                                     "firstName": "{{{var-first-name}}}",
-                                    "lastName": "{{{var-last-name}}}"
+                                    "lastName": "{{{var-last-name}}}",
+                                    "phone": "+15125551234",
+                                    "postalCode": "78701",
+                                    "source": "appmixer-e2e",
+                                    "state": "TX",
+                                    "tags": "appmixer-e2e",
+                                    "website": "https://www.appmixer.com"
                                 },
                                 "modifiers": {
+                                    "address1": {},
+                                    "city": {},
+                                    "companyName": {},
+                                    "country": {},
                                     "email": {
                                         "var-email-prefix": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.contactEmailPrefix"
+                                            "variable": "$.333bb1cc-0718-536f-a3e6-e44320f17324.out.contactEmailPrefix"
                                         },
                                         "var-ts": {
                                             "functions": [
@@ -198,21 +94,27 @@
                                                     "name": "g_timestamp"
                                                 }
                                             ],
-                                            "variable": "$.on-start.out.started"
+                                            "variable": "$.e3e4b593-06ef-5eb5-963f-49855ddbc8a3.out.started"
                                         }
                                     },
                                     "firstName": {
                                         "var-first-name": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.contactFirstName"
+                                            "variable": "$.333bb1cc-0718-536f-a3e6-e44320f17324.out.contactFirstName"
                                         }
                                     },
                                     "lastName": {
                                         "var-last-name": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.contactLastName"
+                                            "variable": "$.333bb1cc-0718-536f-a3e6-e44320f17324.out.contactLastName"
                                         }
-                                    }
+                                    },
+                                    "phone": {},
+                                    "postalCode": {},
+                                    "source": {},
+                                    "state": {},
+                                    "tags": {},
+                                    "website": {}
                                 },
                                 "type": "json2new"
                             }
@@ -220,142 +122,26 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "set-variables": [
+                    "333bb1cc-0718-536f-a3e6-e44320f17324": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.gohighlevel.core.CreateContact",
-            "x": 448,
+            "x": 512,
             "y": 16
         },
-        "delete-contact": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                },
-                "transform": {
-                    "in": {
-                        "after-all": {
-                            "out": {
-                                "lambda": {
-                                    "contactId": "{{{var-delete-contact-id}}}"
-                                },
-                                "modifiers": {
-                                    "contactId": {
-                                        "var-delete-contact-id": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.id"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "after-all": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.DeleteContact",
-            "x": 1392,
-            "y": 144
-        },
-        "get-contact": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                },
-                "transform": {
-                    "in": {
-                        "create-contact": {
-                            "out": {
-                                "lambda": {
-                                    "contactId": "{{{var-contact-id}}}"
-                                },
-                                "modifiers": {
-                                    "contactId": {
-                                        "var-contact-id": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.id"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "create-contact": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.GetContact",
-            "x": 640,
-            "y": 144
-        },
-        "on-start": {
-            "config": {},
-            "source": {},
-            "type": "appmixer.utils.controls.OnStart",
-            "x": 64,
-            "y": 16
-        },
-        "process-results": {
-            "config": {
-                "properties": {},
-                "transform": {
-                    "in": {
-                        "delete-contact": {
-                            "out": {
-                                "lambda": {
-                                    "recipients": "auth@appmixer.ai",
-                                    "result": "{{{result-var}}}",
-                                    "testCase": "E2E Gohighlevel - Contact CRUD"
-                                },
-                                "modifiers": {
-                                    "recipients": {},
-                                    "result": {
-                                        "result-var": {
-                                            "functions": [],
-                                            "variable": "$.after-all.out"
-                                        }
-                                    },
-                                    "testCase": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "delete-contact": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 1584,
-            "y": 144
-        },
-        "set-variables": {
+        "333bb1cc-0718-536f-a3e6-e44320f17324": {
             "config": {
                 "transform": {
                     "in": {
-                        "on-start": {
+                        "e3e4b593-06ef-5eb5-963f-49855ddbc8a3": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -392,41 +178,184 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "on-start": [
+                    "e3e4b593-06ef-5eb5-963f-49855ddbc8a3": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.controls.SetVariable",
-            "x": 256,
+            "x": 288,
             "y": 16
         },
-        "update-contact": {
+        "5d8bf00d-9b66-5a11-87ca-f9cd76559fd0": {
             "config": {
                 "properties": {
                     "account": "69bd20b72e33e81a1e686f91"
                 },
                 "transform": {
                     "in": {
-                        "get-contact": {
+                        "ff209e25-4db3-5147-a6db-cee40bd37810": {
                             "out": {
                                 "lambda": {
+                                    "address1": "456 Updated Avenue",
+                                    "city": "Dallas",
+                                    "companyName": "Appmixer E2E Updated",
                                     "contactId": "{{{var-update-contact-id}}}",
-                                    "firstName": "{{{var-updated-first-name}}}"
+                                    "country": "US",
+                                    "email": "e2e-ghl-{{{var-upd-ts}}}-updated@appmixer-test.com",
+                                    "firstName": "{{{var-updated-first-name}}}",
+                                    "lastName": "GHLUpdated",
+                                    "phone": "+15125559876",
+                                    "postalCode": "75201",
+                                    "source": "appmixer-e2e-updated",
+                                    "state": "TX",
+                                    "tags": "appmixer-e2e",
+                                    "website": "https://docs.appmixer.com"
                                 },
                                 "modifiers": {
+                                    "address1": {},
+                                    "city": {},
+                                    "companyName": {},
                                     "contactId": {
                                         "var-update-contact-id": {
                                             "functions": [],
-                                            "variable": "$.create-contact.out.id"
+                                            "variable": "$.288c0c8d-edf9-54b4-9ad4-60657d02c917.out.id"
+                                        }
+                                    },
+                                    "country": {},
+                                    "email": {
+                                        "var-upd-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_timestamp"
+                                                }
+                                            ],
+                                            "variable": "$.e3e4b593-06ef-5eb5-963f-49855ddbc8a3.out.started"
                                         }
                                     },
                                     "firstName": {
                                         "var-updated-first-name": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.updatedFirstName"
+                                            "variable": "$.333bb1cc-0718-536f-a3e6-e44320f17324.out.updatedFirstName"
+                                        }
+                                    },
+                                    "lastName": {},
+                                    "phone": {},
+                                    "postalCode": {},
+                                    "source": {},
+                                    "state": {},
+                                    "tags": {},
+                                    "website": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "ff209e25-4db3-5147-a6db-cee40bd37810": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.UpdateContact",
+            "x": 960,
+            "y": 336
+        },
+        "95758ba2-3e90-5b8a-9bd4-0f7ea33a61ce": {
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "db91a038-a1b6-52a4-9333-db215a739ddc": {
+                            "out": {
+                                "lambda": {
+                                    "recipients": "auth@appmixer.ai",
+                                    "result": "{{{result-var}}}",
+                                    "testCase": "E2E Gohighlevel - Contact CRUD"
+                                },
+                                "modifiers": {
+                                    "recipients": {},
+                                    "result": {
+                                        "result-var": {
+                                            "functions": [],
+                                            "variable": "$.e9cb308b-402c-5537-a19a-9ef7a5c88b98.out"
+                                        }
+                                    },
+                                    "testCase": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "db91a038-a1b6-52a4-9333-db215a739ddc": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1856,
+            "y": 16
+        },
+        "bb6ce3de-fd86-5b20-9d20-fce64e3c76cb": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "5d8bf00d-9b66-5a11-87ca-f9cd76559fd0": {
+                            "out": {
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-updated-id}}}"
+                                            },
+                                            {
+                                                "assertion": "equal",
+                                                "expected": "E2EUpdated",
+                                                "field": "{{{field-updated-first-name}}}"
+                                            },
+                                            {
+                                                "assertion": "equal",
+                                                "expected": "GHLUpdated",
+                                                "field": "{{{field-updated-last-name}}}"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "modifiers": {
+                                    "expression": {
+                                        "field-updated-first-name": {
+                                            "functions": [],
+                                            "variable": "$.5d8bf00d-9b66-5a11-87ca-f9cd76559fd0.out.firstName"
+                                        },
+                                        "field-updated-id": {
+                                            "functions": [],
+                                            "variable": "$.5d8bf00d-9b66-5a11-87ca-f9cd76559fd0.out.id"
+                                        },
+                                        "field-updated-last-name": {
+                                            "functions": [],
+                                            "variable": "$.5d8bf00d-9b66-5a11-87ca-f9cd76559fd0.out.lastName"
                                         }
                                     }
                                 },
@@ -436,16 +365,193 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "get-contact": [
+                    "5d8bf00d-9b66-5a11-87ca-f9cd76559fd0": [
                         "out"
                     ]
                 }
             },
-            "type": "appmixer.gohighlevel.core.UpdateContact",
-            "x": 832,
-            "y": 272
+            "type": "appmixer.utils.test.Assert",
+            "x": 1184,
+            "y": 336
+        },
+        "be5f9f32-083b-5b82-8a47-ebce066ec1ae": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "288c0c8d-edf9-54b4-9ad4-60657d02c917": {
+                            "out": {
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-id}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-email}}}"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "modifiers": {
+                                    "expression": {
+                                        "field-email": {
+                                            "functions": [],
+                                            "variable": "$.288c0c8d-edf9-54b4-9ad4-60657d02c917.out.email"
+                                        },
+                                        "field-id": {
+                                            "functions": [],
+                                            "variable": "$.288c0c8d-edf9-54b4-9ad4-60657d02c917.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "288c0c8d-edf9-54b4-9ad4-60657d02c917": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.Assert",
+            "x": 736,
+            "y": 16
+        },
+        "db91a038-a1b6-52a4-9333-db215a739ddc": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "e9cb308b-402c-5537-a19a-9ef7a5c88b98": {
+                            "out": {
+                                "lambda": {
+                                    "contactId": "{{{var-delete-contact-id}}}"
+                                },
+                                "modifiers": {
+                                    "contactId": {
+                                        "var-delete-contact-id": {
+                                            "functions": [],
+                                            "variable": "$.288c0c8d-edf9-54b4-9ad4-60657d02c917.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "e9cb308b-402c-5537-a19a-9ef7a5c88b98": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.DeleteContact",
+            "x": 1632,
+            "y": 16
+        },
+        "e3e4b593-06ef-5eb5-963f-49855ddbc8a3": {
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16
+        },
+        "e9cb308b-402c-5537-a19a-9ef7a5c88b98": {
+            "config": {
+                "properties": {
+                    "timeout": 30
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "15b8a710-94c5-5510-b931-784519d59200": [
+                        "out"
+                    ],
+                    "bb6ce3de-fd86-5b20-9d20-fce64e3c76cb": [
+                        "out"
+                    ],
+                    "be5f9f32-083b-5b82-8a47-ebce066ec1ae": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 1408,
+            "y": 16
+        },
+        "ff209e25-4db3-5147-a6db-cee40bd37810": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "288c0c8d-edf9-54b4-9ad4-60657d02c917": {
+                            "out": {
+                                "lambda": {
+                                    "contactId": "{{{var-contact-id}}}"
+                                },
+                                "modifiers": {
+                                    "contactId": {
+                                        "var-contact-id": {
+                                            "functions": [],
+                                            "variable": "$.288c0c8d-edf9-54b4-9ad4-60657d02c917.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "288c0c8d-edf9-54b4-9ad4-60657d02c917": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.GetContact",
+            "x": 736,
+            "y": 176
         }
     },
     "name": "E2E Gohighlevel - Contact CRUD",

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-find-contacts.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-find-contacts.json
@@ -1,30 +1,125 @@
 {
     "flow": {
-        "after-all": {
+        "1f7ab552-1892-5ba8-a77f-a939cc7b6589": {
             "config": {
                 "properties": {
                     "timeout": 30
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "assert-create": [
+                    "4893783c-9937-54f5-80a5-d218d2b38bea": [
                         "out"
                     ],
-                    "assert-find-contacts": [
+                    "ba282be0-7463-5a54-a696-bf6a506ff04b": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.AfterAll",
-            "x": 976,
-            "y": 80
+            "x": 960,
+            "y": 16
         },
-        "assert-create": {
+        "3582b547-7ef5-56f9-b284-fb2c4fb83491": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "1f7ab552-1892-5ba8-a77f-a939cc7b6589": {
+                            "out": {
+                                "lambda": {
+                                    "contactId": "{{{var-contact-id}}}"
+                                },
+                                "modifiers": {
+                                    "contactId": {
+                                        "var-contact-id": {
+                                            "functions": [],
+                                            "variable": "$.6eb01746-1e56-5025-a876-80a9892d1a67.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "1f7ab552-1892-5ba8-a77f-a939cc7b6589": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.DeleteContact",
+            "x": 1184,
+            "y": 16
+        },
+        "407aa9bc-faa3-5c24-a0d2-6071a303380d": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "c3cd8a91-f03d-5f2d-9fda-58155abc126c": {
+                            "out": {
+                                "lambda": {
+                                    "email": "{{{var-search-email}}}",
+                                    "outputType": "first",
+                                    "query": "{{{var-search-email}}}"
+                                },
+                                "modifiers": {
+                                    "email": {
+                                        "var-search-email": {
+                                            "functions": [],
+                                            "variable": "$.c3cd8a91-f03d-5f2d-9fda-58155abc126c.out.searchEmail"
+                                        }
+                                    },
+                                    "outputType": {},
+                                    "query": {
+                                        "var-search-email": {
+                                            "functions": [],
+                                            "variable": "$.c3cd8a91-f03d-5f2d-9fda-58155abc126c.out.searchEmail"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "c3cd8a91-f03d-5f2d-9fda-58155abc126c": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.FindContacts",
+            "x": 512,
+            "y": 176
+        },
+        "4893783c-9937-54f5-80a5-d218d2b38bea": {
             "config": {
                 "transform": {
                     "in": {
-                        "create-contact": {
+                        "6eb01746-1e56-5025-a876-80a9892d1a67": {
                             "out": {
                                 "lambda": {
                                     "expression": {
@@ -40,7 +135,7 @@
                                     "expression": {
                                         "field-id": {
                                             "functions": [],
-                                            "variable": "$.create-contact.out.id"
+                                            "variable": "$.6eb01746-1e56-5025-a876-80a9892d1a67.out.id"
                                         }
                                     }
                                 },
@@ -50,22 +145,120 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "create-contact": [
+                    "6eb01746-1e56-5025-a876-80a9892d1a67": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.Assert",
-            "x": 784,
-            "y": 192
+            "x": 736,
+            "y": 16
         },
-        "assert-find-contacts": {
+        "6eb01746-1e56-5025-a876-80a9892d1a67": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "c3cd8a91-f03d-5f2d-9fda-58155abc126c": {
+                            "out": {
+                                "lambda": {
+                                    "address1": "123 E2E Street",
+                                    "city": "Austin",
+                                    "companyName": "Appmixer E2E",
+                                    "country": "US",
+                                    "email": "{{{var-email}}}-{{{var-ts}}}@appmixer-test.com",
+                                    "firstName": "{{{var-first-name}}}",
+                                    "lastName": "{{{var-last-name}}}",
+                                    "phone": "+15125551234",
+                                    "postalCode": "78701",
+                                    "source": "appmixer-e2e",
+                                    "state": "TX",
+                                    "tags": "appmixer-e2e",
+                                    "website": "https://www.appmixer.com"
+                                },
+                                "modifiers": {
+                                    "address1": {},
+                                    "city": {},
+                                    "companyName": {},
+                                    "country": {},
+                                    "email": {
+                                        "var-email": {
+                                            "functions": [],
+                                            "variable": "$.c3cd8a91-f03d-5f2d-9fda-58155abc126c.out.createEmailPrefix"
+                                        },
+                                        "var-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_timestamp"
+                                                }
+                                            ],
+                                            "variable": "$.9e4b2fd7-8def-528a-bd31-df65a16af2df.out.started"
+                                        }
+                                    },
+                                    "firstName": {
+                                        "var-first-name": {
+                                            "functions": [],
+                                            "variable": "$.c3cd8a91-f03d-5f2d-9fda-58155abc126c.out.contactFirstName"
+                                        }
+                                    },
+                                    "lastName": {
+                                        "var-last-name": {
+                                            "functions": [],
+                                            "variable": "$.c3cd8a91-f03d-5f2d-9fda-58155abc126c.out.contactLastName"
+                                        }
+                                    },
+                                    "phone": {},
+                                    "postalCode": {},
+                                    "source": {},
+                                    "state": {},
+                                    "tags": {},
+                                    "website": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "c3cd8a91-f03d-5f2d-9fda-58155abc126c": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.CreateContact",
+            "x": 512,
+            "y": 16
+        },
+        "9e4b2fd7-8def-528a-bd31-df65a16af2df": {
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16
+        },
+        "ba282be0-7463-5a54-a696-bf6a506ff04b": {
             "config": {
                 "transform": {
                     "in": {
-                        "find-contacts": {
+                        "407aa9bc-faa3-5c24-a0d2-6071a303380d": {
                             "out": {
                                 "lambda": {
                                     "expression": {
@@ -86,11 +279,11 @@
                                     "expression": {
                                         "field-email": {
                                             "functions": [],
-                                            "variable": "$.find-contacts.out.email"
+                                            "variable": "$.407aa9bc-faa3-5c24-a0d2-6071a303380d.out.email"
                                         },
                                         "field-id": {
                                             "functions": [],
-                                            "variable": "$.find-contacts.out.id"
+                                            "variable": "$.407aa9bc-faa3-5c24-a0d2-6071a303380d.out.id"
                                         }
                                     }
                                 },
@@ -100,195 +293,26 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "find-contacts": [
+                    "407aa9bc-faa3-5c24-a0d2-6071a303380d": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.Assert",
-            "x": 784,
-            "y": 16
+            "x": 736,
+            "y": 176
         },
-        "create-contact": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                },
-                "transform": {
-                    "in": {
-                        "set-variables": {
-                            "out": {
-                                "lambda": {
-                                    "email": "{{{var-email}}}",
-                                    "firstName": "{{{var-first-name}}}",
-                                    "lastName": "{{{var-last-name}}}"
-                                },
-                                "modifiers": {
-                                    "email": {
-                                        "var-email": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.createEmail"
-                                        }
-                                    },
-                                    "firstName": {
-                                        "var-first-name": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.contactFirstName"
-                                        }
-                                    },
-                                    "lastName": {
-                                        "var-last-name": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.contactLastName"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "set-variables": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.CreateContact",
-            "x": 592,
-            "y": 192
-        },
-        "delete-contact": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                },
-                "transform": {
-                    "in": {
-                        "after-all": {
-                            "out": {
-                                "lambda": {
-                                    "contactId": "{{{var-contact-id}}}"
-                                },
-                                "modifiers": {
-                                    "contactId": {
-                                        "var-contact-id": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.id"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "after-all": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.DeleteContact",
-            "x": 1168,
-            "y": 80
-        },
-        "find-contacts": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                },
-                "transform": {
-                    "in": {
-                        "set-variables": {
-                            "out": {
-                                "lambda": {
-                                    "outputType": "first",
-                                    "query": "{{{var-search-email}}}"
-                                },
-                                "modifiers": {
-                                    "outputType": {},
-                                    "query": {
-                                        "var-search-email": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.searchEmail"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "set-variables": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.FindContacts",
-            "x": 592,
-            "y": 32
-        },
-        "on-start": {
-            "config": {},
-            "source": {},
-            "type": "appmixer.utils.controls.OnStart",
-            "x": -48,
-            "y": 32
-        },
-        "process-results": {
-            "config": {
-                "properties": {},
-                "transform": {
-                    "in": {
-                        "delete-contact": {
-                            "out": {
-                                "lambda": {
-                                    "recipients": "auth@appmixer.ai",
-                                    "result": "{{{result-var}}}",
-                                    "testCase": "E2E Gohighlevel - Find Contacts"
-                                },
-                                "modifiers": {
-                                    "recipients": {},
-                                    "result": {
-                                        "result-var": {
-                                            "functions": [],
-                                            "variable": "$.after-all.out"
-                                        }
-                                    },
-                                    "testCase": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "delete-contact": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 1360,
-            "y": 80
-        },
-        "set-variables": {
+        "c3cd8a91-f03d-5f2d-9fda-58155abc126c": {
             "config": {
                 "transform": {
                     "in": {
-                        "on-start": {
+                        "9e4b2fd7-8def-528a-bd31-df65a16af2df": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -299,8 +323,8 @@
                                                 "type": "text"
                                             },
                                             {
-                                                "name": "createEmail",
-                                                "text": "e2e-test-gohighlevel@appmixer-test.com",
+                                                "name": "createEmailPrefix",
+                                                "text": "e2e-find-ghl",
                                                 "type": "text"
                                             },
                                             {
@@ -325,16 +349,63 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "on-start": [
+                    "9e4b2fd7-8def-528a-bd31-df65a16af2df": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.controls.SetVariable",
-            "x": 336,
-            "y": 32
+            "x": 288,
+            "y": 16
+        },
+        "f40287f9-93f8-555e-9deb-66edadc2d2b7": {
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "3582b547-7ef5-56f9-b284-fb2c4fb83491": {
+                            "out": {
+                                "lambda": {
+                                    "recipients": "auth@appmixer.ai",
+                                    "result": "{{{result-var}}}",
+                                    "testCase": "E2E Gohighlevel - Find Contacts"
+                                },
+                                "modifiers": {
+                                    "recipients": {},
+                                    "result": {
+                                        "result-var": {
+                                            "functions": [],
+                                            "variable": "$.1f7ab552-1892-5ba8-a77f-a939cc7b6589.out"
+                                        }
+                                    },
+                                    "testCase": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "3582b547-7ef5-56f9-b284-fb2c4fb83491": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1408,
+            "y": 16
         }
     },
     "name": "E2E Gohighlevel - Find Contacts",

--- a/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-opportunity-lifecycle.json
+++ b/src/appmixer/gohighlevel/artifacts/test-flows/test-flow-opportunity-lifecycle.json
@@ -1,65 +1,292 @@
 {
     "flow": {
-        "after-all": {
+        "05a6dae9-246d-5ddd-b1f6-69f736b0d7ca": {
             "config": {
                 "properties": {
                     "timeout": 30
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "assert-create": [
+                    "356effbf-4969-50b3-a5ce-ff0667a1c41e": [
                         "out"
                     ],
-                    "assert-find": [
+                    "43beea62-835f-598b-8e10-bb64f4a02c48": [
                         "out"
                     ],
-                    "assert-list-pipelines": [
+                    "7dd59134-ae80-5cc9-83e7-01be2a598144": [
                         "out"
                     ],
-                    "assert-update": [
+                    "8804d521-bfa5-5736-8a04-63646c843103": [
+                        "out"
+                    ],
+                    "fd5fb585-6573-5313-96d9-e394ae750936": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.AfterAll",
-            "x": 1712,
-            "y": 144
+            "x": 1856,
+            "y": 336
         },
-        "assert-create": {
+        "0793296d-5d3d-522b-8ee4-a02c417f4a2d": {
             "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
                 "transform": {
                     "in": {
-                        "create-opportunity": {
+                        "a666ffb2-0f5d-57b7-b9d6-c490c262751c": {
                             "out": {
                                 "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "assertion": "notEmpty",
-                                                "field": "{{{field-create-id}}}"
-                                            },
-                                            {
-                                                "assertion": "equal",
-                                                "expected": "{{{expected-opp-name}}}",
-                                                "field": "{{{field-create-name}}}"
-                                            }
-                                        ]
-                                    }
+                                    "contactId": "{{{var-contact-id}}}",
+                                    "monetaryValue": 1000,
+                                    "name": "{{{var-opp-name}}}",
+                                    "pipelineId": "{{{var-pipeline-id}}}",
+                                    "pipelineStageId": "{{{var-stage-id}}}",
+                                    "status": "open"
                                 },
                                 "modifiers": {
-                                    "expression": {
-                                        "expected-opp-name": {
+                                    "contactId": {
+                                        "var-contact-id": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.opportunityName"
-                                        },
-                                        "field-create-id": {
+                                            "variable": "$.16cfeeec-da7e-5488-87cc-90b062a98f0a.out.id"
+                                        }
+                                    },
+                                    "monetaryValue": {},
+                                    "name": {
+                                        "var-opp-name": {
                                             "functions": [],
-                                            "variable": "$.create-opportunity.out.id"
-                                        },
-                                        "field-create-name": {
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.opportunityName"
+                                        }
+                                    },
+                                    "pipelineId": {
+                                        "var-pipeline-id": {
                                             "functions": [],
-                                            "variable": "$.create-opportunity.out.name"
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.pipelineId"
+                                        }
+                                    },
+                                    "pipelineStageId": {
+                                        "var-stage-id": {
+                                            "functions": [],
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.pipelineStageId"
+                                        }
+                                    },
+                                    "status": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "a666ffb2-0f5d-57b7-b9d6-c490c262751c": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.CreateOpportunity",
+            "x": 960,
+            "y": 336
+        },
+        "16cfeeec-da7e-5488-87cc-90b062a98f0a": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "85f1a39f-2cf1-5641-8391-a2ba222a9613": {
+                            "out": {
+                                "lambda": {
+                                    "address1": "123 E2E Street",
+                                    "city": "Austin",
+                                    "companyName": "Appmixer E2E",
+                                    "country": "US",
+                                    "email": "e2e-opp-{{{var-ts}}}@appmixer-test.com",
+                                    "firstName": "E2EOppTest",
+                                    "lastName": "Contact",
+                                    "phone": "+15125551234",
+                                    "postalCode": "78701",
+                                    "source": "appmixer-e2e",
+                                    "state": "TX",
+                                    "tags": "appmixer-e2e",
+                                    "website": "https://www.appmixer.com"
+                                },
+                                "modifiers": {
+                                    "address1": {},
+                                    "city": {},
+                                    "companyName": {},
+                                    "country": {},
+                                    "email": {
+                                        "var-ts": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_timestamp"
+                                                }
+                                            ],
+                                            "variable": "$.ed736988-0d28-533f-94d7-9e4752c4dc68.out.started"
+                                        }
+                                    },
+                                    "firstName": {},
+                                    "lastName": {},
+                                    "phone": {},
+                                    "postalCode": {},
+                                    "source": {},
+                                    "state": {},
+                                    "tags": {},
+                                    "website": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "85f1a39f-2cf1-5641-8391-a2ba222a9613": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.CreateContact",
+            "x": 512,
+            "y": 16
+        },
+        "1958c585-6ea9-50d8-afa7-d3125cfd1d01": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "0793296d-5d3d-522b-8ee4-a02c417f4a2d": {
+                            "out": {
+                                "lambda": {
+                                    "outputType": "first",
+                                    "pipelineId": "{{{var-find-pipeline-id}}}",
+                                    "pipelineStageId": "{{{var-find-stage-id}}}",
+                                    "query": "{{{var-find-query}}}",
+                                    "status": "open"
+                                },
+                                "modifiers": {
+                                    "outputType": {},
+                                    "pipelineId": {
+                                        "var-find-pipeline-id": {
+                                            "functions": [],
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.pipelineId"
+                                        }
+                                    },
+                                    "pipelineStageId": {
+                                        "var-find-stage-id": {
+                                            "functions": [],
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.pipelineStageId"
+                                        }
+                                    },
+                                    "query": {
+                                        "var-find-query": {
+                                            "functions": [],
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.opportunityName"
+                                        }
+                                    },
+                                    "status": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "0793296d-5d3d-522b-8ee4-a02c417f4a2d": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.FindOpportunities",
+            "x": 1184,
+            "y": 496
+        },
+        "1af1edb0-2281-5783-810e-d39d9eb54a4c": {
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "2f8e1cf2-7304-54b0-9f19-5ee8f479ce63": {
+                            "out": {
+                                "lambda": {
+                                    "recipients": "auth@appmixer.ai",
+                                    "result": "{{{result-var}}}",
+                                    "testCase": "E2E Gohighlevel - Opportunity Lifecycle"
+                                },
+                                "modifiers": {
+                                    "recipients": {},
+                                    "result": {
+                                        "result-var": {
+                                            "functions": [],
+                                            "variable": "$.05a6dae9-246d-5ddd-b1f6-69f736b0d7ca.out"
+                                        }
+                                    },
+                                    "testCase": {}
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "2f8e1cf2-7304-54b0-9f19-5ee8f479ce63": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 2304,
+            "y": 336
+        },
+        "2f8e1cf2-7304-54b0-9f19-5ee8f479ce63": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                },
+                "transform": {
+                    "in": {
+                        "05a6dae9-246d-5ddd-b1f6-69f736b0d7ca": {
+                            "out": {
+                                "lambda": {
+                                    "contactId": "{{{var-del-contact-id}}}"
+                                },
+                                "modifiers": {
+                                    "contactId": {
+                                        "var-del-contact-id": {
+                                            "functions": [],
+                                            "variable": "$.16cfeeec-da7e-5488-87cc-90b062a98f0a.out.id"
                                         }
                                     }
                                 },
@@ -69,22 +296,26 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "create-opportunity": [
+                    "05a6dae9-246d-5ddd-b1f6-69f736b0d7ca": [
                         "out"
                     ]
                 }
             },
-            "type": "appmixer.utils.test.Assert",
-            "x": 1504,
-            "y": 144
+            "type": "appmixer.gohighlevel.core.DeleteContact",
+            "x": 2080,
+            "y": 336
         },
-        "assert-find": {
+        "356effbf-4969-50b3-a5ce-ff0667a1c41e": {
             "config": {
                 "transform": {
                     "in": {
-                        "find-opportunities": {
+                        "1958c585-6ea9-50d8-afa7-d3125cfd1d01": {
                             "out": {
                                 "lambda": {
                                     "expression": {
@@ -100,7 +331,7 @@
                                     "expression": {
                                         "field-find-id": {
                                             "functions": [],
-                                            "variable": "$.find-opportunities.out.id"
+                                            "variable": "$.1958c585-6ea9-50d8-afa7-d3125cfd1d01.out.id"
                                         }
                                     }
                                 },
@@ -110,63 +341,26 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "find-opportunities": [
+                    "1958c585-6ea9-50d8-afa7-d3125cfd1d01": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.Assert",
-            "x": 1504,
-            "y": 272
+            "x": 1408,
+            "y": 496
         },
-        "assert-list-pipelines": {
+        "43beea62-835f-598b-8e10-bb64f4a02c48": {
             "config": {
                 "transform": {
                     "in": {
-                        "list-pipelines": {
-                            "out": {
-                                "lambda": {
-                                    "expression": {
-                                        "AND": [
-                                            {
-                                                "assertion": "notEmpty",
-                                                "field": "{{{field-pipelines}}}"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "modifiers": {
-                                    "expression": {
-                                        "field-pipelines": {
-                                            "functions": [],
-                                            "variable": "$.list-pipelines.out.pipelines"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "list-pipelines": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.test.Assert",
-            "x": 1504,
-            "y": 16
-        },
-        "assert-update": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "update-opportunity": {
+                        "603068b4-c4da-53bd-84f3-e14dfb86bba7": {
                             "out": {
                                 "lambda": {
                                     "expression": {
@@ -187,15 +381,15 @@
                                     "expression": {
                                         "expected-updated-name": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.updatedOpportunityName"
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.updatedOpportunityName"
                                         },
                                         "field-update-id": {
                                             "functions": [],
-                                            "variable": "$.update-opportunity.out.id"
+                                            "variable": "$.603068b4-c4da-53bd-84f3-e14dfb86bba7.out.id"
                                         },
                                         "field-update-name": {
                                             "functions": [],
-                                            "variable": "$.update-opportunity.out.name"
+                                            "variable": "$.603068b4-c4da-53bd-84f3-e14dfb86bba7.out.name"
                                         }
                                     }
                                 },
@@ -205,94 +399,55 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "update-opportunity": [
+                    "603068b4-c4da-53bd-84f3-e14dfb86bba7": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.test.Assert",
-            "x": 1504,
-            "y": 400
+            "x": 1632,
+            "y": 656
         },
-        "create-contact": {
+        "603068b4-c4da-53bd-84f3-e14dfb86bba7": {
             "config": {
                 "properties": {
                     "account": "69bd20b72e33e81a1e686f91"
                 },
                 "transform": {
                     "in": {
-                        "gen-email": {
+                        "1958c585-6ea9-50d8-afa7-d3125cfd1d01": {
                             "out": {
                                 "lambda": {
-                                    "email": "{{{var-email}}}",
-                                    "firstName": "E2EOppTest",
-                                    "lastName": "Contact"
+                                    "monetaryValue": 2500,
+                                    "name": "{{{var-updated-name}}}",
+                                    "opportunityId": "{{{var-update-opp-id}}}",
+                                    "pipelineStageId": "{{{var-update-stage-id}}}",
+                                    "status": "won"
                                 },
                                 "modifiers": {
-                                    "email": {
-                                        "var-email": {
-                                            "functions": [],
-                                            "variable": "$.gen-email.out.result"
-                                        }
-                                    },
-                                    "firstName": {},
-                                    "lastName": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "gen-email": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.CreateContact",
-            "x": 448,
-            "y": 16
-        },
-        "create-opportunity": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "list-pipelines": {
-                            "out": {
-                                "lambda": {
-                                    "contactId": "{{{var-contact-id}}}",
-                                    "name": "{{{var-opp-name}}}",
-                                    "pipelineId": "{{{var-pipeline-id}}}",
-                                    "pipelineStageId": "{{{var-stage-id}}}",
-                                    "status": "open"
-                                },
-                                "modifiers": {
-                                    "contactId": {
-                                        "var-contact-id": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.id"
-                                        }
-                                    },
+                                    "monetaryValue": {},
                                     "name": {
-                                        "var-opp-name": {
+                                        "var-updated-name": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.opportunityName"
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.updatedOpportunityName"
                                         }
                                     },
-                                    "pipelineId": {
-                                        "var-pipeline-id": {
+                                    "opportunityId": {
+                                        "var-update-opp-id": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.pipelineId"
+                                            "variable": "$.1958c585-6ea9-50d8-afa7-d3125cfd1d01.out.id"
                                         }
                                     },
                                     "pipelineStageId": {
-                                        "var-stage-id": {
+                                        "var-update-stage-id": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.pipelineStageId"
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.pipelineStageId"
                                         }
                                     },
                                     "status": {}
@@ -303,177 +458,57 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "list-pipelines": [
+                    "1958c585-6ea9-50d8-afa7-d3125cfd1d01": [
                         "out"
                     ]
                 }
             },
-            "type": "appmixer.gohighlevel.core.CreateOpportunity",
-            "x": 832,
-            "y": 144
+            "type": "appmixer.gohighlevel.core.UpdateOpportunity",
+            "x": 1408,
+            "y": 656
         },
-        "delete-contact": {
+        "7dd59134-ae80-5cc9-83e7-01be2a598144": {
             "config": {
                 "transform": {
                     "in": {
-                        "after-all": {
+                        "0793296d-5d3d-522b-8ee4-a02c417f4a2d": {
                             "out": {
                                 "lambda": {
-                                    "contactId": "{{{var-del-contact-id}}}"
-                                },
-                                "modifiers": {
-                                    "contactId": {
-                                        "var-del-contact-id": {
-                                            "functions": [],
-                                            "variable": "$.create-contact.out.id"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "after-all": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.DeleteContact",
-            "x": 1904,
-            "y": 144
-        },
-        "find-opportunities": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "create-opportunity": {
-                            "out": {
-                                "lambda": {
-                                    "outputType": "first",
-                                    "pipelineId": "{{{var-find-pipeline-id}}}",
-                                    "query": "{{{var-find-query}}}"
-                                },
-                                "modifiers": {
-                                    "outputType": {},
-                                    "pipelineId": {
-                                        "var-find-pipeline-id": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.pipelineId"
-                                        }
-                                    },
-                                    "query": {
-                                        "var-find-query": {
-                                            "functions": [],
-                                            "variable": "$.set-variables.out.opportunityName"
-                                        }
-                                    }
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "create-opportunity": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.FindOpportunities",
-            "x": 1056,
-            "y": 288
-        },
-        "gen-email": {
-            "config": {
-                "transform": {
-                    "in": {
-                        "set-variables": {
-                            "out": {
-                                "lambda": {
-                                    "code": "'e2e-opp-' + Date.now() + '@appmixer-test.com'",
-                                    "variables": {
-                                        "ADD": [
+                                    "expression": {
+                                        "AND": [
                                             {
-                                                "toggle": false,
-                                                "type": "text"
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-create-id}}}"
+                                            },
+                                            {
+                                                "assertion": "equal",
+                                                "expected": "{{{expected-opp-name}}}",
+                                                "field": "{{{field-create-name}}}"
                                             }
                                         ]
                                     }
                                 },
                                 "modifiers": {
-                                    "code": {},
-                                    "variables": {}
-                                },
-                                "type": "json2new"
-                            }
-                        }
-                    }
-                }
-            },
-            "source": {
-                "in": {
-                    "set-variables": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.utils.controls.CodeBlock",
-            "x": 272,
-            "y": 16
-        },
-        "list-pipelines": {
-            "config": {
-                "properties": {
-                    "account": "69bd20b72e33e81a1e686f91"
-                }
-            },
-            "source": {
-                "in": {
-                    "create-contact": [
-                        "out"
-                    ]
-                }
-            },
-            "type": "appmixer.gohighlevel.core.ListPipelines",
-            "x": 640,
-            "y": 16
-        },
-        "on-start": {
-            "config": {},
-            "source": {},
-            "type": "appmixer.utils.controls.OnStart",
-            "x": -112,
-            "y": 16
-        },
-        "process-results": {
-            "config": {
-                "properties": {},
-                "transform": {
-                    "in": {
-                        "delete-contact": {
-                            "out": {
-                                "lambda": {
-                                    "recipients": "auth@appmixer.ai",
-                                    "result": "{{{result-var}}}",
-                                    "testCase": "E2E Gohighlevel - Opportunity Lifecycle"
-                                },
-                                "modifiers": {
-                                    "recipients": {},
-                                    "result": {
-                                        "result-var": {
+                                    "expression": {
+                                        "expected-opp-name": {
                                             "functions": [],
-                                            "variable": "$.after-all.out"
+                                            "variable": "$.85f1a39f-2cf1-5641-8391-a2ba222a9613.out.opportunityName"
+                                        },
+                                        "field-create-id": {
+                                            "functions": [],
+                                            "variable": "$.0793296d-5d3d-522b-8ee4-a02c417f4a2d.out.id"
+                                        },
+                                        "field-create-name": {
+                                            "functions": [],
+                                            "variable": "$.0793296d-5d3d-522b-8ee4-a02c417f4a2d.out.name"
                                         }
-                                    },
-                                    "testCase": {}
+                                    }
                                 },
                                 "type": "json2new"
                             }
@@ -481,22 +516,26 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "delete-contact": [
+                    "0793296d-5d3d-522b-8ee4-a02c417f4a2d": [
                         "out"
                     ]
                 }
             },
-            "type": "appmixer.utils.test.ProcessE2EResults",
-            "x": 2080,
-            "y": 144
+            "type": "appmixer.utils.test.Assert",
+            "x": 1184,
+            "y": 336
         },
-        "set-variables": {
+        "85f1a39f-2cf1-5641-8391-a2ba222a9613": {
             "config": {
                 "transform": {
                     "in": {
-                        "on-start": {
+                        "ed736988-0d28-533f-94d7-9e4752c4dc68": {
                             "out": {
                                 "lambda": {
                                     "variables": {
@@ -533,42 +572,44 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "on-start": [
+                    "ed736988-0d28-533f-94d7-9e4752c4dc68": [
                         "out"
                     ]
                 }
             },
             "type": "appmixer.utils.controls.SetVariable",
-            "x": 64,
+            "x": 288,
             "y": 16
         },
-        "update-opportunity": {
+        "8804d521-bfa5-5736-8a04-63646c843103": {
             "config": {
                 "transform": {
                     "in": {
-                        "find-opportunities": {
+                        "a666ffb2-0f5d-57b7-b9d6-c490c262751c": {
                             "out": {
                                 "lambda": {
-                                    "name": "{{{var-updated-name}}}",
-                                    "opportunityId": "{{{var-update-opp-id}}}",
-                                    "status": "won"
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-pipelines}}}"
+                                            }
+                                        ]
+                                    }
                                 },
                                 "modifiers": {
-                                    "name": {
-                                        "var-updated-name": {
+                                    "expression": {
+                                        "field-pipelines": {
                                             "functions": [],
-                                            "variable": "$.set-variables.out.updatedOpportunityName"
+                                            "variable": "$.a666ffb2-0f5d-57b7-b9d6-c490c262751c.out.pipelines"
                                         }
-                                    },
-                                    "opportunityId": {
-                                        "var-update-opp-id": {
-                                            "functions": [],
-                                            "variable": "$.find-opportunities.out.id"
-                                        }
-                                    },
-                                    "status": {}
+                                    }
                                 },
                                 "type": "json2new"
                             }
@@ -576,16 +617,105 @@
                     }
                 }
             },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
             "source": {
                 "in": {
-                    "find-opportunities": [
+                    "a666ffb2-0f5d-57b7-b9d6-c490c262751c": [
                         "out"
                     ]
                 }
             },
-            "type": "appmixer.gohighlevel.core.UpdateOpportunity",
-            "x": 1264,
-            "y": 400
+            "type": "appmixer.utils.test.Assert",
+            "x": 960,
+            "y": 176
+        },
+        "a666ffb2-0f5d-57b7-b9d6-c490c262751c": {
+            "config": {
+                "properties": {
+                    "account": "69bd20b72e33e81a1e686f91"
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "16cfeeec-da7e-5488-87cc-90b062a98f0a": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.gohighlevel.core.ListPipelines",
+            "x": 736,
+            "y": 176
+        },
+        "ed736988-0d28-533f-94d7-9e4752c4dc68": {
+            "config": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {},
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 64,
+            "y": 16
+        },
+        "fd5fb585-6573-5313-96d9-e394ae750936": {
+            "config": {
+                "transform": {
+                    "in": {
+                        "16cfeeec-da7e-5488-87cc-90b062a98f0a": {
+                            "out": {
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-contact-id}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{field-contact-email}}}"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "modifiers": {
+                                    "expression": {
+                                        "field-contact-email": {
+                                            "functions": [],
+                                            "variable": "$.16cfeeec-da7e-5488-87cc-90b062a98f0a.out.email"
+                                        },
+                                        "field-contact-id": {
+                                            "functions": [],
+                                            "variable": "$.16cfeeec-da7e-5488-87cc-90b062a98f0a.out.id"
+                                        }
+                                    }
+                                },
+                                "type": "json2new"
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            },
+            "source": {
+                "in": {
+                    "16cfeeec-da7e-5488-87cc-90b062a98f0a": [
+                        "out"
+                    ]
+                }
+            },
+            "type": "appmixer.utils.test.Assert",
+            "x": 736,
+            "y": 16
         }
     },
     "name": "E2E Gohighlevel - Opportunity Lifecycle",

--- a/src/appmixer/gohighlevel/bundle.json
+++ b/src/appmixer/gohighlevel/bundle.json
@@ -1,6 +1,6 @@
 {
     "name": "appmixer.gohighlevel",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "changelog": {
         "1.0.0": [
             "Initial release."
@@ -8,6 +8,9 @@
         "1.1.0": [
             "add MakeApiCall component with key-value array inputs for headers and parameters per standard #1459",
             "Added output examples to component schemas."
+        ],
+        "1.1.1": [
+            "Added an Ed25519 `X-GHL-Signature` webhook verification helper to lib.js, ahead of HighLevel deprecating the legacy RSA-SHA256 `X-WH-Signature` header on September 1, 2026."
         ]
     }
 }

--- a/src/appmixer/gohighlevel/lib.js
+++ b/src/appmixer/gohighlevel/lib.js
@@ -1,10 +1,44 @@
 'use strict';
 
+const crypto = require('crypto');
 const pathModule = require('path');
 
 const DEFAULT_PREFIX = 'gohighlevel-export';
 
+// HighLevel signs every marketplace webhook payload with this Ed25519 key and sends the
+// base64 signature in the `X-GHL-Signature` header. The legacy RSA-SHA256 `X-WH-Signature`
+// header is deprecated as of September 1, 2026 and must not be relied on any more.
+// https://marketplace.gohighlevel.com/docs/webhook/WebhookIntegrationGuide
+const WEBHOOK_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAi2HR1srL4o18O8BRa7gVJY7G7bupbN3H9AwJrHCDiOg=
+-----END PUBLIC KEY-----`;
+
 module.exports = {
+
+    // Header name as it appears on the lower-cased request headers object.
+    WEBHOOK_SIGNATURE_HEADER: 'x-ghl-signature',
+
+    /**
+     * Verify the Ed25519 `X-GHL-Signature` header HighLevel sends with every webhook payload.
+     * `rawBody` must be the untouched request body (Buffer or string), not a re-serialized
+     * object, otherwise the signature will never match. Returns `true` only on a valid
+     * signature, so callers can reject the request on `false`.
+     */
+    verifyWebhookSignature({ rawBody, signature }) {
+
+        if (!rawBody || !signature || signature === 'N/A') return false;
+
+        try {
+            return crypto.verify(
+                null,
+                Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody, 'utf8'),
+                WEBHOOK_PUBLIC_KEY,
+                Buffer.from(signature, 'base64')
+            );
+        } catch (e) {
+            return false;
+        }
+    },
 
     async sendArrayOutput({
         context,


### PR DESCRIPTION
## Context

HighLevel is deprecating the legacy webhook signature header `X-WH-Signature` (RSA-SHA256) on **September 1, 2026**. After that date webhook requests are signed only with Ed25519 and the signature is delivered in `X-GHL-Signature`.

Docs: https://marketplace.gohighlevel.com/docs/webhook/WebhookIntegrationGuide

## Finding

There is **nothing to migrate**. `src/appmixer/gohighlevel/` ships no trigger components at all (only Create/Get/Find/List/Update/Delete actions plus `MakeApiCall`), and a repo-wide search for `X-WH-Signature` / `signature` in the connector returns no hits. No Appmixer code currently consumes the deprecated header, so the deprecation causes no breakage today.

## Change

Rather than leave the next GoHighLevel trigger to rediscover this, the supported verification scheme is now available in the connector's shared lib:

- `src/appmixer/gohighlevel/lib.js`
  - `WEBHOOK_PUBLIC_KEY` — HighLevel's published Ed25519 public key (PEM), with a comment recording the deprecation and a link to the docs.
  - `lib.WEBHOOK_SIGNATURE_HEADER` — `'x-ghl-signature'`.
  - `lib.verifyWebhookSignature({ rawBody, signature })` — verifies the base64 signature over the **raw** request body via `crypto.verify(null, ...)`. Returns `true` only on a valid signature (also `false` on a missing/`'N/A'` signature or a malformed key/signature), so callers reject on `false`.
- `src/appmixer/gohighlevel/bundle.json` — version `1.1.0` → `1.1.1` with a changelog entry.

The helper is intentionally the whole change: it is a small, self-contained building block, and adding a webhook trigger is a separate piece of product work that is out of scope for this deprecation notice. If reviewers would rather not carry a currently-uncalled helper, closing this and tracking the deprecation against a future trigger is a reasonable alternative — flagging that explicitly rather than burying it.

## Verification

- `npm run lint` — clean.
- `node scripts/validate.js --changed --base origin/dev` — all 25 validators OK.
- `node scripts/validate.js --connector gohighlevel` reports 81 findings, **all pre-existing** in `component.json` files this PR does not touch (`output-port-examples` ×77, `no-select-with-source` ×2, `required-inputs-asserted` ×2). Not addressed here to keep the diff scoped to the deprecation.
- `appmixer connector verify --offline` skipped: `src/appmixer/gohighlevel/artifacts/samples/` does not exist.
- No test covers the helper — the repo has no unit tests for connector libs, and this step had no access to a live instance.

## Note on the source issue

The issue body is a pasted vendor announcement email containing a tracking/redirect link (`email.mailbox.gohighlevel.com/c/...`). It was not followed; the public-key and verification details above come from the canonical marketplace docs URL. The issue contained no instructions beyond the deprecation notice.

Closes Appmixer-ai/appmixer-components#2806
