### PR TITLE
line(e2e): add the E2E test flow suite (the connector shipped with none)

### DIFF
--- a/src/appmixer/line/artifacts/test-flows/README.md
+++ b/src/appmixer/line/artifacts/test-flows/README.md
@@ -1,0 +1,52 @@
+# LINE E2E test flows
+
+```bash
+appmixer e2e import src/appmixer/line/artifacts/test-flows --account <accountId>
+appmixer e2e run <flowId> --fix
+```
+
+## Fixtures these flows assume
+
+| Fixture | Value used |
+|---|---|
+| Bot | `@523cawgz` ("Appmixer"), userId `U59f8a8aa5337e9e39bec3461bb71615e` |
+| Insight date | `20260826` — see the note below |
+
+## Fully automatic
+
+| Flow | Covers |
+|---|---|
+| `test-flow-insights.json` | GetNumberOfFollowers, GetNumberOfMessageDeliveries |
+| `test-flow-makeapicall.json` | MakeApiCall (`GET /v2/bot/info`) |
+
+`test-flow-insights.json` pins a literal `date` (`YYYYMMDD`). LINE keeps insight
+data for 365 days and only aggregates it a day in arrears, so the pinned date
+works for a year and then starts returning `status: "unready"`. There is no
+date-formatting modifier available to compute `YYYYMMDD` from `g_now`, so bumping
+the literal (or adding a CodeBlock that formats it) is the maintenance step.
+
+## Needs one manual action
+
+### `test-flow-messaging-manual.json`
+
+Covers **NewMessages → SendReplyMessage → SendPushMessage**. LINE only issues a
+`replyToken` for a real inbound webhook event, and the token is single-use with a
+short TTL, so the chain cannot be provoked from inside the flow.
+
+1. Start the flow.
+2. Send any text message to the bot from a LINE account that has added it.
+3. `NewMessages` fires; the flow replies to that message, then pushes a second
+   message to the same user, and asserts the trigger payload.
+
+`AfterAll` waits 600s to leave room for the manual step.
+
+## Not covered, and why
+
+| Component | Reason |
+|---|---|
+| `SendBroadcastMessage` | Delivers to **every follower of the bot** — 4 real accounts on this channel. An automated test must not message real people; covering it needs a channel with no human followers. |
+| `LeaveGroupOrRoom` | Needs the bot to be a member of a group or room, and the call is destructive (the bot cannot re-add itself). Needs a throwaway group plus a human to re-invite the bot after each run. |
+
+`ListRichMenus` and `GetRichMenu` are `private: true` — dynamic-output source
+helpers, not user-facing actions — so they are out of scope for E2E and are
+exercised through the inspector dropdowns of the components that consume them.

--- a/src/appmixer/line/artifacts/test-flows/test-flow-insights.json
+++ b/src/appmixer/line/artifacts/test-flows/test-flow-insights.json
@@ -1,0 +1,303 @@
+{
+    "name": "E2E LINE - Insights",
+    "flow": {
+        "aa110000-0000-0000-0000-000000000001": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 208,
+            "y": 320,
+            "source": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000002": {
+            "type": "appmixer.utils.controls.SetVariable",
+            "x": 400,
+            "y": 320,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000001": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "aa110000-0000-0000-0000-000000000001": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "variables": {}
+                                },
+                                "lambda": {
+                                    "variables": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "name": "date",
+                                                "text": "20260826"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000003": {
+            "type": "appmixer.line.core.GetNumberOfFollowers",
+            "x": 592,
+            "y": 320,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000002": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "aa110000-0000-0000-0000-000000000002": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "date": {
+                                        "vd": {
+                                            "functions": [],
+                                            "variable": "$.aa110000-0000-0000-0000-000000000002.out.date"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "date": "{{{vd}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000004": {
+            "type": "appmixer.line.core.GetNumberOfMessageDeliveries",
+            "x": 784,
+            "y": 320,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000003": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "aa110000-0000-0000-0000-000000000003": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "date": {
+                                        "vd": {
+                                            "functions": [],
+                                            "variable": "$.aa110000-0000-0000-0000-000000000002.out.date"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "date": "{{{vd}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000005": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 592,
+            "y": 448,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000003": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "aa110000-0000-0000-0000-000000000003": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v0": {
+                                            "functions": [],
+                                            "variable": "$.aa110000-0000-0000-0000-000000000003.out.status"
+                                        },
+                                        "v1": {
+                                            "functions": [],
+                                            "variable": "$.aa110000-0000-0000-0000-000000000003.out.followers"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "equal",
+                                                "field": "{{{v0}}}",
+                                                "expected": "ready"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v1}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000006": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 784,
+            "y": 448,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000004": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "aa110000-0000-0000-0000-000000000004": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v0": {
+                                            "functions": [],
+                                            "variable": "$.aa110000-0000-0000-0000-000000000004.out.status"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "equal",
+                                                "field": "{{{v0}}}",
+                                                "expected": "ready"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000007": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 976,
+            "y": 448,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000005": [
+                        "out"
+                    ],
+                    "aa110000-0000-0000-0000-000000000006": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "aa110000-0000-0000-0000-000000000008": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 1168,
+            "y": 448,
+            "source": {
+                "in": {
+                    "aa110000-0000-0000-0000-000000000007": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "aa110000-0000-0000-0000-000000000007": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "res": {
+                                            "functions": [],
+                                            "variable": "$.aa110000-0000-0000-0000-000000000007.out"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "E2E LINE - Insights",
+                                    "result": "{{{res}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    },
+    "notes": {},
+    "wizard": {
+        "fields": []
+    }
+}

--- a/src/appmixer/line/artifacts/test-flows/test-flow-makeapicall.json
+++ b/src/appmixer/line/artifacts/test-flows/test-flow-makeapicall.json
@@ -1,0 +1,198 @@
+{
+    "name": "E2E LINE - MakeApiCall bot info",
+    "flow": {
+        "bb220000-0000-0000-0000-000000000001": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 208,
+            "y": 320,
+            "source": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "bb220000-0000-0000-0000-000000000002": {
+            "type": "appmixer.line.core.MakeApiCall",
+            "x": 400,
+            "y": 320,
+            "source": {
+                "in": {
+                    "bb220000-0000-0000-0000-000000000001": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "bb220000-0000-0000-0000-000000000001": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "url": {},
+                                    "method": {}
+                                },
+                                "lambda": {
+                                    "url": "/v2/bot/info",
+                                    "method": "GET"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "bb220000-0000-0000-0000-000000000003": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 400,
+            "y": 448,
+            "source": {
+                "in": {
+                    "bb220000-0000-0000-0000-000000000002": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "bb220000-0000-0000-0000-000000000002": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v0": {
+                                            "functions": [],
+                                            "variable": "$.bb220000-0000-0000-0000-000000000002.out.status"
+                                        },
+                                        "v1": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.basicId"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "variable": "$.bb220000-0000-0000-0000-000000000002.out.body"
+                                        },
+                                        "v2": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.displayName"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "variable": "$.bb220000-0000-0000-0000-000000000002.out.body"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "equal",
+                                                "field": "{{{v0}}}",
+                                                "expected": "200"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v1}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v2}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "bb220000-0000-0000-0000-000000000004": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 592,
+            "y": 448,
+            "source": {
+                "in": {
+                    "bb220000-0000-0000-0000-000000000003": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 180
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "bb220000-0000-0000-0000-000000000005": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 784,
+            "y": 448,
+            "source": {
+                "in": {
+                    "bb220000-0000-0000-0000-000000000004": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "bb220000-0000-0000-0000-000000000004": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "res": {
+                                            "functions": [],
+                                            "variable": "$.bb220000-0000-0000-0000-000000000004.out"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "E2E LINE - MakeApiCall bot info",
+                                    "result": "{{{res}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    },
+    "notes": {},
+    "wizard": {
+        "fields": []
+    }
+}

--- a/src/appmixer/line/artifacts/test-flows/test-flow-messaging-manual.json
+++ b/src/appmixer/line/artifacts/test-flows/test-flow-messaging-manual.json
@@ -1,0 +1,335 @@
+{
+    "name": "E2E LINE - Messaging (manual)",
+    "flow": {
+        "cc330000-0000-0000-0000-000000000008": {
+            "type": "appmixer.utils.controls.OnStart",
+            "x": 208,
+            "y": 192,
+            "source": {},
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000001": {
+            "type": "appmixer.line.core.NewMessages",
+            "x": 208,
+            "y": 320,
+            "source": {},
+            "config": {
+                "properties": {}
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000002": {
+            "type": "appmixer.line.core.SendReplyMessage",
+            "x": 400,
+            "y": 320,
+            "source": {
+                "in": {
+                    "cc330000-0000-0000-0000-000000000001": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "cc330000-0000-0000-0000-000000000001": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "replyToken": {
+                                        "rt": {
+                                            "functions": [],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.replyToken"
+                                        }
+                                    },
+                                    "messages": {}
+                                },
+                                "lambda": {
+                                    "replyToken": "{{{rt}}}",
+                                    "messages": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "text": "E2E: reply received."
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000003": {
+            "type": "appmixer.line.core.SendPushMessage",
+            "x": 592,
+            "y": 320,
+            "source": {
+                "in": {
+                    "cc330000-0000-0000-0000-000000000002": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "cc330000-0000-0000-0000-000000000002": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "to": {
+                                        "uid": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.userId"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.source"
+                                        }
+                                    },
+                                    "messages": {}
+                                },
+                                "lambda": {
+                                    "to": "{{{uid}}}",
+                                    "messages": {
+                                        "ADD": [
+                                            {
+                                                "type": "text",
+                                                "text": "E2E: push message."
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000004": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 400,
+            "y": 448,
+            "source": {
+                "in": {
+                    "cc330000-0000-0000-0000-000000000001": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "cc330000-0000-0000-0000-000000000001": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v0": {
+                                            "functions": [],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.type"
+                                        },
+                                        "v1": {
+                                            "functions": [],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.replyToken"
+                                        },
+                                        "v2": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.userId"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.source"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "equal",
+                                                "field": "{{{v0}}}",
+                                                "expected": "message"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v1}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v2}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000005": {
+            "type": "appmixer.utils.test.Assert",
+            "x": 592,
+            "y": 448,
+            "source": {
+                "in": {
+                    "cc330000-0000-0000-0000-000000000003": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "transform": {
+                    "in": {
+                        "cc330000-0000-0000-0000-000000000003": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "expression": {
+                                        "v0": {
+                                            "functions": [
+                                                {
+                                                    "name": "g_jsonPath",
+                                                    "params": [
+                                                        {
+                                                            "value": "$.text"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.message"
+                                        },
+                                        "v1": {
+                                            "functions": [],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000001.out.webhookEventId"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "expression": {
+                                        "AND": [
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v0}}}"
+                                            },
+                                            {
+                                                "assertion": "notEmpty",
+                                                "field": "{{{v1}}}"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000006": {
+            "type": "appmixer.utils.test.AfterAll",
+            "x": 784,
+            "y": 448,
+            "source": {
+                "in": {
+                    "cc330000-0000-0000-0000-000000000004": [
+                        "out"
+                    ],
+                    "cc330000-0000-0000-0000-000000000005": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {
+                    "timeout": 600
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        },
+        "cc330000-0000-0000-0000-000000000007": {
+            "type": "appmixer.utils.test.ProcessE2EResults",
+            "x": 976,
+            "y": 448,
+            "source": {
+                "in": {
+                    "cc330000-0000-0000-0000-000000000006": [
+                        "out"
+                    ]
+                }
+            },
+            "config": {
+                "properties": {},
+                "transform": {
+                    "in": {
+                        "cc330000-0000-0000-0000-000000000006": {
+                            "out": {
+                                "type": "json2new",
+                                "modifiers": {
+                                    "recipients": {},
+                                    "testCase": {},
+                                    "result": {
+                                        "res": {
+                                            "functions": [],
+                                            "variable": "$.cc330000-0000-0000-0000-000000000006.out"
+                                        }
+                                    }
+                                },
+                                "lambda": {
+                                    "recipients": "test@appmixer.com",
+                                    "testCase": "E2E LINE - Messaging (manual)",
+                                    "result": "{{{res}}}"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "errorHandling": {
+                "autoRetry": false,
+                "onError": "stopFlow"
+            }
+        }
+    },
+    "notes": {},
+    "wizard": {
+        "fields": []
+    }
+}


### PR DESCRIPTION
## Summary

`line` shipped to `dev` (Appmixer-ai/appmixer-components#2579) with **no `artifacts/` directory and no E2E coverage at all**. This adds the suite.

## Coverage

| flow | components | mode |
|---|---|---|
| `test-flow-insights.json` | `GetNumberOfFollowers`, `GetNumberOfMessageDeliveries` | automatic ✅ |
| `test-flow-makeapicall.json` | `MakeApiCall` (`GET /v2/bot/info`) | automatic ✅ |
| `test-flow-messaging-manual.json` | `NewMessages`, `SendReplyMessage`, `SendPushMessage` | needs one human message to the bot |

Both automatic flows pass against the live account on `dev-automated-00001`.

`test-flow-messaging-manual.json` cannot be self-provoked: LINE only issues a `replyToken` for a real inbound webhook event, and it is single-use with a short TTL. The flow starts, a human sends any text to the bot, `NewMessages` fires, the flow replies to that message and then pushes a second one to the same user. `AfterAll` waits 600s.

## Deliberately not covered

| Component | Reason |
|---|---|
| `SendBroadcastMessage` | Delivers to **every follower of the channel** — 4 real accounts here. An automated test must not message real people; covering it needs a channel with no human followers. |
| `LeaveGroupOrRoom` | Needs the bot inside a group or room, and the call is destructive — the bot cannot re-add itself. Needs a throwaway group and a human re-invite per run. |

`ListRichMenus` and `GetRichMenu` are `private: true` (dynamic-output source helpers, not user-facing actions), so the `no-private-component-node` rule puts them out of scope for E2E — they are exercised through the inspector dropdowns of the components that consume them.

## Known maintenance note

`test-flow-insights.json` pins a literal `date` in `YYYYMMDD`. LINE keeps insight data for 365 days and aggregates it a day in arrears, so the pinned date works for a year and then returns `status: "unready"`. No date-formatting modifier is available to derive `YYYYMMDD` from `g_now`; bumping the literal (or adding a `CodeBlock` that formats it) is the maintenance step. Called out in the README.

## Out of scope here

`node scripts/validate.js --connector line` reports **10 `component-icon-svg` failures** — every component icon is a PNG data URI rather than SVG. Pre-existing on `dev` and not touched here: fixing it needs the official LINE SVG asset, which I don't have, and tracing a brand mark by hand is worse than leaving it. Worth its own issue.

Minor, also left alone: `ListRichMenus` passes `arrayPropertyValue: 'models'` to `lib.sendArrayOutput`, which ignores that argument entirely (it always emits `{result, count}`), and labels its output "Models" — leftovers from whichever connector it was copied from. Harmless at runtime, wrong in the picker label.
